### PR TITLE
Enhance markdown_filter with variable support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/ci.yml) [![Security Scanning](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/codeql.yml) [![Known Vulnerabilities](https://snyk.io/test/github/cnkang/nginx-markdown-for-agents/badge.svg)](https://snyk.io/test/github/cnkang/nginx-markdown-for-agents) [![License](https://img.shields.io/github/license/cnkang/nginx-markdown-for-agents)](https://github.com/cnkang/nginx-markdown-for-agents/blob/main/LICENSE) [![NGINX](https://img.shields.io/badge/NGINX-%3E%3D1.24.0-009639?logo=nginx&logoColor=white)](https://github.com/cnkang/nginx-markdown-for-agents/blob/main/docs/guides/INSTALLATION.md) [![Latest Release](https://img.shields.io/github/v/release/cnkang/nginx-markdown-for-agents?sort=semver)](https://github.com/cnkang/nginx-markdown-for-agents/releases)
 
-English | [简体中文](README_zh-CN.md)
+English | [Simplified Chinese](README_zh-CN.md)
 
 An NGINX filter module that converts HTML responses to Markdown on the fly — so AI agents can consume your web content without scraping.
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/ci.yml) [![Security Scanning](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/cnkang/nginx-markdown-for-agents/actions/workflows/codeql.yml) [![Known Vulnerabilities](https://snyk.io/test/github/cnkang/nginx-markdown-for-agents/badge.svg)](https://snyk.io/test/github/cnkang/nginx-markdown-for-agents) [![License](https://img.shields.io/github/license/cnkang/nginx-markdown-for-agents)](https://github.com/cnkang/nginx-markdown-for-agents/blob/main/LICENSE) [![NGINX](https://img.shields.io/badge/NGINX-%3E%3D1.24.0-009639?logo=nginx&logoColor=white)](https://github.com/cnkang/nginx-markdown-for-agents/blob/main/docs/guides/INSTALLATION.md) [![Latest Release](https://img.shields.io/github/v/release/cnkang/nginx-markdown-for-agents?sort=semver)](https://github.com/cnkang/nginx-markdown-for-agents/releases)
 
-[English](README.md) | 简体中文
+[English](README.md) | Simplified Chinese
 
 一个 NGINX 过滤模块，实时将 HTML 响应转为 Markdown — 让 AI Agent 直接读懂你的网页，无需爬虫。
 

--- a/components/nginx-module/README.md
+++ b/components/nginx-module/README.md
@@ -55,7 +55,7 @@ See [Configuration Guide](../../docs/guides/CONFIGURATION.md) for complete direc
 
 ### Core Directives
 
-- `markdown_filter on|off` - Enable/disable conversion
+- `markdown_filter on|off|$variable` - Enable/disable conversion (supports per-request variable toggle)
 - `markdown_max_size <size>` - Maximum response size
 - `markdown_timeout <time>` - Conversion timeout
 - `markdown_on_error pass|reject` - Failure strategy

--- a/components/nginx-module/src/ngx_http_markdown_accept.c
+++ b/components/nginx-module/src/ngx_http_markdown_accept.c
@@ -446,8 +446,12 @@ ngx_http_markdown_should_convert(ngx_http_request_t *r,
     ngx_http_markdown_accept_entry_t     *entry;
     ngx_uint_t                            i;
     
-    /* Check if conversion is enabled */
-    if (!ngx_http_markdown_is_enabled(r, conf)) {
+    /*
+     * markdown_filter is resolved once in header filter and cached in request
+     * context for phase consistency. Keep this function focused on Accept
+     * matching only.
+     */
+    if (conf == NULL) {
         return 0;
     }
     

--- a/components/nginx-module/src/ngx_http_markdown_accept.c
+++ b/components/nginx-module/src/ngx_http_markdown_accept.c
@@ -447,7 +447,7 @@ ngx_http_markdown_should_convert(ngx_http_request_t *r,
     ngx_uint_t                            i;
     
     /* Check if conversion is enabled */
-    if (!conf->enabled) {
+    if (!ngx_http_markdown_is_enabled(r, conf)) {
         return 0;
     }
     

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -268,7 +268,7 @@ ngx_http_markdown_check_eligibility(ngx_http_request_t *r,
                                     ngx_http_markdown_conf_t *conf)
 {
     /* Check if conversion is enabled in configuration (FR-02.6) */
-    if (!conf->enabled) {
+    if (!ngx_http_markdown_is_enabled(r, conf)) {
         return NGX_HTTP_MARKDOWN_INELIGIBLE_CONFIG;
     }
     

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -267,8 +267,11 @@ ngx_http_markdown_eligibility_t
 ngx_http_markdown_check_eligibility(ngx_http_request_t *r,
                                     ngx_http_markdown_conf_t *conf)
 {
-    /* Check if conversion is enabled in configuration (FR-02.6) */
-    if (!ngx_http_markdown_is_enabled(r, conf)) {
+    /*
+     * markdown_filter enablement is resolved once by header filter to avoid
+     * repeated evaluation of dynamic expressions in the same request.
+     */
+    if (conf == NULL) {
         return NGX_HTTP_MARKDOWN_INELIGIBLE_CONFIG;
     }
     

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -244,7 +244,7 @@ ngx_http_markdown_is_streaming(ngx_http_request_t *r,
  * 4. Content-Type is text/html (FR-02.3)
  * 5. Response size within configured limit (FR-10.1)
  * 6. Not unbounded streaming (FR-02.8)
- * 7. Conversion enabled in configuration (FR-02.6)
+ * 7. Conversion enabled for this request (FR-02.6), as resolved by caller
  *
  * Note: Chunked Transfer-Encoding responses are ELIGIBLE per FR-02.7.
  * The module buffers all chunks before conversion. Only unbounded streaming
@@ -258,20 +258,22 @@ ngx_http_markdown_is_streaming(ngx_http_request_t *r,
  *
  * Parameters:
  *   r    - NGINX request structure
- *   conf - Module configuration
+ *   conf           - Module configuration
+ *   filter_enabled - Caller-resolved markdown_filter decision for this request
  *
  * Returns:
  *   Eligibility enum indicating result and reason
  */
 ngx_http_markdown_eligibility_t
 ngx_http_markdown_check_eligibility(ngx_http_request_t *r,
-                                    ngx_http_markdown_conf_t *conf)
+                                    ngx_http_markdown_conf_t *conf,
+                                    ngx_flag_t filter_enabled)
 {
     /*
      * markdown_filter enablement is resolved once by header filter to avoid
      * repeated evaluation of dynamic expressions in the same request.
      */
-    if (conf == NULL) {
+    if (conf == NULL || !filter_enabled) {
         return NGX_HTTP_MARKDOWN_INELIGIBLE_CONFIG;
     }
     

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -100,6 +100,7 @@ static const ngx_str_t *ngx_http_markdown_log_verbosity_name(ngx_uint_t value);
 static const ngx_str_t *ngx_http_markdown_compression_name(
     ngx_http_markdown_compression_type_e compression_type);
 static const ngx_str_t *ngx_http_markdown_enabled_source_name(ngx_uint_t value);
+static ngx_uint_t ngx_http_markdown_is_ascii_space(u_char ch);
 static ngx_int_t ngx_http_markdown_parse_filter_flag(ngx_str_t *value, ngx_flag_t *enabled);
 ngx_flag_t ngx_http_markdown_is_enabled(ngx_http_request_t *r,
     ngx_http_markdown_conf_t *conf);
@@ -1111,12 +1112,43 @@ ngx_http_markdown_enabled_source_name(ngx_uint_t value)
     }
 }
 
+static ngx_uint_t
+ngx_http_markdown_is_ascii_space(u_char ch)
+{
+    return (ch == ' ' || ch == '\t' || ch == '\r'
+            || ch == '\n' || ch == '\f' || ch == '\v');
+}
+
 static ngx_int_t
 ngx_http_markdown_parse_filter_flag(ngx_str_t *value, ngx_flag_t *enabled)
 {
+    ngx_str_t  normalized;
+    u_char    *start;
+    u_char    *end;
+
     if (value == NULL || enabled == NULL) {
         return NGX_ERROR;
     }
+
+    /*
+     * Normalize by trimming surrounding ASCII whitespace.
+     * This keeps per-request variable parsing tolerant to values such as
+     * " on " or "\t1\n" without allocating new buffers.
+     */
+    start = value->data;
+    end = value->data + value->len;
+
+    while (start < end && ngx_http_markdown_is_ascii_space(*start)) {
+        start++;
+    }
+
+    while (end > start && ngx_http_markdown_is_ascii_space(*(end - 1))) {
+        end--;
+    }
+
+    normalized.data = start;
+    normalized.len = (size_t) (end - start);
+    value = &normalized;
 
     if (value->len == 0) {
         *enabled = 0;

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -1657,7 +1657,7 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
     }
 
     /* Check if response is eligible for conversion */
-    eligibility = ngx_http_markdown_check_eligibility(r, conf);
+    eligibility = ngx_http_markdown_check_eligibility(r, conf, filter_enabled);
     if (eligibility != NGX_HTTP_MARKDOWN_ELIGIBLE) {
         /* Not eligible, pass through */
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -38,6 +38,7 @@ static void *ngx_http_markdown_create_conf(ngx_conf_t *cf);
 static char *ngx_http_markdown_merge_conf(ngx_conf_t *cf, void *parent, void *child);
 
 /* Configuration directive handlers */
+static char *ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_markdown_on_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_markdown_flavor(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_markdown_auth_policy(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
@@ -98,6 +99,10 @@ static const ngx_str_t *ngx_http_markdown_conditional_requests_name(ngx_uint_t v
 static const ngx_str_t *ngx_http_markdown_log_verbosity_name(ngx_uint_t value);
 static const ngx_str_t *ngx_http_markdown_compression_name(
     ngx_http_markdown_compression_type_e compression_type);
+static const ngx_str_t *ngx_http_markdown_enabled_source_name(ngx_uint_t value);
+static ngx_int_t ngx_http_markdown_parse_filter_flag(ngx_str_t *value, ngx_flag_t *enabled);
+ngx_flag_t ngx_http_markdown_is_enabled(ngx_http_request_t *r,
+    ngx_http_markdown_conf_t *conf);
 static void ngx_http_markdown_log_merged_conf(ngx_conf_t *cf, ngx_http_markdown_conf_t *conf);
 static ngx_int_t ngx_http_markdown_forward_headers(ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx);
@@ -122,9 +127,10 @@ static ngx_http_output_body_filter_pt ngx_http_next_body_filter;
  */
 static ngx_command_t ngx_http_markdown_filter_commands[] = {
     /*
-     * markdown_filter on|off
+     * markdown_filter on|off|$variable
      * 
      * Enables or disables Markdown conversion for this context.
+     * Also supports per-request toggle via nginx variables/complex values.
      * Default: off
      * Context: http, server, location
      * 
@@ -135,10 +141,10 @@ static ngx_command_t ngx_http_markdown_filter_commands[] = {
      */
     {
         ngx_string("markdown_filter"),
-        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
-        ngx_conf_set_flag_slot,
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_markdown_filter,
         NGX_HTTP_LOC_CONF_OFFSET,
-        offsetof(ngx_http_markdown_conf_t, enabled),
+        0,
         NULL
     },
     
@@ -510,6 +516,8 @@ ngx_http_markdown_create_conf(ngx_conf_t *cf)
     
     /* Set unset values (NGX_CONF_UNSET*) for proper inheritance */
     conf->enabled = NGX_CONF_UNSET;
+    conf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_UNSET;
+    conf->enabled_complex = NULL;
     conf->max_size = NGX_CONF_UNSET_SIZE;
     conf->timeout = NGX_CONF_UNSET_MSEC;
     conf->on_error = NGX_CONF_UNSET_UINT;
@@ -560,8 +568,29 @@ ngx_http_markdown_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_http_markdown_conf_t *prev = parent;
     ngx_http_markdown_conf_t *conf = child;
     
+    /*
+     * Merge markdown_filter with explicit source tracking.
+     *
+     * Priority:
+     * 1. Child explicit value (on/off or complex expression)
+     * 2. Parent inherited value
+     * 3. Default off
+     */
+    if (conf->enabled_source == NGX_HTTP_MARKDOWN_ENABLED_UNSET) {
+        if (prev->enabled_source == NGX_HTTP_MARKDOWN_ENABLED_UNSET) {
+            conf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+            conf->enabled = 0;
+            conf->enabled_complex = NULL;
+        } else {
+            conf->enabled_source = prev->enabled_source;
+            conf->enabled = prev->enabled;
+            conf->enabled_complex = prev->enabled_complex;
+        }
+    } else if (conf->enabled_source == NGX_HTTP_MARKDOWN_ENABLED_STATIC) {
+        conf->enabled_complex = NULL;
+    }
+
     /* Merge flag and scalar configuration values */
-    ngx_conf_merge_value(conf->enabled, prev->enabled, 0);
     ngx_conf_merge_size_value(conf->max_size, prev->max_size, 10 * 1024 * 1024); /* 10MB */
     ngx_conf_merge_msec_value(conf->timeout, prev->timeout, 5000); /* 5 seconds */
     ngx_conf_merge_uint_value(conf->on_error, prev->on_error, 
@@ -588,6 +617,79 @@ ngx_http_markdown_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     /* Startup/reload-time configuration snapshot (FR-12.7) */
     ngx_http_markdown_log_merged_conf(cf, conf);
     
+    return NGX_CONF_OK;
+}
+
+/*
+ * Configuration directive handler: markdown_filter
+ *
+ * Supported values:
+ * - on | off          (static configuration)
+ * - $variable         (dynamic per-request switch)
+ * - complex value containing variables
+ */
+static char *
+ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t          *mcf = conf;
+    ngx_http_compile_complex_value_t   ccv;
+    ngx_http_complex_value_t          *complex_value;
+    ngx_str_t                         *value;
+    u_char                            *var_marker;
+
+    (void) cmd;
+
+    if (mcf->enabled_source != NGX_HTTP_MARKDOWN_ENABLED_UNSET) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    if (value[1].len == 2
+        && ngx_strcasecmp(value[1].data, (u_char *) "on") == 0)
+    {
+        mcf->enabled = 1;
+        mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+        mcf->enabled_complex = NULL;
+        return NGX_CONF_OK;
+    }
+
+    if (value[1].len == 3
+        && ngx_strcasecmp(value[1].data, (u_char *) "off") == 0)
+    {
+        mcf->enabled = 0;
+        mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+        mcf->enabled_complex = NULL;
+        return NGX_CONF_OK;
+    }
+
+    var_marker = ngx_strlchr(value[1].data, value[1].data + value[1].len, '$');
+    if (var_marker == NULL) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid value \"%V\" in \"markdown_filter\" directive, "
+                           "it must be \"on\", \"off\", or contain a variable",
+                           &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    complex_value = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+    if (complex_value == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = complex_value;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    mcf->enabled = 0;
+    mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_COMPLEX;
+    mcf->enabled_complex = complex_value;
+
     return NGX_CONF_OK;
 }
 
@@ -989,6 +1091,133 @@ ngx_http_markdown_compression_name(ngx_http_markdown_compression_type_e compress
     }
 }
 
+static const ngx_str_t *
+ngx_http_markdown_enabled_source_name(ngx_uint_t value)
+{
+    static ngx_str_t unset = ngx_string("unset");
+    static ngx_str_t static_value = ngx_string("static");
+    static ngx_str_t complex = ngx_string("complex");
+    static ngx_str_t unknown = ngx_string("unknown");
+
+    switch (value) {
+        case NGX_HTTP_MARKDOWN_ENABLED_UNSET:
+            return &unset;
+        case NGX_HTTP_MARKDOWN_ENABLED_STATIC:
+            return &static_value;
+        case NGX_HTTP_MARKDOWN_ENABLED_COMPLEX:
+            return &complex;
+        default:
+            return &unknown;
+    }
+}
+
+static ngx_int_t
+ngx_http_markdown_parse_filter_flag(ngx_str_t *value, ngx_flag_t *enabled)
+{
+    if (value == NULL || enabled == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (value->len == 0) {
+        *enabled = 0;
+        return NGX_OK;
+    }
+
+    if (value->len == 1) {
+        if (value->data[0] == '1') {
+            *enabled = 1;
+            return NGX_OK;
+        }
+
+        if (value->data[0] == '0') {
+            *enabled = 0;
+            return NGX_OK;
+        }
+    }
+
+    if (value->len == 2
+        && ngx_strncasecmp(value->data, (u_char *) "on", 2) == 0)
+    {
+        *enabled = 1;
+        return NGX_OK;
+    }
+
+    if (value->len == 3
+        && ngx_strncasecmp(value->data, (u_char *) "off", 3) == 0)
+    {
+        *enabled = 0;
+        return NGX_OK;
+    }
+
+    if (value->len == 3
+        && ngx_strncasecmp(value->data, (u_char *) "yes", 3) == 0)
+    {
+        *enabled = 1;
+        return NGX_OK;
+    }
+
+    if (value->len == 2
+        && ngx_strncasecmp(value->data, (u_char *) "no", 2) == 0)
+    {
+        *enabled = 0;
+        return NGX_OK;
+    }
+
+    if (value->len == 4
+        && ngx_strncasecmp(value->data, (u_char *) "true", 4) == 0)
+    {
+        *enabled = 1;
+        return NGX_OK;
+    }
+
+    if (value->len == 5
+        && ngx_strncasecmp(value->data, (u_char *) "false", 5) == 0)
+    {
+        *enabled = 0;
+        return NGX_OK;
+    }
+
+    return NGX_ERROR;
+}
+
+ngx_flag_t
+ngx_http_markdown_is_enabled(ngx_http_request_t *r, ngx_http_markdown_conf_t *conf)
+{
+    ngx_str_t    evaluated;
+    ngx_flag_t   enabled;
+    ngx_int_t    rc;
+
+    if (conf == NULL) {
+        return 0;
+    }
+
+    if (conf->enabled_source != NGX_HTTP_MARKDOWN_ENABLED_COMPLEX
+        || conf->enabled_complex == NULL)
+    {
+        return conf->enabled;
+    }
+
+    if (r == NULL) {
+        return 0;
+    }
+
+    if (ngx_http_complex_value(r, conf->enabled_complex, &evaluated) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "markdown filter: failed to evaluate markdown_filter variable");
+        return 0;
+    }
+
+    rc = ngx_http_markdown_parse_filter_flag(&evaluated, &enabled);
+    if (rc != NGX_OK) {
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                      "markdown filter: markdown_filter variable resolved to invalid value "
+                      "\"%V\", treating as off", &evaluated);
+        return 0;
+    }
+
+    return enabled;
+}
+
 static void
 ngx_http_markdown_log_merged_conf(ngx_conf_t *cf, ngx_http_markdown_conf_t *conf)
 {
@@ -1003,12 +1232,13 @@ ngx_http_markdown_log_merged_conf(ngx_conf_t *cf, ngx_http_markdown_conf_t *conf
     log_level = ngx_http_markdown_log_verbosity_to_ngx_level(conf->log_verbosity);
 
     ngx_conf_log_error(log_level, cf, 0,
-                      "markdown filter config: enabled=%ui max_size=%uz timeout_ms=%M "
+                      "markdown filter config: enabled=%ui enabled_source=%V max_size=%uz timeout_ms=%M "
                       "on_error=%V flavor=%V token_estimate=%ui front_matter=%ui "
                       "on_wildcard=%ui auth_policy=%V auth_cookie_patterns=%ui "
                       "etag=%ui conditional_requests=%V log_verbosity=%V "
                       "buffer_chunked=%ui stream_types=%ui",
                       (ngx_uint_t) conf->enabled,
+                      ngx_http_markdown_enabled_source_name(conf->enabled_source),
                       conf->max_size,
                       conf->timeout,
                       ngx_http_markdown_on_error_name(conf->on_error),
@@ -1370,7 +1600,7 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
 
     /* Get module configuration */
     conf = ngx_http_get_module_loc_conf(r, ngx_http_markdown_filter_module);
-    if (conf == NULL || conf->enabled == 0) {
+    if (conf == NULL || !ngx_http_markdown_is_enabled(r, conf)) {
         /* Module disabled, pass through */
         return ngx_http_next_header_filter(r);
     }
@@ -2478,7 +2708,7 @@ ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     /* Get module configuration */
     conf = ngx_http_get_module_loc_conf(r, ngx_http_markdown_filter_module);
-    if (conf == NULL || conf->enabled == 0) {
+    if (conf == NULL || !ngx_http_markdown_is_enabled(r, conf)) {
         /* Module disabled, pass through */
         return ngx_http_next_body_filter(r, in);
     }

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -1628,11 +1628,23 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
     ngx_http_markdown_ctx_t         *ctx;
     ngx_http_markdown_conf_t        *conf;
     ngx_http_markdown_eligibility_t  eligibility;
+    ngx_flag_t                       filter_enabled;
     ngx_int_t                        should_convert;
 
     /* Get module configuration */
     conf = ngx_http_get_module_loc_conf(r, ngx_http_markdown_filter_module);
-    if (conf == NULL || !ngx_http_markdown_is_enabled(r, conf)) {
+    if (conf == NULL) {
+        /* Module not configured, pass through */
+        return ngx_http_next_header_filter(r);
+    }
+
+    /*
+     * Resolve markdown_filter once in header phase and cache the result in
+     * request context. Body phase must reuse this decision to avoid
+     * header/body inconsistencies for dynamic variables.
+     */
+    filter_enabled = ngx_http_markdown_is_enabled(r, conf);
+    if (!filter_enabled) {
         /* Module disabled, pass through */
         return ngx_http_next_header_filter(r);
     }
@@ -1671,6 +1683,7 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
 
     /* Initialize context */
     ctx->request = r;
+    ctx->filter_enabled = filter_enabled;
     ctx->eligible = 1;
     ctx->buffer_initialized = 0;
     ctx->headers_forwarded = 0;
@@ -2740,16 +2753,27 @@ ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     /* Get module configuration */
     conf = ngx_http_get_module_loc_conf(r, ngx_http_markdown_filter_module);
-    if (conf == NULL || !ngx_http_markdown_is_enabled(r, conf)) {
+    if (conf == NULL) {
         /* Module disabled, pass through */
         return ngx_http_next_body_filter(r, in);
     }
 
-    /* Get or create request context */
+    /*
+     * Get request context created by header filter.
+     *
+     * IMPORTANT: Do not re-evaluate markdown_filter here. Dynamic expressions
+     * can resolve differently between phases; body filter must follow the
+     * cached header-phase decision.
+     */
     ctx = ngx_http_get_module_ctx(r, ngx_http_markdown_filter_module);
     if (ctx == NULL) {
         /* No context means header filter didn't set up conversion */
         /* Pass through unchanged */
+        return ngx_http_next_body_filter(r, in);
+    }
+
+    if (!ctx->filter_enabled) {
+        r->buffered &= ~NGX_HTTP_MARKDOWN_BUFFERED;
         return ngx_http_next_body_filter(r, in);
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -140,6 +140,7 @@ typedef struct {
     ngx_chain_t                 *in;           /* Input chain */
     ngx_chain_t                 *out;          /* Output chain */
     ngx_http_markdown_buffer_t   buffer;       /* Response buffer */
+    ngx_flag_t                   filter_enabled; /* Cached markdown_filter decision from header phase */
     ngx_flag_t                   buffer_initialized;
     ngx_flag_t                   eligible;     /* Eligible for conversion */
     ngx_flag_t                   headers_forwarded; /* Whether downstream headers were sent */

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -49,6 +49,13 @@
 #define NGX_HTTP_MARKDOWN_LOG_DEBUG  3  /* Debug and above */
 
 /*
+ * Configuration source for markdown_filter directive
+ */
+#define NGX_HTTP_MARKDOWN_ENABLED_UNSET    0  /* Not configured in this scope */
+#define NGX_HTTP_MARKDOWN_ENABLED_STATIC   1  /* markdown_filter on|off */
+#define NGX_HTTP_MARKDOWN_ENABLED_COMPLEX  2  /* markdown_filter <variable/expr> */
+
+/*
  * Compression type enumeration
  *
  * Identifies the compression format of upstream response content.
@@ -70,6 +77,8 @@ typedef enum {
  *
  * Configuration defaults (defined in ngx_http_markdown_create_loc_conf):
  * - enabled: NGX_CONF_UNSET (inherit from parent)
+ * - enabled_source: NGX_HTTP_MARKDOWN_ENABLED_UNSET (inherit from parent)
+ * - enabled_complex: NULL
  * - max_size: 10MB (10 * 1024 * 1024 bytes)
  * - timeout: 5000ms (5 seconds)
  * - on_error: NGX_HTTP_MARKDOWN_ON_ERROR_PASS (fail-open)
@@ -87,7 +96,9 @@ typedef enum {
  * - auto_decompress: 1 (on by default)
  */
 typedef struct {
-    ngx_flag_t   enabled;              /* markdown_filter on|off */
+    ngx_flag_t   enabled;              /* markdown_filter static resolved value */
+    ngx_uint_t   enabled_source;       /* markdown_filter source (static|complex|unset) */
+    ngx_http_complex_value_t *enabled_complex; /* markdown_filter variable/complex expression */
     size_t       max_size;             /* markdown_max_size (default: 10MB) */
     ngx_msec_t   timeout;              /* markdown_timeout (default: 5000ms) */
     ngx_uint_t   on_error;             /* markdown_on_error pass|reject (default: pass) */
@@ -245,6 +256,10 @@ void ngx_http_markdown_sort_accept_entries(ngx_array_t *entries);
 
 /* Determine if request should be converted based on Accept header */
 ngx_int_t ngx_http_markdown_should_convert(ngx_http_request_t *r,
+    ngx_http_markdown_conf_t *conf);
+
+/* Resolve markdown_filter on/off state for the current request */
+ngx_flag_t ngx_http_markdown_is_enabled(ngx_http_request_t *r,
     ngx_http_markdown_conf_t *conf);
 
 /*

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -323,7 +323,8 @@ typedef enum {
 
 /* Check if response is eligible for conversion */
 ngx_http_markdown_eligibility_t ngx_http_markdown_check_eligibility(
-    ngx_http_request_t *r, ngx_http_markdown_conf_t *conf);
+    ngx_http_request_t *r, ngx_http_markdown_conf_t *conf,
+    ngx_flag_t filter_enabled);
 
 /* Get human-readable string for eligibility result */
 const ngx_str_t *ngx_http_markdown_eligibility_string(

--- a/components/nginx-module/tests/integration/run_integration_tests.sh
+++ b/components/nginx-module/tests/integration/run_integration_tests.sh
@@ -439,6 +439,80 @@ http {
 }
 
 #
+# Test 5: Variable-Driven markdown_filter
+#
+test_variable_driven_markdown_filter() {
+    log_test 5 "Variable-driven markdown_filter resolution"
+
+    local config='
+worker_processes 1;
+'"${CONFIG_ERROR_LOG_LINE}"'
+'"${CONFIG_PID_LINE}"'
+events { worker_connections 1024; }
+http {
+    access_log '"${NGINX_ACCESS_LOG}"';
+
+    map $arg_md $markdown_enabled {
+        default "maybe";
+        "1" " on ";
+        "0" "off";
+        "true" "yes";
+    }
+
+    server {
+        listen '"${TEST_PORT}"';
+        location /test {
+            markdown_filter $markdown_enabled;
+            return 200 '"'"'<html><body><h1>Var Toggle</h1></body></html>'"'"';
+            default_type text/html;
+        }
+    }
+}
+'
+
+    start_nginx "$config" || { log_fail "$NGINX_START_FAILURE_MSG"; return 1; }
+
+    local response
+    local content_type
+
+    response=$(make_request "GET" "/test?md=1" "$MEDIA_TYPE_MARKDOWN" "")
+    content_type=$(get_header "$response" "$HEADER_CONTENT_TYPE")
+    if echo "$content_type" | grep -q "$MEDIA_TYPE_MARKDOWN"; then
+        log_pass "md=1 enables conversion (trimmed \" on \" value)"
+    else
+        log_fail "md=1 should convert, got $content_type"
+    fi
+
+    response=$(make_request "GET" "/test?md=0" "$MEDIA_TYPE_MARKDOWN" "")
+    content_type=$(get_header "$response" "$HEADER_CONTENT_TYPE")
+    if echo "$content_type" | grep -q "text/html"; then
+        log_pass "md=0 disables conversion"
+    else
+        log_fail "md=0 should not convert, got $content_type"
+    fi
+
+    response=$(make_request "GET" "/test?md=true" "$MEDIA_TYPE_MARKDOWN" "")
+    content_type=$(get_header "$response" "$HEADER_CONTENT_TYPE")
+    if echo "$content_type" | grep -q "$MEDIA_TYPE_MARKDOWN"; then
+        log_pass "md=true enables conversion (yes/true mapping)"
+    else
+        log_fail "md=true should convert, got $content_type"
+    fi
+
+    response=$(make_request "GET" "/test?md=bad" "$MEDIA_TYPE_MARKDOWN" "")
+    content_type=$(get_header "$response" "$HEADER_CONTENT_TYPE")
+    if echo "$content_type" | grep -q "text/html"; then
+        log_pass "Invalid variable value safely disables conversion"
+    else
+        log_fail "Invalid value should not convert, got $content_type"
+    fi
+
+    stop_nginx
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    return 0
+}
+
+#
 # Main test execution
 #
 main() {
@@ -467,6 +541,7 @@ main() {
     test_passthrough
     test_configuration_inheritance
     test_authenticated_content
+    test_variable_driven_markdown_filter
     
     # Summary
     echo ""

--- a/components/nginx-module/tests/unit/config_merge_test.c
+++ b/components/nginx-module/tests/unit/config_merge_test.c
@@ -8,8 +8,14 @@
 #define UNSET_INT (-1)
 #define UNSET_SIZE ((size_t) -1)
 
+#define ENABLED_UNSET 0
+#define ENABLED_STATIC 1
+#define ENABLED_COMPLEX 2
+
 typedef struct {
     int enabled;
+    int enabled_source;
+    const char *enabled_complex;
     size_t max_size;
     int on_error;
     int flavor;
@@ -21,7 +27,19 @@ typedef struct {
 static void
 merge_conf(conf_t *child, const conf_t *parent)
 {
-    if (child->enabled == UNSET_INT) child->enabled = (parent->enabled == UNSET_INT) ? 0 : parent->enabled;
+    if (child->enabled_source == ENABLED_UNSET) {
+        if (parent->enabled_source == ENABLED_UNSET) {
+            child->enabled_source = ENABLED_STATIC;
+            child->enabled = 0;
+            child->enabled_complex = NULL;
+        } else {
+            child->enabled_source = parent->enabled_source;
+            child->enabled = parent->enabled;
+            child->enabled_complex = parent->enabled_complex;
+        }
+    } else if (child->enabled_source == ENABLED_STATIC) {
+        child->enabled_complex = NULL;
+    }
     if (child->max_size == UNSET_SIZE) child->max_size = (parent->max_size == UNSET_SIZE) ? (10 * 1024 * 1024) : parent->max_size;
     if (child->on_error == UNSET_INT) child->on_error = (parent->on_error == UNSET_INT) ? 0 : parent->on_error;
     if (child->flavor == UNSET_INT) child->flavor = (parent->flavor == UNSET_INT) ? 0 : parent->flavor;
@@ -35,6 +53,8 @@ unset_conf(void)
 {
     conf_t c;
     c.enabled = UNSET_INT;
+    c.enabled_source = ENABLED_UNSET;
+    c.enabled_complex = NULL;
     c.max_size = UNSET_SIZE;
     c.on_error = UNSET_INT;
     c.flavor = UNSET_INT;
@@ -53,6 +73,7 @@ test_inherit_from_parent(void)
     TEST_SUBSECTION("Child inherits parent values");
 
     parent.enabled = 1;
+    parent.enabled_source = ENABLED_STATIC;
     parent.max_size = 5 * 1024 * 1024;
     parent.on_error = 1;
     parent.flavor = 1;
@@ -63,6 +84,7 @@ test_inherit_from_parent(void)
     merge_conf(&child, &parent);
 
     TEST_ASSERT(child.enabled == 1, "enabled should inherit");
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "enabled_source should inherit");
     TEST_ASSERT(child.max_size == parent.max_size, "max_size should inherit");
     TEST_ASSERT(child.on_error == parent.on_error, "on_error should inherit");
     TEST_ASSERT(child.flavor == parent.flavor, "flavor should inherit");
@@ -81,16 +103,19 @@ test_child_override(void)
     TEST_SUBSECTION("Child override wins");
 
     parent.enabled = 0;
+    parent.enabled_source = ENABLED_STATIC;
     parent.max_size = 2 * 1024 * 1024;
     parent.flavor = 0;
 
     child.enabled = 1;
+    child.enabled_source = ENABLED_STATIC;
     child.max_size = 1024;
     child.flavor = 1;
 
     merge_conf(&child, &parent);
 
     TEST_ASSERT(child.enabled == 1, "child enabled override should remain");
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "child enabled_source override should remain");
     TEST_ASSERT(child.max_size == 1024, "child max_size override should remain");
     TEST_ASSERT(child.flavor == 1, "child flavor override should remain");
     TEST_PASS("Override precedence works");
@@ -105,12 +130,58 @@ test_defaults_when_both_unset(void)
     TEST_SUBSECTION("Defaults applied when parent and child are unset");
     merge_conf(&child, &parent);
     TEST_ASSERT(child.enabled == 0, "default enabled should be off");
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "default enabled_source should be static");
     TEST_ASSERT(child.max_size == 10 * 1024 * 1024, "default max_size should be 10MB");
     TEST_ASSERT(child.on_error == 0, "default on_error should be pass");
     TEST_ASSERT(child.flavor == 0, "default flavor should be commonmark");
     TEST_ASSERT(child.on_wildcard == 0, "default on_wildcard should be off");
     TEST_ASSERT(child.auto_decompress == 1, "default auto_decompress should be on");
     TEST_PASS("Defaults are correct");
+}
+
+static void
+test_enabled_source_merge_behavior(void)
+{
+    conf_t parent = unset_conf();
+    conf_t child = unset_conf();
+
+    TEST_SUBSECTION("enabled_source and enabled_complex merge behavior");
+
+    parent.enabled = 0;
+    parent.enabled_source = ENABLED_COMPLEX;
+    parent.enabled_complex = "parent_complex";
+    merge_conf(&child, &parent);
+
+    TEST_ASSERT(child.enabled_source == ENABLED_COMPLEX, "child should inherit complex source");
+    TEST_ASSERT(child.enabled_complex == parent.enabled_complex, "child should inherit complex expression");
+
+    parent = unset_conf();
+    parent.enabled = 1;
+    parent.enabled_source = ENABLED_STATIC;
+    parent.enabled_complex = NULL;
+    child = unset_conf();
+    child.enabled = 0;
+    child.enabled_source = ENABLED_COMPLEX;
+    child.enabled_complex = "child_complex";
+    merge_conf(&child, &parent);
+
+    TEST_ASSERT(child.enabled_source == ENABLED_COMPLEX, "child complex should override parent static");
+    TEST_ASSERT(STR_EQ(child.enabled_complex, "child_complex"), "child complex expression should be preserved");
+
+    parent = unset_conf();
+    parent.enabled = 1;
+    parent.enabled_source = ENABLED_COMPLEX;
+    parent.enabled_complex = "parent_complex";
+    child = unset_conf();
+    child.enabled = 0;
+    child.enabled_source = ENABLED_STATIC;
+    child.enabled_complex = "stale";
+    merge_conf(&child, &parent);
+
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "child static should override parent complex");
+    TEST_ASSERT(child.enabled_complex == NULL, "static source should clear complex expression");
+
+    TEST_PASS("enabled_source merge behavior is correct");
 }
 
 int
@@ -123,6 +194,7 @@ main(void)
     test_inherit_from_parent();
     test_child_override();
     test_defaults_when_both_unset();
+    test_enabled_source_merge_behavior();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/config_parsing_test.c
+++ b/components/nginx-module/tests/unit/config_parsing_test.c
@@ -34,8 +34,37 @@ typedef struct {
 static int valid_on_error(const char *v) { return STR_EQ(v, "pass") || STR_EQ(v, "reject"); }
 static int valid_flavor(const char *v) { return STR_EQ(v, "commonmark") || STR_EQ(v, "gfm"); }
 static int valid_auth_policy(const char *v) { return STR_EQ(v, "allow") || STR_EQ(v, "deny"); }
+static int valid_var_start_char(char c)
+{
+    return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+static int valid_markdown_filter_complex(const char *v)
+{
+    const char *p;
+
+    if (v == NULL) {
+        return 0;
+    }
+
+    p = v;
+    while ((p = strchr(p, '$')) != NULL) {
+        if (p[1] == '{') {
+            const char *close = strchr(p + 2, '}');
+            if (close != NULL && close > (p + 2)) {
+                return 1;
+            }
+        } else if (valid_var_start_char(p[1])) {
+            return 1;
+        }
+        p++;
+    }
+
+    return 0;
+}
+
 static int valid_markdown_filter(const char *v) {
-    return STR_EQ(v, "on") || STR_EQ(v, "off") || (v != NULL && strchr(v, '$') != NULL);
+    return STR_EQ(v, "on") || STR_EQ(v, "off") || valid_markdown_filter_complex(v);
 }
 static int valid_conditional(const char *v) {
     return STR_EQ(v, "full_support") || STR_EQ(v, "if_modified_since_only") || STR_EQ(v, "disabled");
@@ -73,6 +102,10 @@ test_value_validation(void)
     TEST_ASSERT(valid_markdown_filter("on"), "markdown_filter should accept on");
     TEST_ASSERT(valid_markdown_filter("off"), "markdown_filter should accept off");
     TEST_ASSERT(valid_markdown_filter("$convert_html"), "markdown_filter should accept variable");
+    TEST_ASSERT(valid_markdown_filter("${convert_html}"), "markdown_filter should accept braced variable");
+    TEST_ASSERT(valid_markdown_filter("pre_$convert_html_post"), "markdown_filter should accept complex expression");
+    TEST_ASSERT(!valid_markdown_filter("convert_html"), "markdown_filter should reject expression without variable");
+    TEST_ASSERT(!valid_markdown_filter("$"), "markdown_filter should reject degenerate variable marker");
     TEST_ASSERT(!valid_markdown_filter("yes"), "markdown_filter should reject invalid static value");
     TEST_ASSERT(!valid_markdown_filter("1"), "markdown_filter should reject numeric literal");
     TEST_ASSERT(valid_flavor("commonmark"), "flavor should accept commonmark");

--- a/components/nginx-module/tests/unit/config_parsing_test.c
+++ b/components/nginx-module/tests/unit/config_parsing_test.c
@@ -34,6 +34,9 @@ typedef struct {
 static int valid_on_error(const char *v) { return STR_EQ(v, "pass") || STR_EQ(v, "reject"); }
 static int valid_flavor(const char *v) { return STR_EQ(v, "commonmark") || STR_EQ(v, "gfm"); }
 static int valid_auth_policy(const char *v) { return STR_EQ(v, "allow") || STR_EQ(v, "deny"); }
+static int valid_markdown_filter(const char *v) {
+    return STR_EQ(v, "on") || STR_EQ(v, "off") || (v != NULL && strchr(v, '$') != NULL);
+}
 static int valid_conditional(const char *v) {
     return STR_EQ(v, "full_support") || STR_EQ(v, "if_modified_since_only") || STR_EQ(v, "disabled");
 }
@@ -67,6 +70,11 @@ test_value_validation(void)
     TEST_ASSERT(valid_on_error("pass"), "on_error should accept pass");
     TEST_ASSERT(valid_on_error("reject"), "on_error should accept reject");
     TEST_ASSERT(!valid_on_error("PASS"), "on_error should be case-sensitive");
+    TEST_ASSERT(valid_markdown_filter("on"), "markdown_filter should accept on");
+    TEST_ASSERT(valid_markdown_filter("off"), "markdown_filter should accept off");
+    TEST_ASSERT(valid_markdown_filter("$convert_html"), "markdown_filter should accept variable");
+    TEST_ASSERT(!valid_markdown_filter("yes"), "markdown_filter should reject invalid static value");
+    TEST_ASSERT(!valid_markdown_filter("1"), "markdown_filter should reject numeric literal");
     TEST_ASSERT(valid_flavor("commonmark"), "flavor should accept commonmark");
     TEST_ASSERT(valid_flavor("gfm"), "flavor should accept gfm");
     TEST_ASSERT(!valid_flavor("markdown"), "flavor should reject invalid value");

--- a/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
+++ b/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
@@ -23,6 +23,10 @@ typedef struct {
     const char *enabled_complex;
 } conf_t;
 
+typedef struct {
+    int filter_enabled;
+} ctx_t;
+
 static int
 is_ascii_space(char ch)
 {
@@ -150,6 +154,16 @@ is_enabled_runtime(const request_t *r, const conf_t *conf)
     }
 
     return enabled;
+}
+
+static int
+body_enabled_from_cached_ctx(const conf_t *conf, const ctx_t *ctx)
+{
+    if (conf == NULL || ctx == NULL) {
+        return 0;
+    }
+
+    return ctx->filter_enabled;
 }
 
 static void
@@ -284,6 +298,42 @@ test_is_enabled_complex_resolution(void)
 }
 
 static void
+test_body_phase_uses_cached_header_decision(void)
+{
+    conf_t conf;
+    request_t header_req;
+    request_t body_req;
+    ctx_t ctx;
+
+    TEST_SUBSECTION("body phase uses cached header decision");
+
+    conf = unset_conf();
+    conf.enabled = 0;
+    conf.enabled_source = ENABLED_COMPLEX;
+    conf.enabled_complex = "compiled";
+
+    header_req.eval_status = TEST_NGX_OK;
+    header_req.value = "on";
+    ctx.filter_enabled = is_enabled_runtime(&header_req, &conf);
+    TEST_ASSERT(ctx.filter_enabled == 1, "header should cache enabled decision");
+
+    body_req.eval_status = TEST_NGX_OK;
+    body_req.value = "off";
+
+    TEST_ASSERT(is_enabled_runtime(&body_req, &conf) == 0,
+                "fresh body-time evaluation can resolve differently");
+    TEST_ASSERT(body_enabled_from_cached_ctx(&conf, &ctx) == 1,
+                "body phase should use cached header decision");
+
+    TEST_ASSERT(body_enabled_from_cached_ctx(NULL, &ctx) == 0,
+                "NULL conf should disable body processing");
+    TEST_ASSERT(body_enabled_from_cached_ctx(&conf, NULL) == 0,
+                "NULL ctx should disable body processing");
+
+    TEST_PASS("cached header decision behavior is correct");
+}
+
+static void
 test_enabled_merge_behavior(void)
 {
     conf_t parent;
@@ -345,6 +395,7 @@ main(void)
     test_parse_filter_flag_values();
     test_is_enabled_static_and_edge_cases();
     test_is_enabled_complex_resolution();
+    test_body_phase_uses_cached_header_decision();
     test_enabled_merge_behavior();
 
     printf("\n========================================\n");

--- a/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
+++ b/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
@@ -1,6 +1,11 @@
 /*
  * Test: markdown_filter_runtime
  * Description: markdown_filter runtime parsing and resolution behavior
+ *
+ * NOTE:
+ * This file uses a lightweight behavioral model (not direct linkage against
+ * nginx module objects). Real runtime wiring is covered by integration tests
+ * in tests/integration/run_integration_tests.sh.
  */
 
 #include "test_common.h"

--- a/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
+++ b/components/nginx-module/tests/unit/markdown_filter_runtime_test.c
@@ -1,0 +1,354 @@
+/*
+ * Test: markdown_filter_runtime
+ * Description: markdown_filter runtime parsing and resolution behavior
+ */
+
+#include "test_common.h"
+
+#define TEST_NGX_OK 0
+#define TEST_NGX_ERROR (-1)
+
+#define ENABLED_UNSET 0
+#define ENABLED_STATIC 1
+#define ENABLED_COMPLEX 2
+
+typedef struct {
+    const char *value;
+    int eval_status;
+} request_t;
+
+typedef struct {
+    int enabled;
+    int enabled_source;
+    const char *enabled_complex;
+} conf_t;
+
+static int
+is_ascii_space(char ch)
+{
+    return ch == ' ' || ch == '\t' || ch == '\r'
+        || ch == '\n' || ch == '\f' || ch == '\v';
+}
+
+static char
+ascii_lower(char ch)
+{
+    if (ch >= 'A' && ch <= 'Z') {
+        return (char)(ch - 'A' + 'a');
+    }
+    return ch;
+}
+
+static int
+eq_nocase_lit(const char *start, size_t len, const char *lit)
+{
+    size_t lit_len;
+    size_t i;
+
+    if (start == NULL || lit == NULL) {
+        return 0;
+    }
+
+    lit_len = strlen(lit);
+    if (len != lit_len) {
+        return 0;
+    }
+
+    for (i = 0; i < len; i++) {
+        if (ascii_lower(start[i]) != lit[i]) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int
+parse_filter_flag_runtime(const char *raw, int *enabled)
+{
+    const char *start;
+    const char *end;
+    size_t len;
+
+    if (raw == NULL || enabled == NULL) {
+        return TEST_NGX_ERROR;
+    }
+
+    start = raw;
+    end = raw + strlen(raw);
+
+    while (start < end && is_ascii_space(*start)) {
+        start++;
+    }
+
+    while (end > start && is_ascii_space(*(end - 1))) {
+        end--;
+    }
+
+    len = (size_t)(end - start);
+    if (len == 0) {
+        *enabled = 0;
+        return TEST_NGX_OK;
+    }
+
+    if (len == 1 && start[0] == '1') {
+        *enabled = 1;
+        return TEST_NGX_OK;
+    }
+    if (len == 1 && start[0] == '0') {
+        *enabled = 0;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "on")) {
+        *enabled = 1;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "off")) {
+        *enabled = 0;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "yes")) {
+        *enabled = 1;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "no")) {
+        *enabled = 0;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "true")) {
+        *enabled = 1;
+        return TEST_NGX_OK;
+    }
+    if (eq_nocase_lit(start, len, "false")) {
+        *enabled = 0;
+        return TEST_NGX_OK;
+    }
+
+    return TEST_NGX_ERROR;
+}
+
+static int
+is_enabled_runtime(const request_t *r, const conf_t *conf)
+{
+    int enabled;
+
+    if (conf == NULL) {
+        return 0;
+    }
+
+    if (conf->enabled_source != ENABLED_COMPLEX || conf->enabled_complex == NULL) {
+        return conf->enabled;
+    }
+
+    if (r == NULL || r->eval_status != TEST_NGX_OK || r->value == NULL) {
+        return 0;
+    }
+
+    enabled = 0;
+    if (parse_filter_flag_runtime(r->value, &enabled) != TEST_NGX_OK) {
+        return 0;
+    }
+
+    return enabled;
+}
+
+static void
+merge_enabled_fields(conf_t *child, const conf_t *parent)
+{
+    if (child->enabled_source == ENABLED_UNSET) {
+        if (parent->enabled_source == ENABLED_UNSET) {
+            child->enabled_source = ENABLED_STATIC;
+            child->enabled = 0;
+            child->enabled_complex = NULL;
+        } else {
+            child->enabled_source = parent->enabled_source;
+            child->enabled = parent->enabled;
+            child->enabled_complex = parent->enabled_complex;
+        }
+    } else if (child->enabled_source == ENABLED_STATIC) {
+        child->enabled_complex = NULL;
+    }
+}
+
+static conf_t
+unset_conf(void)
+{
+    conf_t c;
+    c.enabled = 0;
+    c.enabled_source = ENABLED_UNSET;
+    c.enabled_complex = NULL;
+    return c;
+}
+
+static void
+test_parse_filter_flag_values(void)
+{
+    int flag;
+
+    TEST_SUBSECTION("parse_filter_flag supported values and trimming");
+
+    flag = -1;
+    TEST_ASSERT(parse_filter_flag_runtime("1", &flag) == TEST_NGX_OK, "should parse \"1\"");
+    TEST_ASSERT(flag == 1, "\"1\" should map to enabled");
+
+    flag = -1;
+    TEST_ASSERT(parse_filter_flag_runtime(" off ", &flag) == TEST_NGX_OK, "should trim and parse \" off \"");
+    TEST_ASSERT(flag == 0, "\" off \" should map to disabled");
+
+    flag = -1;
+    TEST_ASSERT(parse_filter_flag_runtime("\tYes\n", &flag) == TEST_NGX_OK, "should trim and parse \"yes\"");
+    TEST_ASSERT(flag == 1, "\"yes\" should map to enabled");
+
+    flag = -1;
+    TEST_ASSERT(parse_filter_flag_runtime("False", &flag) == TEST_NGX_OK, "should parse case-insensitive false");
+    TEST_ASSERT(flag == 0, "\"False\" should map to disabled");
+
+    flag = 7;
+    TEST_ASSERT(parse_filter_flag_runtime("maybe", &flag) == TEST_NGX_ERROR, "invalid value should fail");
+    TEST_ASSERT(flag == 7, "invalid parse must not overwrite output flag");
+
+    TEST_ASSERT(parse_filter_flag_runtime(NULL, &flag) == TEST_NGX_ERROR, "NULL value should fail");
+    TEST_ASSERT(parse_filter_flag_runtime("on", NULL) == TEST_NGX_ERROR, "NULL output flag should fail");
+
+    TEST_PASS("parse_filter_flag behavior is correct");
+}
+
+static void
+test_is_enabled_static_and_edge_cases(void)
+{
+    conf_t conf;
+    request_t req;
+
+    TEST_SUBSECTION("is_enabled static config and edge cases");
+
+    TEST_ASSERT(is_enabled_runtime(NULL, NULL) == 0, "NULL conf should be disabled");
+
+    conf = unset_conf();
+    conf.enabled = 1;
+    conf.enabled_source = ENABLED_STATIC;
+    TEST_ASSERT(is_enabled_runtime(NULL, &conf) == 1, "static enabled should not require request");
+
+    conf.enabled = 0;
+    req.value = "1";
+    req.eval_status = TEST_NGX_OK;
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 0, "static disabled should remain disabled");
+
+    conf.enabled = 1;
+    conf.enabled_source = ENABLED_COMPLEX;
+    conf.enabled_complex = "compiled";
+    TEST_ASSERT(is_enabled_runtime(NULL, &conf) == 0, "complex mode should disable when request is NULL");
+
+    conf.enabled = 1;
+    conf.enabled_source = ENABLED_COMPLEX;
+    conf.enabled_complex = NULL;
+    TEST_ASSERT(is_enabled_runtime(NULL, &conf) == 1,
+                "complex source without compiled value should fall back to static enabled");
+
+    TEST_PASS("is_enabled static and edge behavior is correct");
+}
+
+static void
+test_is_enabled_complex_resolution(void)
+{
+    conf_t conf;
+    request_t req;
+
+    TEST_SUBSECTION("is_enabled complex resolution");
+
+    conf = unset_conf();
+    conf.enabled = 0;
+    conf.enabled_source = ENABLED_COMPLEX;
+    conf.enabled_complex = "compiled";
+
+    req.eval_status = TEST_NGX_OK;
+    req.value = "on";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 1, "\"on\" should enable");
+
+    req.value = " 0 ";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 0, "\" 0 \" should disable");
+
+    req.value = "true";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 1, "\"true\" should enable");
+
+    req.value = "no";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 0, "\"no\" should disable");
+
+    req.value = "maybe";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 0, "invalid value should disable");
+
+    req.eval_status = TEST_NGX_ERROR;
+    req.value = "1";
+    TEST_ASSERT(is_enabled_runtime(&req, &conf) == 0, "evaluation failure should disable");
+
+    TEST_PASS("is_enabled complex behavior is correct");
+}
+
+static void
+test_enabled_merge_behavior(void)
+{
+    conf_t parent;
+    conf_t child;
+
+    TEST_SUBSECTION("enabled field merge behavior");
+
+    parent = unset_conf();
+    child = unset_conf();
+    merge_enabled_fields(&child, &parent);
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "unset parent/child should default source to static");
+    TEST_ASSERT(child.enabled == 0, "unset parent/child should default to disabled");
+    TEST_ASSERT(child.enabled_complex == NULL, "unset parent/child should clear complex pointer");
+
+    parent = unset_conf();
+    parent.enabled = 0;
+    parent.enabled_source = ENABLED_COMPLEX;
+    parent.enabled_complex = "parent_complex";
+    child = unset_conf();
+    merge_enabled_fields(&child, &parent);
+    TEST_ASSERT(child.enabled_source == ENABLED_COMPLEX, "child should inherit complex source");
+    TEST_ASSERT(child.enabled_complex == parent.enabled_complex, "child should inherit complex pointer");
+
+    parent = unset_conf();
+    parent.enabled = 1;
+    parent.enabled_source = ENABLED_COMPLEX;
+    parent.enabled_complex = "parent_complex";
+    child = unset_conf();
+    child.enabled = 0;
+    child.enabled_source = ENABLED_STATIC;
+    child.enabled_complex = "stale_value";
+    merge_enabled_fields(&child, &parent);
+    TEST_ASSERT(child.enabled_source == ENABLED_STATIC, "child static source should override parent");
+    TEST_ASSERT(child.enabled == 0, "child static value should be preserved");
+    TEST_ASSERT(child.enabled_complex == NULL, "child static source should clear complex pointer");
+
+    parent = unset_conf();
+    parent.enabled = 1;
+    parent.enabled_source = ENABLED_STATIC;
+    parent.enabled_complex = NULL;
+    child = unset_conf();
+    child.enabled = 0;
+    child.enabled_source = ENABLED_COMPLEX;
+    child.enabled_complex = "child_complex";
+    merge_enabled_fields(&child, &parent);
+    TEST_ASSERT(child.enabled_source == ENABLED_COMPLEX, "child complex source should override parent static");
+    TEST_ASSERT(child.enabled_complex != NULL, "child complex pointer should be preserved");
+
+    TEST_PASS("enabled merge behavior is correct");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("markdown_filter_runtime Tests\n");
+    printf("========================================\n");
+
+    test_parse_filter_flag_values();
+    test_is_enabled_static_and_edge_cases();
+    test_is_enabled_complex_resolution();
+    test_enabled_merge_behavior();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -175,8 +175,13 @@ The module automatically detects and decompresses upstream compressed content (g
 Common causes:
 1. **Module not enabled**: Check `markdown_filter on;` is set
 2. **Missing Accept header**: Ensure client sends `Accept: text/markdown`
-3. **Response not eligible**: Must be 200 status with `text/html` content type
-4. **Size limit exceeded**: Response larger than `markdown_max_size`
+3. **Variable map mismatch** (when using `markdown_filter $var`):
+   - Exact `map $http_accept` strings often miss real-world multi-value `Accept` headers
+   - Use regex map rules for `Accept` matching
+   - Prefer `$uri` over `$request_uri` for extension checks (query strings can break matches)
+   - If map includes `text/*`, enable `markdown_on_wildcard on;`
+4. **Response not eligible**: Must be 200 status with `text/html` content type
+5. **Size limit exceeded**: Response larger than `markdown_max_size`
 
 ### Why is conversion failing?
 

--- a/docs/features/CONFIGURATION_STRUCTURE.md
+++ b/docs/features/CONFIGURATION_STRUCTURE.md
@@ -13,6 +13,8 @@ The `ngx_http_markdown_conf_t` structure holds all configuration directives for 
 ```c
 typedef struct {
     ngx_flag_t   enabled;              /* markdown_filter on|off */
+    ngx_uint_t   enabled_source;       /* markdown_filter source: static/complex/unset */
+    ngx_http_complex_value_t *enabled_complex; /* markdown_filter variable expression */
     size_t       max_size;             /* markdown_max_size (default: 10MB) */
     ngx_msec_t   timeout;              /* markdown_timeout (default: 5000ms) */
     ngx_uint_t   on_error;             /* markdown_on_error pass|reject (default: pass) */
@@ -35,7 +37,9 @@ typedef struct {
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | `ngx_flag_t` | `0` (off) | Enable/disable Markdown conversion |
+| `enabled` | `ngx_flag_t` | `0` (off) | Static fallback for Markdown conversion |
+| `enabled_source` | `ngx_uint_t` | `STATIC` (after merge) | Tracks whether markdown_filter is static or variable-driven |
+| `enabled_complex` | `ngx_http_complex_value_t*` | `NULL` | Optional compiled variable/complex expression for per-request toggle |
 | `max_size` | `size_t` | `10MB` | Maximum response size to convert |
 | `timeout` | `ngx_msec_t` | `5000ms` | Conversion timeout |
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -41,11 +41,13 @@ Configuration follows NGINX's standard inheritance model where inner scopes inhe
 
 #### markdown_filter
 
-**Syntax:** `markdown_filter on | off;`  
+**Syntax:** `markdown_filter on | off | $variable;`  
 **Default:** `off`  
 **Context:** http, server, location
 
 Enables or disables Markdown conversion for the current context.
+You can also use an NGINX variable/complex value for per-request control.
+Resolved values accept `1/0`, `on/off`, `true/false`, `yes/no` (case-insensitive).
 
 **Example:**
 ```nginx
@@ -53,6 +55,23 @@ location /docs {
     markdown_filter on;
 }
 ```
+
+**Dynamic Example:**
+```nginx
+map $http_user_agent $markdown_enabled {
+    default 1;
+    "~*curl" 0;
+}
+
+location /docs {
+    markdown_filter $markdown_enabled;
+}
+```
+
+**Best Practices for Variable-Driven `markdown_filter`:**
+- Prefer regex matching for `Accept` header maps because real clients often send comma-separated values and q-factors.
+- Prefer `$uri` (normalized path without query string) over `$request_uri` when matching file extensions.
+- If your variable map enables conversion for `Accept: text/*` or `Accept: */*`, also set `markdown_on_wildcard on;`.
 
 ---
 
@@ -477,6 +496,43 @@ http {
     }
 }
 ```
+
+---
+
+### Variable-Driven Conversion (Accept + Path Aware)
+
+Use `markdown_filter` with NGINX variables when you want conversion only for specific request patterns (for example, `.html` pages requested as text/markdown or text wildcard clients).
+
+```nginx
+# Parse Accept robustly (supports multiple media types and q-values)
+map $http_accept $markdown_accept {
+    default 0;
+    "~*(^|,)\\s*text/markdown(\\s*;|,|$)" 1;
+    "~*(^|,)\\s*text/\\*(\\s*;|,|$)" 1;
+}
+
+# Match path on normalized URI (query string excluded)
+map $uri $convert_html {
+    default 0;
+    "~*\\.html$" $markdown_accept;
+}
+
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://backend;
+        markdown_on_wildcard on;
+        markdown_filter $convert_html;
+    }
+}
+```
+
+**Why this pattern is recommended:**
+- `map $http_accept` with exact string values is brittle; many clients send `Accept` with multiple values.
+- `$request_uri` includes query strings (for example `/index.html?x=1`) and can break extension matching.
+- `markdown_on_wildcard on` is required if you intentionally treat `text/*` as convertible.
 
 ---
 

--- a/docs/guides/OPERATIONS.md
+++ b/docs/guides/OPERATIONS.md
@@ -305,6 +305,12 @@ nginx -T | grep markdown_filter
 # Verify markdown_filter is "on"
 ```
 
+If you use variable-driven enablement (`markdown_filter $some_var;`), also inspect related `map` blocks:
+```bash
+nginx -T | sed -n '/map \\$http_accept/,/}/p'
+nginx -T | sed -n '/map \\$uri/,/}/p'
+```
+
 3. **Verify response eligibility:**
 ```bash
 curl -I http://localhost/test
@@ -319,12 +325,17 @@ tail -100 /var/log/nginx/error.log | grep markdown
 **Common Causes:**
 - `markdown_filter off` in configuration
 - Accept header missing or incorrect
+- `markdown_filter` variable map not matching real `Accept` header format
+- Extension/path map uses `$request_uri` and fails when query strings are present
+- `text/*` path in map enabled but `markdown_on_wildcard` is still `off`
 - Response not eligible (non-200 status, non-HTML content)
 - Response exceeds `markdown_max_size` limit
 
 **Solutions:**
 - Enable filter: `markdown_filter on;`
 - Verify client sends `Accept: text/markdown`
+- For map-based config, use regex for `Accept` matching and prefer `$uri` for extension checks
+- Enable wildcard support when required: `markdown_on_wildcard on;`
 - Check backend returns 200 with `Content-Type: text/html`
 - Increase size limit if needed: `markdown_max_size 20m;`
 

--- a/docs/testing/DIRECTIVE_VALIDATION_TESTS.md
+++ b/docs/testing/DIRECTIVE_VALIDATION_TESTS.md
@@ -4,18 +4,19 @@ This document provides validation test cases for all configuration directives ex
 
 ## Test Configuration Examples
 
-### 1. markdown_filter (on|off)
+### 1. markdown_filter (on|off|$variable)
 
 **Valid configurations:**
 ```nginx
 markdown_filter on;
 markdown_filter off;
+markdown_filter $convert_html;
 ```
 
 **Invalid configurations:**
 ```nginx
-markdown_filter yes;        # Error: invalid value, must be "on" or "off"
-markdown_filter 1;          # Error: invalid value, must be "on" or "off"
+markdown_filter yes;        # Error: invalid value, must be "on", "off", or a variable
+markdown_filter 1;          # Error: invalid value, must be "on", "off", or a variable
 markdown_filter;            # Error: missing value
 ```
 
@@ -23,6 +24,7 @@ markdown_filter;            # Error: missing value
 - Default: off
 - Context: http, server, location
 - Inheritance: child overrides parent
+- Variables/complex values are evaluated per request; resolved values support 1/0, on/off, true/false, yes/no
 
 ---
 

--- a/docs/testing/INTEGRATION_TESTS.md
+++ b/docs/testing/INTEGRATION_TESTS.md
@@ -2,404 +2,98 @@
 
 ## Overview
 
-This document describes the integration test suite for the NGINX Markdown filter module. These tests validate end-to-end functionality with real NGINX instances and the Rust converter.
+This document describes the integration tests executed by:
 
-**Scope:** Real-NGINX integration scenarios for request/response behavior validation  
-**Coverage Goal (Planning):** Minimum 70% on critical integration paths  
-**Requirements:** FR-01.1, FR-02.1-FR-02.3, FR-03.1, FR-04.1-FR-04.3, FR-06.1-FR-06.4, FR-08.1-FR-08.3, FR-09.1, FR-10.1, FR-10.3, FR-12.5-FR-12.6, FR-12.11
-
-## Test Scenarios
-
-### Test 1: Basic Conversion with Accept: text/markdown
-
-**Validates:** FR-01.1, FR-02.1, FR-02.2, FR-02.3, FR-03.1, FR-04.1
-
-**Scenario:**
-1. Configure NGINX with markdown_filter enabled
-2. Client sends GET request with `Accept: text/markdown`
-3. Backend returns 200 OK with `Content-Type: text/html`
-4. Module converts HTML to Markdown
-
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/markdown; charset=utf-8`
-- Response includes `Vary: Accept` header
-- Response body is valid Markdown (not HTML)
-- Markdown preserves semantic structure (headings, paragraphs, links)
-
-**Test Files:**
-- Use tests/corpus/simple/basic.html
-- Use tests/corpus/simple/headings.html
-- Use tests/corpus/simple/lists.html
-
-### Test 2: Passthrough with Accept: text/html
-
-**Validates:** FR-01.6, FR-02.4
-
-**Scenario:**
-1. Configure NGINX with markdown_filter enabled
-2. Client sends GET request with `Accept: text/html`
-3. Backend returns 200 OK with `Content-Type: text/html`
-4. Module does NOT convert (passthrough)
-
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/html` (unchanged)
-- Response body is original HTML (not converted)
-- No `Vary: Accept` header added
-
-**Test Files:**
-- Use tests/corpus/simple/basic.html
-
-### Test 3: Failure Handling with Oversized Responses
-
-**Validates:** FR-10.1, FR-10.3, FR-09.1 (fail-open)
-
-**Scenario:**
-1. Configure NGINX with `markdown_max_size 1k`
-2. Configure `markdown_on_error pass` (fail-open)
-3. Client sends GET request with `Accept: text/markdown`
-4. Backend returns response > 1k
-
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/html` (original, not converted)
-- Response body is original HTML
-- Error logged: "response size exceeds limit, category=resource_limit"
-
-**Test Files:**
-- Use `tests/corpus/complex/wikipedia-article.html` (large file)
-
-### Test 4: Configuration Inheritance
-
-**Validates:** FR-12.5, FR-12.6, FR-12.11
-
-**Scenario:**
-1. Configure `markdown_filter on` at http level
-2. Configure `markdown_max_size 10m` at http level
-3. Override `markdown_filter off` at specific location
-4. Override `markdown_max_size 5m` at another location
-
-**Expected Results:**
-- Location with `markdown_filter off`: No conversion occurs
-- Location with `markdown_max_size 5m`: Uses 5m limit (not 10m)
-- Location without overrides: Inherits http-level settings
-
-**Configuration Example:**
-```nginx
-http {
-    markdown_filter on;
-    markdown_max_size 10m;
-    
-    server {
-        location /enabled {
-            # Inherits: markdown_filter on, markdown_max_size 10m
-        }
-        
-        location /disabled {
-            markdown_filter off;  # Override
-        }
-        
-        location /custom-limit {
-            markdown_max_size 5m;  # Override
-        }
-    }
-}
+```bash
+components/nginx-module/tests/integration/run_integration_tests.sh
 ```
 
-### Test 5: Conditional Requests with ETags
+These tests run against a real NGINX process and validate end-to-end request/response behavior for the currently implemented runtime suite.
 
-**Validates:** FR-06.1, FR-06.3, FR-06.4
+## Current Runtime Test Set
 
-**Scenario:**
-1. Configure NGINX with `markdown_etag on`
-2. Configure `markdown_conditional_requests full_support`
-3. Client makes initial GET request with `Accept: text/markdown`
-4. Client extracts ETag from response
-5. Client makes second GET request with `If-None-Match: <etag>`
+The script currently runs 5 scenarios:
 
-**Expected Results:**
-- First request: 200 OK with ETag header
-- Second request: 304 Not Modified
-- 304 response includes ETag and Vary headers
-- 304 response has no body
+### Test 1: Basic Conversion with `Accept: text/markdown`
 
-**Test Files:**
-- Use tests/corpus/simple/basic.html
+Validates that HTML responses are converted to Markdown when conversion is enabled and the client requests `text/markdown`.
 
-### Test 6: Authenticated Content Handling
+### Test 2: Passthrough with `Accept: text/html`
 
-**Validates:** FR-08.1, FR-08.3
+Validates that conversion is skipped when the client does not request Markdown.
 
-**Scenario:**
-1. Configure NGINX with `markdown_auth_policy allow`
-2. Client sends GET request with `Authorization: Bearer token123`
-3. Client sends GET request with `Accept: text/markdown`
+### Test 3: Configuration Inheritance
 
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/markdown` (conversion occurs)
-- Response includes `Cache-Control: private` header
-- Response body is Markdown
+Validates that `markdown_filter` inheritance and location-level overrides behave correctly.
 
-**Test Files:**
-- Use tests/corpus/simple/basic.html
+### Test 4: Authenticated Content Handling
 
-### Test 7: HEAD Request Handling
+Validates authenticated-request handling with `markdown_auth_policy allow` and `Cache-Control: private`.
 
-**Validates:** FR-04.9
+### Test 5: Variable-Driven `markdown_filter` Resolution
 
-**Scenario:**
-1. Configure NGINX with markdown_filter enabled
-2. Client sends HEAD request with `Accept: text/markdown`
-3. Backend returns 200 OK with `Content-Type: text/html`
+Validates dynamic enablement via `markdown_filter $variable`, including:
 
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/markdown`
-- Response includes `Content-Length` header (calculated from Markdown)
-- Response has NO body
+- truthy/falsy runtime values (`on`, `off`, `yes`, `no`, etc.)
+- surrounding whitespace normalization (for example `" on "`)
+- safe fallback for invalid runtime values (treated as disabled)
 
-### Test 8: Range Request Bypass
+## Requirements Coverage (Current Runtime Suite)
 
-**Validates:** FR-07.1, FR-07.2
+The current runtime script provides direct end-to-end coverage for:
 
-**Scenario:**
-1. Configure NGINX with markdown_filter enabled
-2. Client sends GET request with `Range: bytes=0-100`
-3. Backend returns 206 Partial Content
+- core content negotiation and conversion path
+- passthrough behavior
+- configuration inheritance and override behavior
+- authenticated content policy handling
+- variable-driven `markdown_filter` resolution behavior
 
-**Expected Results:**
-- Response status: 206 Partial Content (unchanged)
-- Response Content-Type: `text/html` (not converted)
-- Response body is partial HTML (not converted)
+Additional scenarios (for example conditional requests, range bypass, chunked/streaming edge paths) are covered by other tests and can be expanded in this runtime suite later.
 
-### Test 9: Chunked Transfer-Encoding
-
-**Validates:** FR-02.7, FR-02.8
-
-**Scenario:**
-1. Configure NGINX with `markdown_buffer_chunked on`
-2. Backend returns response with `Transfer-Encoding: chunked`
-3. Client sends GET request with `Accept: text/markdown`
-
-**Expected Results:**
-- Response status: 200 OK
-- Response Content-Type: `text/markdown` (conversion occurs)
-- All chunks are buffered and converted
-- Response body is complete Markdown
-
-### Test 10: Streaming Content Exclusion
-
-**Validates:** FR-02.8, FR-02.9
-
-**Scenario:**
-1. Configure NGINX with `markdown_stream_types text/event-stream`
-2. Backend returns response with `Content-Type: text/event-stream`
-3. Client sends GET request with `Accept: text/markdown`
-
-**Expected Results:**
-- Response status: 200 OK (unchanged)
-- Response Content-Type: `text/event-stream` (not converted)
-- Response body is original stream (not converted)
-
-## Test Execution
-
-### Prerequisites
-
-1. NGINX compiled with markdown filter module
-2. Rust converter library built (`libmarkdown_converter.a`)
-3. Test corpus available in `tests/corpus/` directory
-4. `curl` installed for making HTTP requests
-5. `jq` installed for JSON parsing (optional)
-
-### Running Tests
-
-Use the provided test script:
+## How to Run
 
 ```bash
 cd components/nginx-module/tests/integration
 ./run_integration_tests.sh
 ```
 
-The script will:
-1. Start NGINX with test configuration
-2. Execute all test scenarios
-3. Verify expected results
-4. Report pass/fail for each test
-5. Stop NGINX and cleanup
+## Prerequisites
 
-### Manual Testing
+1. `nginx` is available in `PATH`.
+2. NGINX build includes this module.
+3. Rust converter library is built and linked in that NGINX build.
+4. `curl` is installed.
 
-For manual testing, use the example configurations and curl commands below.
+## Expected Output (Shape)
 
-#### Example 1: Basic Conversion
+You should see 5 test sections and a summary similar to:
 
-```bash
-# Start NGINX with test config
-nginx -c /path/to/test.conf
-
-# Make request
-curl -v -H "Accept: text/markdown" http://localhost:8080/test
-
-# Expected: Content-Type: text/markdown, Markdown body
-```
-
-#### Example 2: Conditional Request
-
-```bash
-# First request
-RESPONSE=$(curl -i -H "Accept: text/markdown" http://localhost:8080/test)
-ETAG=$(echo "$RESPONSE" | grep -i "ETag:" | cut -d' ' -f2 | tr -d '\r')
-
-# Second request with If-None-Match
-curl -v -H "Accept: text/markdown" -H "If-None-Match: $ETAG" http://localhost:8080/test
-
-# Expected: 304 Not Modified
-```
-
-## Coverage Analysis
-
-### Critical Paths Covered
-
-1. **Content Negotiation:** Accept header parsing and evaluation ✓
-2. **Eligibility Checking:** Method, status, content-type validation ✓
-3. **Buffering:** Response body accumulation and size limits ✓
-4. **Conversion:** HTML to Markdown transformation ✓
-5. **Header Management:** Content-Type, Vary, ETag, Cache-Control ✓
-6. **Error Handling:** Fail-open and fail-closed strategies ✓
-7. **Configuration:** Inheritance and precedence ✓
-8. **Conditional Requests:** If-None-Match and 304 responses ✓
-9. **Authentication:** Authorization header detection and cache control ✓
-
-### Coverage Metrics
-
-Based on the test scenarios above, the integration tests achieve:
-
-- **Content Negotiation:** 100% (Tests 1, 2)
-- **Eligibility Checking:** 90% (Tests 1, 2, 8, 9, 10)
-- **Buffering:** 85% (Tests 1, 3, 9)
-- **Conversion:** 80% (Tests 1, 5, 6, 7)
-- **Header Management:** 95% (Tests 1, 5, 6, 7)
-- **Error Handling:** 75% (Test 3)
-- **Configuration:** 80% (Test 4)
-- **Conditional Requests:** 85% (Test 5)
-- **Authentication:** 80% (Test 6)
-
-**Overall Coverage:** ~85% of critical paths (exceeds 70% target)
-
-## Test Results
-
-### Expected Output
-
-```
-=== NGINX Markdown Filter Module - Integration Tests ===
-
+```text
 Test 1: Basic Conversion with Accept: text/markdown
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/markdown
-  ✓ Vary: Accept header present
-  ✓ Body is valid Markdown
-  PASSED
-
-Test 2: Passthrough with Accept: text/html
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/html (unchanged)
-  ✓ Body is HTML (not converted)
-  PASSED
-
-Test 3: Failure Handling with Oversized Responses
-  ✓ Status code: 200 OK (fail-open)
-  ✓ Content-Type: text/html (original)
-  ✓ Error logged with category=resource_limit
-  PASSED
-
-Test 4: Configuration Inheritance
-  ✓ /enabled: Conversion occurs (inherits http-level setting)
-  ✓ /disabled: No conversion (location override)
-  ✓ /custom-limit: Uses 5m limit (location override)
-  PASSED
-
-Test 5: Conditional Requests with ETags
-  ✓ First request: 200 OK with ETag
-  ✓ Second request: 304 Not Modified
-  ✓ 304 includes ETag and Vary headers
-  ✓ 304 has no body
-  PASSED
-
-Test 6: Authenticated Content Handling
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/markdown (conversion occurs)
-  ✓ Cache-Control: private header present
-  PASSED
-
-Test 7: HEAD Request Handling
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/markdown
-  ✓ Content-Length header present
-  ✓ No body in response
-  PASSED
-
-Test 8: Range Request Bypass
-  ✓ Status code: 206 Partial Content
-  ✓ Content-Type: text/html (not converted)
-  ✓ Body is partial HTML
-  PASSED
-
-Test 9: Chunked Transfer-Encoding
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/markdown (conversion occurs)
-  ✓ Body is complete Markdown
-  PASSED
-
-Test 10: Streaming Content Exclusion
-  ✓ Status code: 200 OK
-  ✓ Content-Type: text/event-stream (not converted)
-  ✓ Body is original stream
-  PASSED
-
-=== All integration tests passed! (10/10) ===
-Coverage: 85% of critical paths
+...
+Test 5: Variable-driven markdown_filter resolution
+...
+Tests run:    5
+Tests failed: 0
 ```
 
 ## Troubleshooting
 
-### Common Issues
+### `nginx not found in PATH`
 
-1. **NGINX fails to start:**
-   - Check NGINX error log: `/tmp/nginx-markdown-test-error.log`
-   - Verify module is compiled correctly
-   - Verify Rust library is linked
+Install NGINX or add it to your shell `PATH`.
 
-2. **Conversion not occurring:**
-   - Check Accept header is `text/markdown`
-   - Verify `markdown_filter on` in configuration
-   - Check response is eligible (GET/HEAD, 200, text/html)
-   - Check error log for conversion failures
+### Conversion not happening in variable-driven mode
 
-3. **Tests fail with "Connection refused":**
-   - Verify NGINX is running: `ps aux | grep nginx`
-   - Check port 8080 is not in use: `lsof -i :8080`
-   - Verify firewall allows localhost connections
+Check:
 
-4. **ETag tests fail:**
-   - Verify `markdown_etag on` in configuration
-   - Verify `markdown_conditional_requests full_support`
-   - Check ETag format in response headers
+1. `markdown_filter $your_var;` is configured in the active location.
+2. The variable resolves to supported values (`1/0`, `on/off`, `yes/no`, `true/false`).
+3. Client sends `Accept: text/markdown`.
 
-## Next Steps
+### NGINX startup/config errors
 
-After integration tests pass:
+Inspect temporary logs generated by the script:
 
-1. Run performance benchmarks (see E2E and performance docs)
-2. Measure and document latency overhead
-3. Test with production-like traffic patterns
-4. Validate resource usage under load
-5. Document operational best practices
-
-## References
-
-- Requirements: `.kiro/specs/nginx-markdown-for-agents/requirements.md`
-- Design: `.kiro/specs/nginx-markdown-for-agents/design.md`
-- Test Corpus: `tests/corpus/README.md`
-- Unit Tests: `components/nginx-module/tests/unit/*_test.c`
+- `/tmp/nginx-markdown-test-error.log`
+- `/tmp/nginx-start.log`

--- a/tools/docs/check_docs.py
+++ b/tools/docs/check_docs.py
@@ -19,9 +19,6 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 ARCHIVE_SEGMENT = "docs/archive/"
 LINK_RE = re.compile(r"(!?\[[^\]]+\]\(([^)]+)\))")
-ENGLISH_POLICY_EXCLUDE = [
-    "README_zh-CN.md",
-]
 
 
 def iter_markdown_files() -> list[Path]:
@@ -81,20 +78,24 @@ def check_heading_hierarchy(files: list[Path]) -> list[str]:
 def check_english_policy(files: list[Path]) -> list[str]:
     # Detect CJK Han ideographs only (avoid false positives from punctuation such as middle dots).
     try:
-        cmd = [
-            "rg",
-            "-n",
-            "--pcre2",
-            r"[\x{3400}-\x{4DBF}\x{4E00}-\x{9FFF}\x{F900}-\x{FAFF}]",
-            "--glob",
-            "!docs/archive/**",
-            "--glob",
-            "*.md",
-        ]
-        for exclude in ENGLISH_POLICY_EXCLUDE:
-            cmd.extend(["--glob", f"!{exclude}"])
-        cmd.append(".")
-        proc = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+        proc = subprocess.run(
+            [
+                "rg",
+                "-n",
+                "--pcre2",
+                r"[\x{3400}-\x{4DBF}\x{4E00}-\x{9FFF}\x{F900}-\x{FAFF}]",
+                "--glob",
+                "!docs/archive/**",
+                "--glob",
+                "*.md",
+                "--glob",
+                "!README_zh-CN.md",
+                ".",
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
     except FileNotFoundError:
         # Fallback: no check if rg is unavailable; caller can still rely on other checks.
         return []

--- a/tools/docs/check_docs.py
+++ b/tools/docs/check_docs.py
@@ -4,7 +4,7 @@
 Runs lightweight checks for maintained Markdown docs (excluding docs/archive):
 - local link validity
 - heading hierarchy consistency (ignoring code fences)
-- non-English Han characters (enforces English docs policy)
+- non-English Han characters (enforces English docs policy for canonical docs)
 - duplicate doc sync (via tools/docs/check_duplicate_docs.py)
 """
 
@@ -19,6 +19,9 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 ARCHIVE_SEGMENT = "docs/archive/"
 LINK_RE = re.compile(r"(!?\[[^\]]+\]\(([^)]+)\))")
+ENGLISH_POLICY_EXCLUDE = [
+    "README_zh-CN.md",
+]
 
 
 def iter_markdown_files() -> list[Path]:
@@ -76,24 +79,22 @@ def check_heading_hierarchy(files: list[Path]) -> list[str]:
 
 
 def check_english_policy(files: list[Path]) -> list[str]:
-    # Python's stdlib re does not support \p{Han}; use subprocess rg for accuracy.
+    # Detect CJK Han ideographs only (avoid false positives from punctuation such as middle dots).
     try:
-        proc = subprocess.run(
-            [
-                "rg",
-                "-n",
-                "--pcre2",
-                r"[\p{Han}]",
-                "--glob",
-                "!docs/archive/**",
-                "--glob",
-                "*.md",
-                ".",
-            ],
-            cwd=ROOT,
-            text=True,
-            capture_output=True,
-        )
+        cmd = [
+            "rg",
+            "-n",
+            "--pcre2",
+            r"[\x{3400}-\x{4DBF}\x{4E00}-\x{9FFF}\x{F900}-\x{FAFF}]",
+            "--glob",
+            "!docs/archive/**",
+            "--glob",
+            "*.md",
+        ]
+        for exclude in ENGLISH_POLICY_EXCLUDE:
+            cmd.extend(["--glob", f"!{exclude}"])
+        cmd.append(".")
+        proc = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
     except FileNotFoundError:
         # Fallback: no check if rg is unavailable; caller can still rely on other checks.
         return []


### PR DESCRIPTION
## Summary by Sourcery

Add variable/complex value support for the markdown_filter directive and improve configuration, documentation, and tests around dynamic enablement and language policy.

New Features:
- Allow markdown_filter to be controlled by NGINX variables/complex values with per-request evaluation.

Enhancements:
- Track markdown_filter configuration source (static vs variable) in module config and logs.
- Refine Accept/path-based configuration guidance with recommended variable-driven patterns and troubleshooting tips.
- Clarify README language labels and document markdown_filter variable support in module-level README.
- Expand docs tooling to exclude specific non-English canonical docs from Han character checks and narrow the regex to CJK ideographs only.

Tests:
- Extend configuration parsing unit tests and directive validation docs to cover markdown_filter variable usage and invalid values.