### PR TITLE
Add Prometheus metrics support and improve content negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `markdown_metrics_format` configuration directive (`auto|prometheus`) for opt-in Prometheus text exposition format on the existing `markdown_metrics` endpoint
+- Prometheus text exposition format (`text/plain; version=0.0.4; charset=utf-8`) output on the `markdown_metrics` endpoint, selected via Accept header content negotiation when enabled
+- New shared-memory counters: `requests_entered`, skip-reason breakdown (`skips.config`, `skips.method`, `skips.status`, `skips.content_type`, `skips.size`, `skips.streaming`, `skips.auth`, `skips.range`, `skips.accept`), `failopen_count`, `estimated_token_savings`
+- Content negotiation for metrics endpoint: JSON, plain text, or Prometheus format based on Accept header and `markdown_metrics_format` configuration
+- Prometheus metrics guide (`docs/guides/prometheus-metrics.md`) covering metric catalog, scrape configuration, rollout judgment advice, and metric stability policy
+- Property-based tests for Prometheus output format correctness (7 properties, Python Hypothesis)
+- C unit tests for Prometheus renderer, content negotiation, skip-reason mapping, and snapshot collection
 - Shared 0.4.0 release-gate constants module (`tools/release/release_constants.py`) to centralize sub-spec discovery keywords, P0 release-decision sub-specs, and scope-evaluation non-goals used by validation/tests.
 - Focused release-gate edge-case tests for checklist parsing and file read failures (`tools/release/tests/test_release_gate_checks.py`).
 - Scope-evaluation regression coverage to ensure short proposal tokens are not rejected solely because they appear inside a longer non-goal phrase.

--- a/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
@@ -329,6 +329,23 @@ ngx_http_markdown_log_verbosity_name(ngx_uint_t value)
 }
 
 static const ngx_str_t *
+ngx_http_markdown_metrics_format_name(ngx_uint_t value)
+{
+    static ngx_str_t auto_fmt = ngx_string("auto");
+    static ngx_str_t prometheus = ngx_string("prometheus");
+    static ngx_str_t unknown = ngx_string("unknown");
+
+    switch (value) {
+    case NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO:
+        return &auto_fmt;
+    case NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS:
+        return &prometheus;
+    default:
+        return &unknown;
+    }
+}
+
+static const ngx_str_t *
 ngx_http_markdown_compression_name(ngx_http_markdown_compression_type_e compression_type)
 {
     static ngx_str_t none = ngx_string("none");
@@ -550,7 +567,8 @@ ngx_http_markdown_log_merged_conf(ngx_conf_t *cf, ngx_http_markdown_conf_t *conf
                        "log_verbosity=%V buffer_chunked=%ui "
                        "stream_types=%ui "
                        "large_body_threshold=%uz "
-                       "trust_forwarded_headers=%ui",
+                       "trust_forwarded_headers=%ui "
+                       "metrics_format=%V",
                        (ngx_uint_t) conf->enabled,
                        ngx_http_markdown_enabled_source_name(conf->enabled_source),
                        conf->max_size,
@@ -568,7 +586,9 @@ ngx_http_markdown_log_merged_conf(ngx_conf_t *cf, ngx_http_markdown_conf_t *conf
                        (ngx_uint_t) conf->buffer_chunked,
                        stream_type_count,
                        conf->large_body_threshold,
-                       (ngx_uint_t) conf->trust_forwarded_headers);
+                       (ngx_uint_t) conf->trust_forwarded_headers,
+                       ngx_http_markdown_metrics_format_name(
+                           conf->metrics_format));
 }
 
 #endif /* NGX_HTTP_MARKDOWN_CONFIG_CORE_IMPL_H */

--- a/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
@@ -140,6 +140,7 @@ ngx_http_markdown_create_conf(ngx_conf_t *cf)
     conf->auto_decompress = NGX_CONF_UNSET;
     conf->large_body_threshold = NGX_CONF_UNSET_SIZE;
     conf->trust_forwarded_headers = NGX_CONF_UNSET;
+    conf->metrics_format = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -203,6 +204,8 @@ ngx_http_markdown_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->buffer_chunked, prev->buffer_chunked, 1);
     ngx_conf_merge_value(conf->auto_decompress, prev->auto_decompress, 1);
     ngx_conf_merge_value(conf->trust_forwarded_headers, prev->trust_forwarded_headers, 0);
+    ngx_conf_merge_uint_value(conf->metrics_format, prev->metrics_format,
+                              NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO);
     ngx_conf_merge_size_value(conf->large_body_threshold,
                               prev->large_body_threshold,
                               NGX_HTTP_MARKDOWN_THRESHOLD_OFF);

--- a/components/nginx-module/src/ngx_http_markdown_config_directives_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_directives_impl.h
@@ -396,6 +396,28 @@ static ngx_command_t ngx_http_markdown_filter_commands[] = {
     },
 
     /*
+     * markdown_metrics_format auto|prometheus
+     *
+     * Controls the output format of the markdown_metrics endpoint.
+     * - auto: JSON or plain-text based on Accept header (default)
+     * - prometheus: Prometheus text exposition format for non-JSON
+     * Default: auto
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_metrics_format prometheus;
+     */
+    {
+        ngx_string("markdown_metrics_format"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_markdown_metrics_format,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+
+    /*
      * markdown_metrics
      *
      * Enables metrics exposure endpoint at this location.

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -417,8 +417,10 @@ static char *
 ngx_http_markdown_metrics_format(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf)
 {
-    ngx_http_markdown_conf_t *mcf = conf;
-    ngx_str_t                *value;
+    static u_char              auto_str[] = "auto";
+    static u_char              prom_str[] = "prometheus";
+    ngx_http_markdown_conf_t  *mcf = conf;
+    ngx_str_t                 *value;
 
     value = cf->args->elts;
 
@@ -426,11 +428,11 @@ ngx_http_markdown_metrics_format(ngx_conf_t *cf,
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "auto") == 0) {
+    if (ngx_strcasecmp(value[1].data, auto_str) == 0) {
         mcf->metrics_format =
             NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO;
     } else if (ngx_strcasecmp(value[1].data,
-                              (u_char *) "prometheus") == 0)
+                              prom_str) == 0)
     {
         mcf->metrics_format =
             NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS;

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -23,6 +23,8 @@
 static char *
 ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char                      on_str[]  = "on";
+    static u_char                      off_str[] = "off";
     ngx_http_markdown_conf_t          *mcf = conf;
     ngx_http_compile_complex_value_t   ccv;
     ngx_http_complex_value_t          *complex_value;
@@ -38,7 +40,7 @@ ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     value = cf->args->elts;
 
     if (value[1].len == 2
-        && ngx_strcasecmp(value[1].data, (u_char *) "on") == 0)
+        && ngx_strcasecmp(value[1].data, on_str) == 0)
     {
         mcf->enabled = 1;
         mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
@@ -47,7 +49,7 @@ ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     if (value[1].len == 3
-        && ngx_strcasecmp(value[1].data, (u_char *) "off") == 0)
+        && ngx_strcasecmp(value[1].data, off_str) == 0)
     {
         mcf->enabled = 0;
         mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
@@ -89,6 +91,8 @@ ngx_http_markdown_filter(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_markdown_on_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char             pass_str[]   = "pass";
+    static u_char             reject_str[] = "reject";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -98,9 +102,11 @@ ngx_http_markdown_on_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "pass") == 0) {
+    if (ngx_strcasecmp(value[1].data, pass_str) == 0) {
         mcf->on_error = NGX_HTTP_MARKDOWN_ON_ERROR_PASS;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "reject") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              reject_str) == 0)
+    {
         mcf->on_error = NGX_HTTP_MARKDOWN_ON_ERROR_REJECT;
     } else {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -117,6 +123,8 @@ ngx_http_markdown_on_error(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_markdown_flavor(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char             cm_str[]  = "commonmark";
+    static u_char             gfm_str[] = "gfm";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -126,9 +134,11 @@ ngx_http_markdown_flavor(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "commonmark") == 0) {
+    if (ngx_strcasecmp(value[1].data, cm_str) == 0) {
         mcf->flavor = NGX_HTTP_MARKDOWN_FLAVOR_COMMONMARK;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "gfm") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              gfm_str) == 0)
+    {
         mcf->flavor = NGX_HTTP_MARKDOWN_FLAVOR_GFM;
     } else {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -145,6 +155,8 @@ ngx_http_markdown_flavor(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_markdown_auth_policy(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char             allow_str[] = "allow";
+    static u_char             deny_str[]  = "deny";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -154,9 +166,11 @@ ngx_http_markdown_auth_policy(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "allow") == 0) {
+    if (ngx_strcasecmp(value[1].data, allow_str) == 0) {
         mcf->auth_policy = NGX_HTTP_MARKDOWN_AUTH_POLICY_ALLOW;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "deny") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              deny_str) == 0)
+    {
         mcf->auth_policy = NGX_HTTP_MARKDOWN_AUTH_POLICY_DENY;
     } else {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -216,6 +230,10 @@ ngx_http_markdown_auth_cookies(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_markdown_conditional_requests(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char             full_str[] = "full_support";
+    static u_char             ims_str[]  =
+        "if_modified_since_only";
+    static u_char             dis_str[]  = "disabled";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -225,11 +243,17 @@ ngx_http_markdown_conditional_requests(ngx_conf_t *cf, ngx_command_t *cmd, void 
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "full_support") == 0) {
-        mcf->conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_FULL_SUPPORT;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "if_modified_since_only") == 0) {
-        mcf->conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_IF_MODIFIED_SINCE;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "disabled") == 0) {
+    if (ngx_strcasecmp(value[1].data, full_str) == 0) {
+        mcf->conditional_requests =
+            NGX_HTTP_MARKDOWN_CONDITIONAL_FULL_SUPPORT;
+    } else if (ngx_strcasecmp(value[1].data,
+                              ims_str) == 0)
+    {
+        mcf->conditional_requests =
+            NGX_HTTP_MARKDOWN_CONDITIONAL_IF_MODIFIED_SINCE;
+    } else if (ngx_strcasecmp(value[1].data,
+                              dis_str) == 0)
+    {
         mcf->conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_DISABLED;
     } else {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -246,6 +270,10 @@ ngx_http_markdown_conditional_requests(ngx_conf_t *cf, ngx_command_t *cmd, void 
 static char *
 ngx_http_markdown_log_verbosity(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    static u_char             err_str[]   = "error";
+    static u_char             warn_str[]  = "warn";
+    static u_char             info_str[]  = "info";
+    static u_char             debug_str[] = "debug";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -255,13 +283,19 @@ ngx_http_markdown_log_verbosity(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return "is duplicate";
     }
 
-    if (ngx_strcasecmp(value[1].data, (u_char *) "error") == 0) {
+    if (ngx_strcasecmp(value[1].data, err_str) == 0) {
         mcf->log_verbosity = NGX_HTTP_MARKDOWN_LOG_ERROR;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "warn") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              warn_str) == 0)
+    {
         mcf->log_verbosity = NGX_HTTP_MARKDOWN_LOG_WARN;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "info") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              info_str) == 0)
+    {
         mcf->log_verbosity = NGX_HTTP_MARKDOWN_LOG_INFO;
-    } else if (ngx_strcasecmp(value[1].data, (u_char *) "debug") == 0) {
+    } else if (ngx_strcasecmp(value[1].data,
+                              debug_str) == 0)
+    {
         mcf->log_verbosity = NGX_HTTP_MARKDOWN_LOG_DEBUG;
     } else {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -375,6 +409,7 @@ static char *
 ngx_http_markdown_large_body_threshold(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf)
 {
+    static u_char             off_str[] = "off";
     ngx_http_markdown_conf_t *mcf = conf;
     ngx_str_t                *value;
 
@@ -387,7 +422,7 @@ ngx_http_markdown_large_body_threshold(ngx_conf_t *cf,
     }
 
     if (value[1].len == 3
-        && ngx_strcasecmp(value[1].data, (u_char *) "off") == 0)
+        && ngx_strcasecmp(value[1].data, off_str) == 0)
     {
         mcf->large_body_threshold = 0;
         return NGX_CONF_OK;

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -412,6 +412,40 @@ ngx_http_markdown_large_body_threshold(ngx_conf_t *cf,
     return NGX_CONF_OK;
 }
 
+/* Configuration directive handler: markdown_metrics_format (auto | prometheus). */
+static char *
+ngx_http_markdown_metrics_format(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t *mcf = conf;
+    ngx_str_t                *value;
+
+    value = cf->args->elts;
+
+    if (mcf->metrics_format != NGX_CONF_UNSET_UINT) {
+        return "is duplicate";
+    }
+
+    if (ngx_strcasecmp(value[1].data, (u_char *) "auto") == 0) {
+        mcf->metrics_format =
+            NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO;
+    } else if (ngx_strcasecmp(value[1].data,
+                              (u_char *) "prometheus") == 0)
+    {
+        mcf->metrics_format =
+            NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS;
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "invalid value \"%V\" in \"%V\" "
+            "directive, it must be "
+            "\"auto\" or \"prometheus\"",
+            &value[1], &cmd->name);
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
 /**
  * Register the markdown_metrics content handler for the current location.
  *

--- a/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
@@ -443,6 +443,13 @@ ngx_http_markdown_handle_conversion_failure(ngx_http_request_t *r,
                  elapsed_ms);
 
     markdown_result_free(result);
+
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
+
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf,
         "markdown filter: fail-open strategy - returning original HTML");
@@ -532,6 +539,13 @@ ngx_http_markdown_handle_converter_not_initialized(
                  "markdown filter: converter not "
                  "initialized, category=system");
     ngx_http_markdown_record_system_failure(ctx);
+
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
+
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf,
         "markdown filter: fail-open strategy "
@@ -662,6 +676,36 @@ ngx_http_markdown_execute_conversion(ngx_http_request_t *r,
     }
 
     ngx_http_markdown_record_conversion_success(ctx, result, *elapsed_ms);
+
+    /*
+     * Estimate token savings when markdown_token_estimate
+     * is enabled and the Rust FFI returned a non-zero
+     * token estimate for the Markdown output.
+     *
+     * HTML token estimate uses a rough 4-bytes-per-token
+     * heuristic.  Savings = max(0, html_tokens - md_tokens).
+     */
+    if (conf->token_estimate
+        && result->token_estimate > 0
+        && ctx->buffer.size > 0)
+    {
+        ngx_atomic_uint_t  html_tokens;
+        ngx_atomic_uint_t  savings;
+
+        html_tokens = ctx->buffer.size / 4;
+        if (html_tokens > result->token_estimate) {
+            savings = html_tokens
+                - (ngx_atomic_uint_t) result->token_estimate;
+        } else {
+            savings = 0;
+        }
+
+        if (savings > 0) {
+            NGX_HTTP_MARKDOWN_METRIC_ADD(
+                estimated_token_savings, savings);
+        }
+    }
+
     return NGX_OK;
 }
 

--- a/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
@@ -444,11 +444,7 @@ ngx_http_markdown_handle_conversion_failure(ngx_http_request_t *r,
 
     markdown_result_free(result);
 
-    if (conf->on_error
-        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
-    {
-        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
-    }
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf,
@@ -540,11 +536,7 @@ ngx_http_markdown_handle_converter_not_initialized(
                  "initialized, category=system");
     ngx_http_markdown_record_system_failure(ctx);
 
-    if (conf->on_error
-        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
-    {
-        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
-    }
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf,

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -15,6 +15,7 @@
 #include "ngx_http_markdown_lifecycle_impl.h"
 #include "ngx_http_markdown_decision_log_impl.h"
 #include "ngx_http_markdown_request_impl.h"
+#include "ngx_http_markdown_prometheus_impl.h"
 #include "ngx_http_markdown_metrics_impl.h"
 
 /*

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -15,8 +15,8 @@
 #include "ngx_http_markdown_lifecycle_impl.h"
 #include "ngx_http_markdown_decision_log_impl.h"
 #include "ngx_http_markdown_request_impl.h"
-#include "ngx_http_markdown_prometheus_impl.h"
 #include "ngx_http_markdown_metrics_impl.h"
+#include "ngx_http_markdown_prometheus_impl.h"
 
 /*
  * Module context

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -62,6 +62,12 @@ struct MarkdownOptions;
 #define NGX_HTTP_MARKDOWN_LOG_DEBUG  3  /* Debug and above */
 
 /*
+ * Configuration constants for metrics_format directive
+ */
+#define NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO        0  /* JSON or plain-text (default) */
+#define NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS   1  /* Prometheus text exposition */
+
+/*
  * Configuration source for markdown_filter directive
  */
 #define NGX_HTTP_MARKDOWN_ENABLED_UNSET    0  /* Not configured in this scope */
@@ -129,6 +135,7 @@ typedef struct {
     ngx_flag_t   auto_decompress;      /* markdown_auto_decompress on|off (default: on) */
     size_t       large_body_threshold; /* markdown_large_body_threshold (NGX_HTTP_MARKDOWN_THRESHOLD_OFF = off) */
     ngx_flag_t   trust_forwarded_headers; /* markdown_trust_forwarded_headers on|off (default: off) */
+    ngx_uint_t   metrics_format;       /* markdown_metrics_format auto|prometheus (default: auto) */
 } ngx_http_markdown_conf_t;
 
 /*
@@ -330,6 +337,49 @@ typedef struct {
      */
     ngx_atomic_t  fullbuffer_path_hits;      /* Requests routed to full-buffer path */
     ngx_atomic_t  incremental_path_hits;     /* Requests routed to incremental path */
+
+    /*
+     * Total requests that entered the decision chain.
+     *
+     * Incremented in the header filter after scope enablement
+     * check passes.  This is the denominator for conversion
+     * rate calculations.
+     */
+    ngx_atomic_t  requests_entered;
+
+    /*
+     * Skip counters by reason code.
+     *
+     * Each field corresponds to a specific eligibility check
+     * failure.  Grouped into a sub-struct so that the parent
+     * ngx_http_markdown_metrics_t stays within the 20-field
+     * limit enforced by static analysis (SonarCloud rule
+     * c:S1820).
+     */
+    struct {
+        ngx_atomic_t  config;        /* SKIP_CONFIG */
+        ngx_atomic_t  method;        /* SKIP_METHOD */
+        ngx_atomic_t  status;        /* SKIP_STATUS */
+        ngx_atomic_t  content_type;  /* SKIP_CONTENT_TYPE */
+        ngx_atomic_t  size;          /* SKIP_SIZE */
+        ngx_atomic_t  streaming;     /* SKIP_STREAMING */
+        ngx_atomic_t  auth;          /* SKIP_AUTH */
+        ngx_atomic_t  range;         /* SKIP_RANGE */
+        ngx_atomic_t  accept;        /* SKIP_ACCEPT */
+    } skips;
+
+    /*
+     * Fail-open counter: conversion failed but original HTML
+     * served due to markdown_on_error pass.
+     */
+    ngx_atomic_t  failopen_count;
+
+    /*
+     * Estimated cumulative token savings across all successful
+     * conversions.  Only non-zero when markdown_token_estimate
+     * is enabled.  Value is an approximation.
+     */
+    ngx_atomic_t  estimated_token_savings;
 } ngx_http_markdown_metrics_t;
 
 /* Module declaration */

--- a/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
@@ -84,12 +84,16 @@ typedef struct {
 } ngx_http_markdown_metrics_snapshot_t;
 
 /*
- * Response buffer size for the metrics endpoint.  The current JSON/text
- * output is well under 2 KiB, but we leave headroom for future fields.
- * Increase this constant if new metrics push the output beyond the limit.
+ * Response buffer size for the metrics endpoint.
  *
- * Estimated current output: ~1.5 KiB (JSON), ~1.2 KiB (text).
- * Last updated when fullbuffer_path_hits / incremental_path_hits were added.
+ * Estimated current output per format:
+ *   JSON:       ~2.0 KiB
+ *   Plain text: ~1.5 KiB
+ *   Prometheus: ~3.2 KiB (most verbose due to HELP/TYPE lines)
+ *
+ * The 5 KiB buffer provides ~1.8 KiB headroom above the largest
+ * format.  Increase this constant if new metrics push the
+ * Prometheus output beyond the limit.
  */
 #define NGX_HTTP_MARKDOWN_METRICS_BUF_SIZE  5120
 
@@ -164,6 +168,12 @@ static ngx_flag_t ngx_http_markdown_metrics_value_contains(
     ngx_str_t *value, u_char *needle, size_t needle_len);
 
 static u_char  ngx_http_markdown_metrics_accept_json[] = "application/json";
+static u_char  ngx_http_markdown_metrics_accept_openmetrics[] =
+    "application/openmetrics-text";
+static u_char  ngx_http_markdown_metrics_accept_prom_ver[] =
+    "version=0.0.4";
+static u_char  ngx_http_markdown_metrics_accept_text_plain[] =
+    "text/plain";
 
 /*
  * Validate method and shared-state availability for the metrics handler.
@@ -244,6 +254,70 @@ ngx_http_markdown_metrics_prefers_json(ngx_http_request_t *r)
     return 0;
 }
 
+/*
+ * Check whether the Accept header explicitly requests
+ * Prometheus exposition format.
+ *
+ * Matches:
+ *   application/openmetrics-text
+ *   text/plain; version=0.0.4  (both "text/plain" AND
+ *       "version=0.0.4" must be present)
+ *
+ * Does NOT match:
+ *   text/plain  (without version — legacy plain text)
+ *   application/xml; version=0.0.4  (wrong media type)
+ *   version=0.0.4  (no media type at all)
+ */
+static ngx_flag_t
+ngx_http_markdown_metrics_prefers_prometheus(
+    ngx_http_request_t *r)
+{
+    ngx_table_elt_t  *accept_header;
+
+    accept_header = NULL;
+
+#if (NGX_HTTP_HEADERS)
+    accept_header = r->headers_in.accept;
+#else
+    static ngx_str_t accept_name = ngx_string("Accept");
+
+    accept_header =
+        ngx_http_markdown_find_request_header(
+            r, &accept_name);
+#endif
+
+    if (accept_header == NULL) {
+        return 0;
+    }
+
+    if (ngx_http_markdown_metrics_value_contains(
+            &accept_header->value,
+            ngx_http_markdown_metrics_accept_openmetrics,
+            sizeof(ngx_http_markdown_metrics_accept_openmetrics) - 1))
+    {
+        return 1;
+    }
+
+    /*
+     * Match "text/plain; version=0.0.4" — both substrings
+     * must be present to avoid false positives from
+     * unrelated media types carrying version=0.0.4.
+     */
+    if (ngx_http_markdown_metrics_value_contains(
+            &accept_header->value,
+            ngx_http_markdown_metrics_accept_text_plain,
+            sizeof(ngx_http_markdown_metrics_accept_text_plain) - 1)
+        && ngx_http_markdown_metrics_value_contains(
+            &accept_header->value,
+            ngx_http_markdown_metrics_accept_prom_ver,
+            sizeof(ngx_http_markdown_metrics_accept_prom_ver) - 1))
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
 static ngx_flag_t
 ngx_http_markdown_metrics_value_contains(ngx_str_t *value,
     u_char *needle,
@@ -284,14 +358,19 @@ ngx_http_markdown_metrics_value_contains(ngx_str_t *value,
  *
  * Content negotiation state machine:
  *
- *   auto       + Accept: application/json  -> JSON
- *   auto       + Accept: text/plain        -> plain text
- *   auto       + (any other / none)        -> plain text
- *   prometheus + Accept: application/json  -> JSON
- *   prometheus + Accept: text/plain        -> Prometheus
- *   prometheus + Accept: text/plain; v=0.0.4 -> Prometheus
- *   prometheus + Accept: openmetrics-text  -> Prometheus
- *   prometheus + (any other / none)        -> Prometheus
+ *   auto       + Accept: application/json     -> JSON
+ *   auto       + (any other / none)           -> plain text
+ *   prometheus + Accept: application/json     -> JSON
+ *   prometheus + Accept: openmetrics-text     -> Prometheus
+ *   prometheus + Accept: text/plain; v=0.0.4  -> Prometheus
+ *   prometheus + (any other / none)           -> plain text
+ *
+ * When metrics_format is prometheus, Prometheus format is
+ * served only for explicit Prometheus-aware Accept values.
+ * Plain "text/plain" without version=0.0.4 falls back to
+ * the legacy human-readable text format, preserving
+ * backward compatibility for operators who curl without
+ * a specific Accept header.
  *
  * Returns one of the NGX_HTTP_MARKDOWN_METRICS_OUTPUT_*
  * constants.
@@ -311,7 +390,8 @@ ngx_http_markdown_metrics_select_format(
 
     if (conf != NULL
         && conf->metrics_format
-           == NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS)
+           == NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS
+        && ngx_http_markdown_metrics_prefers_prometheus(r))
     {
         return NGX_HTTP_MARKDOWN_METRICS_OUTPUT_PROMETHEUS;
     }

--- a/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
@@ -737,6 +737,13 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
     case NGX_HTTP_MARKDOWN_METRICS_OUTPUT_PROMETHEUS:
         p = ngx_http_markdown_metrics_write_prometheus(
                 p, b->end, &snapshot);
+        if (p == NULL) {
+            ngx_log_error(NGX_LOG_ERR,
+                r->connection->log, 0,
+                "markdown_metrics: Prometheus output "
+                "truncated, buffer too small");
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
         ngx_str_set(&r->headers_out.content_type,
                      "text/plain; version=0.0.4; "
                      "charset=utf-8");

--- a/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
@@ -97,6 +97,17 @@ typedef struct {
  */
 #define NGX_HTTP_MARKDOWN_METRICS_BUF_SIZE  5120
 
+/*
+ * Forward declaration: the Prometheus renderer is defined in
+ * ngx_http_markdown_prometheus_impl.h but called from the
+ * metrics handler below.  Declared here so the call site
+ * compiles before the definition is included.
+ */
+static u_char *
+ngx_http_markdown_metrics_write_prometheus(
+    u_char *p, u_char *end,
+    ngx_http_markdown_metrics_snapshot_t *snapshot);
+
 /**
  * Capture a best-effort snapshot of the global metrics counters into the
  * provided snapshot structure.

--- a/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_metrics_impl.h
@@ -59,6 +59,28 @@ typedef struct {
     /* Path hit metrics (threshold router) */
     ngx_atomic_uint_t fullbuffer_path_hits;
     ngx_atomic_uint_t incremental_path_hits;
+
+    /* Requests entering the decision chain */
+    ngx_atomic_uint_t requests_entered;
+
+    /* Skip counters by reason code */
+    struct {
+        ngx_atomic_uint_t config;
+        ngx_atomic_uint_t method;
+        ngx_atomic_uint_t status;
+        ngx_atomic_uint_t content_type;
+        ngx_atomic_uint_t size;
+        ngx_atomic_uint_t streaming;
+        ngx_atomic_uint_t auth;
+        ngx_atomic_uint_t range;
+        ngx_atomic_uint_t accept;
+    } skips;
+
+    /* Fail-open counter */
+    ngx_atomic_uint_t failopen_count;
+
+    /* Estimated cumulative token savings */
+    ngx_atomic_uint_t estimated_token_savings;
 } ngx_http_markdown_metrics_snapshot_t;
 
 /*
@@ -124,6 +146,18 @@ ngx_http_markdown_collect_metrics_snapshot(ngx_http_markdown_metrics_snapshot_t 
     snapshot->decompressions.brotli = metrics->decompressions.brotli;
     snapshot->fullbuffer_path_hits = metrics->fullbuffer_path_hits;
     snapshot->incremental_path_hits = metrics->incremental_path_hits;
+    snapshot->requests_entered = metrics->requests_entered;
+    snapshot->skips.config = metrics->skips.config;
+    snapshot->skips.method = metrics->skips.method;
+    snapshot->skips.status = metrics->skips.status;
+    snapshot->skips.content_type = metrics->skips.content_type;
+    snapshot->skips.size = metrics->skips.size;
+    snapshot->skips.streaming = metrics->skips.streaming;
+    snapshot->skips.auth = metrics->skips.auth;
+    snapshot->skips.range = metrics->skips.range;
+    snapshot->skips.accept = metrics->skips.accept;
+    snapshot->failopen_count = metrics->failopen_count;
+    snapshot->estimated_token_savings = metrics->estimated_token_savings;
 }
 
 static ngx_flag_t ngx_http_markdown_metrics_value_contains(
@@ -235,6 +269,57 @@ ngx_http_markdown_metrics_value_contains(ngx_str_t *value,
 }
 
 /*
+ * Output format constants for the metrics handler.
+ *
+ * Used by ngx_http_markdown_metrics_select_format() and the
+ * three-way dispatch switch in the handler.
+ */
+#define NGX_HTTP_MARKDOWN_METRICS_OUTPUT_TEXT        0
+#define NGX_HTTP_MARKDOWN_METRICS_OUTPUT_JSON        1
+#define NGX_HTTP_MARKDOWN_METRICS_OUTPUT_PROMETHEUS  2
+
+/*
+ * Select metrics output format based on Accept header and
+ * markdown_metrics_format configuration.
+ *
+ * Content negotiation state machine:
+ *
+ *   auto       + Accept: application/json  -> JSON
+ *   auto       + Accept: text/plain        -> plain text
+ *   auto       + (any other / none)        -> plain text
+ *   prometheus + Accept: application/json  -> JSON
+ *   prometheus + Accept: text/plain        -> Prometheus
+ *   prometheus + Accept: text/plain; v=0.0.4 -> Prometheus
+ *   prometheus + Accept: openmetrics-text  -> Prometheus
+ *   prometheus + (any other / none)        -> Prometheus
+ *
+ * Returns one of the NGX_HTTP_MARKDOWN_METRICS_OUTPUT_*
+ * constants.
+ */
+static ngx_uint_t
+ngx_http_markdown_metrics_select_format(
+    ngx_http_request_t *r)
+{
+    ngx_http_markdown_conf_t  *conf;
+
+    conf = ngx_http_get_module_loc_conf(
+        r, ngx_http_markdown_filter_module);
+
+    if (ngx_http_markdown_metrics_prefers_json(r)) {
+        return NGX_HTTP_MARKDOWN_METRICS_OUTPUT_JSON;
+    }
+
+    if (conf != NULL
+        && conf->metrics_format
+           == NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS)
+    {
+        return NGX_HTTP_MARKDOWN_METRICS_OUTPUT_PROMETHEUS;
+    }
+
+    return NGX_HTTP_MARKDOWN_METRICS_OUTPUT_TEXT;
+}
+
+/*
  * Derive averages from the raw counters after taking the best-effort snapshot.
  * Division only occurs when the relevant denominator is non-zero.
  */
@@ -313,7 +398,21 @@ ngx_http_markdown_metrics_write_json(
         "  \"decompressions_deflate\": %uA,\n"
         "  \"decompressions_brotli\": %uA,\n"
         "  \"fullbuffer_path_hits\": %uA,\n"
-        "  \"incremental_path_hits\": %uA\n"
+        "  \"incremental_path_hits\": %uA,\n"
+        "  \"requests_entered\": %uA,\n"
+        "  \"skips\": {\n"
+        "    \"config\": %uA,\n"
+        "    \"method\": %uA,\n"
+        "    \"status\": %uA,\n"
+        "    \"content_type\": %uA,\n"
+        "    \"size\": %uA,\n"
+        "    \"streaming\": %uA,\n"
+        "    \"auth\": %uA,\n"
+        "    \"range\": %uA,\n"
+        "    \"accept\": %uA\n"
+        "  },\n"
+        "  \"failopen_count\": %uA,\n"
+        "  \"estimated_token_savings\": %uA\n"
         "}",
         snapshot->conversions_attempted,
         snapshot->conversions_succeeded,
@@ -340,7 +439,19 @@ ngx_http_markdown_metrics_write_json(
         snapshot->decompressions.deflate,
         snapshot->decompressions.brotli,
         snapshot->fullbuffer_path_hits,
-        snapshot->incremental_path_hits);
+        snapshot->incremental_path_hits,
+        snapshot->requests_entered,
+        snapshot->skips.config,
+        snapshot->skips.method,
+        snapshot->skips.status,
+        snapshot->skips.content_type,
+        snapshot->skips.size,
+        snapshot->skips.streaming,
+        snapshot->skips.auth,
+        snapshot->skips.range,
+        snapshot->skips.accept,
+        snapshot->failopen_count,
+        snapshot->estimated_token_savings);
 }
 
 /**
@@ -401,7 +512,21 @@ ngx_http_markdown_metrics_write_text(
         "\n"
         "Path Routing:\n"
         "- Full-Buffer Path Hits: %uA\n"
-        "- Incremental Path Hits: %uA\n",
+        "- Incremental Path Hits: %uA\n"
+        "\n"
+        "Decision Chain:\n"
+        "- Requests Entered: %uA\n"
+        "- Skips (Config): %uA\n"
+        "- Skips (Method): %uA\n"
+        "- Skips (Status): %uA\n"
+        "- Skips (Content-Type): %uA\n"
+        "- Skips (Size): %uA\n"
+        "- Skips (Streaming): %uA\n"
+        "- Skips (Auth): %uA\n"
+        "- Skips (Range): %uA\n"
+        "- Skips (Accept): %uA\n"
+        "- Fail-Open Count: %uA\n"
+        "- Estimated Token Savings: %uA\n",
         snapshot->conversions_attempted,
         snapshot->conversions_succeeded,
         snapshot->conversions_failed,
@@ -427,7 +552,19 @@ ngx_http_markdown_metrics_write_text(
         snapshot->decompressions.deflate,
         snapshot->decompressions.brotli,
         snapshot->fullbuffer_path_hits,
-        snapshot->incremental_path_hits);
+        snapshot->incremental_path_hits,
+        snapshot->requests_entered,
+        snapshot->skips.config,
+        snapshot->skips.method,
+        snapshot->skips.status,
+        snapshot->skips.content_type,
+        snapshot->skips.size,
+        snapshot->skips.streaming,
+        snapshot->skips.auth,
+        snapshot->skips.range,
+        snapshot->skips.accept,
+        snapshot->failopen_count,
+        snapshot->estimated_token_savings);
 }
 
 /*
@@ -455,7 +592,7 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
     ngx_chain_t                           out;
     u_char                               *p;
     size_t                                len;
-    ngx_flag_t                            json_format;
+    ngx_uint_t                            format;
     ngx_http_markdown_metrics_snapshot_t  snapshot;
     ngx_atomic_uint_t                     conversions_completed;
     ngx_atomic_uint_t                     conversion_time_avg_ms;
@@ -467,7 +604,7 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
         return rc;
     }
 
-    json_format = ngx_http_markdown_metrics_prefers_json(r);
+    format = ngx_http_markdown_metrics_select_format(r);
 
     rc = ngx_http_discard_request_body(r);
     if (rc != NGX_OK) {
@@ -475,34 +612,55 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
     }
 
     ngx_http_markdown_collect_metrics_snapshot(&snapshot);
-    ngx_http_markdown_metrics_derive_values(&snapshot,
-                                            &conversions_completed,
-                                            &conversion_time_avg_ms,
-                                            &input_bytes_avg,
-                                            &output_bytes_avg);
+    ngx_http_markdown_metrics_derive_values(
+        &snapshot,
+        &conversions_completed,
+        &conversion_time_avg_ms,
+        &input_bytes_avg,
+        &output_bytes_avg);
 
-    b = ngx_create_temp_buf(r->pool, NGX_HTTP_MARKDOWN_METRICS_BUF_SIZE);
+    b = ngx_create_temp_buf(r->pool,
+            NGX_HTTP_MARKDOWN_METRICS_BUF_SIZE);
     if (b == NULL) {
         ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
-                     "markdown_metrics: failed to allocate response buffer");
+            "markdown_metrics: failed to allocate "
+            "response buffer");
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
     p = b->pos;
-    if (json_format) {
-        p = ngx_http_markdown_metrics_write_json(p, b->end,
-                                                 &snapshot,
-                                                 conversions_completed,
-                                                 conversion_time_avg_ms,
-                                                 input_bytes_avg,
-                                                 output_bytes_avg);
-    } else {
-        p = ngx_http_markdown_metrics_write_text(p, b->end,
-                                                 &snapshot,
-                                                 conversions_completed,
-                                                 conversion_time_avg_ms,
-                                                 input_bytes_avg,
-                                                 output_bytes_avg);
+
+    switch (format) {
+
+    case NGX_HTTP_MARKDOWN_METRICS_OUTPUT_JSON:
+        p = ngx_http_markdown_metrics_write_json(
+                p, b->end, &snapshot,
+                conversions_completed,
+                conversion_time_avg_ms,
+                input_bytes_avg,
+                output_bytes_avg);
+        ngx_str_set(&r->headers_out.content_type,
+                     "application/json");
+        break;
+
+    case NGX_HTTP_MARKDOWN_METRICS_OUTPUT_PROMETHEUS:
+        p = ngx_http_markdown_metrics_write_prometheus(
+                p, b->end, &snapshot);
+        ngx_str_set(&r->headers_out.content_type,
+                     "text/plain; version=0.0.4; "
+                     "charset=utf-8");
+        break;
+
+    default:
+        p = ngx_http_markdown_metrics_write_text(
+                p, b->end, &snapshot,
+                conversions_completed,
+                conversion_time_avg_ms,
+                input_bytes_avg,
+                output_bytes_avg);
+        ngx_str_set(&r->headers_out.content_type,
+                     "text/plain");
+        break;
     }
 
     len = p - b->pos;
@@ -510,13 +668,8 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
 
     r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_length_n = len;
-
-    if (json_format) {
-        ngx_str_set(&r->headers_out.content_type, "application/json");
-    } else {
-        ngx_str_set(&r->headers_out.content_type, "text/plain");
-    }
-    r->headers_out.content_type_len = r->headers_out.content_type.len;
+    r->headers_out.content_type_len =
+        r->headers_out.content_type.len;
 
     b->last_buf = (r == r->main) ? 1 : 0;
     b->last_in_chain = 1;

--- a/components/nginx-module/src/ngx_http_markdown_module_state_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_module_state_impl.h
@@ -47,6 +47,71 @@ static u_char ngx_http_markdown_empty_string[] = "";
     NGX_HTTP_MARKDOWN_METRIC_ADD(field, 1)
 
 /*
+ * Increment the skip counter for the given eligibility result.
+ *
+ * Maps ngx_http_markdown_eligibility_t enum values to the
+ * corresponding skips.* atomic counter in shared memory.
+ * Unknown values fall back to skips.config with a warning.
+ *
+ * NGX_HTTP_MARKDOWN_ELIGIBLE is a no-op (should not be
+ * called for eligible requests).
+ *
+ * Parameters:
+ *   eligibility - the eligibility check result
+ */
+static void
+ngx_http_markdown_metric_inc_skip(
+    ngx_http_markdown_eligibility_t eligibility)
+{
+    switch (eligibility) {
+
+    case NGX_HTTP_MARKDOWN_ELIGIBLE:
+        /* No-op: eligible requests are not skips */
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_CONFIG:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.config);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_METHOD:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.method);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_STATUS:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.status);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_CONTENT_TYPE:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.content_type);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_SIZE:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.size);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_STREAMING:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.streaming);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_AUTH:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.auth);
+        return;
+
+    case NGX_HTTP_MARKDOWN_INELIGIBLE_RANGE:
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.range);
+        return;
+
+    default:
+        /*
+         * Unknown eligibility value — count under
+         * skips.config as a safe fallback.
+         */
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.config);
+        return;
+    }
+}
+
+/*
  * Lifecycle hooks registered with nginx module callbacks.
  *
  * - filter_init wires this module into header/body filter chains.

--- a/components/nginx-module/src/ngx_http_markdown_module_state_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_module_state_impl.h
@@ -112,6 +112,31 @@ ngx_http_markdown_metric_inc_skip(
 }
 
 /*
+ * Increment the fail-open counter when the configured error
+ * strategy is "pass" (fail-open).
+ *
+ * Centralizes the repeated guard so every fail-open path uses
+ * the same check and future fail-open paths cannot drift.
+ *
+ * Parameters:
+ *   conf - module location configuration
+ */
+static void
+ngx_http_markdown_metric_inc_failopen(
+    const ngx_http_markdown_conf_t *conf)
+{
+    if (conf == NULL) {
+        return;
+    }
+
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
+}
+
+/*
  * Lifecycle hooks registered with nginx module callbacks.
  *
  * - filter_init wires this module into header/body filter chains.

--- a/components/nginx-module/src/ngx_http_markdown_payload_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_payload_impl.h
@@ -163,11 +163,7 @@ ngx_http_markdown_handle_decompression_alloc_error(
         ngx_http_markdown_reason_from_error_category(
             category, r->connection->log));
 
-    if (conf->on_error
-        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
-    {
-        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
-    }
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf, debug_message);
@@ -396,11 +392,7 @@ ngx_http_markdown_handle_buffer_init_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    if (conf->on_error
-        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
-    {
-        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
-    }
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");
@@ -451,11 +443,7 @@ ngx_http_markdown_handle_buffer_append_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    if (conf->on_error
-        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
-    {
-        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
-    }
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");

--- a/components/nginx-module/src/ngx_http_markdown_payload_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_payload_impl.h
@@ -163,6 +163,12 @@ ngx_http_markdown_handle_decompression_alloc_error(
         ngx_http_markdown_reason_from_error_category(
             category, r->connection->log));
 
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
+
     return ngx_http_markdown_reject_or_fail_open_buffered_response(
         r, ctx, conf, debug_message);
 }
@@ -390,6 +396,8 @@ ngx_http_markdown_handle_buffer_init_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
+    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");
     ngx_http_markdown_reclassify_fail_open_path(ctx);
@@ -438,6 +446,8 @@ ngx_http_markdown_handle_buffer_append_failure(ngx_http_request_t *r,
     if (conf->on_error == NGX_HTTP_MARKDOWN_ON_ERROR_REJECT) {
         return NGX_ERROR;
     }
+
+    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");

--- a/components/nginx-module/src/ngx_http_markdown_payload_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_payload_impl.h
@@ -396,7 +396,11 @@ ngx_http_markdown_handle_buffer_init_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");
@@ -447,7 +451,11 @@ ngx_http_markdown_handle_buffer_append_failure(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    if (conf->on_error
+        == NGX_HTTP_MARKDOWN_ON_ERROR_PASS)
+    {
+        NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    }
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                   "markdown filter: fail-open strategy - returning original HTML");

--- a/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
@@ -233,6 +233,16 @@ ngx_http_markdown_metrics_write_prometheus(
             + snapshot->conversion_latency_le_1000ms
             + snapshot->conversion_latency_gt_1000ms);
 
+    /*
+     * Detect buffer exhaustion.  ngx_slprintf stops at end
+     * without signaling an error, so p == end means the
+     * output was silently truncated.  Return NULL to let
+     * the caller distinguish truncation from success.
+     */
+    if (p == end) {
+        return NULL;
+    }
+
     return p;
 }
 

--- a/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
@@ -1,0 +1,224 @@
+#ifndef NGX_HTTP_MARKDOWN_PROMETHEUS_IMPL_H
+#define NGX_HTTP_MARKDOWN_PROMETHEUS_IMPL_H
+
+/*
+ * Prometheus text exposition format renderer.
+ *
+ * WARNING: This header is an implementation detail of the main
+ * translation unit (ngx_http_markdown_filter_module.c).  It must
+ * NOT be included from any other .c file or used as a standalone
+ * compilation unit.
+ *
+ * Renders a metrics snapshot as Prometheus text exposition format
+ * (content type: text/plain; version=0.0.4; charset=utf-8).
+ * All label values are compile-time constants — no runtime
+ * escaping is needed.
+ */
+
+/*
+ * Render a metrics snapshot as Prometheus text exposition format.
+ *
+ * Writes HELP, TYPE, and metric lines for all module counters
+ * into the buffer between p and end.  Returns a pointer past
+ * the last byte written.
+ *
+ * Parameters:
+ *   p        - Start of writable buffer region
+ *   end      - One past the end of the buffer
+ *   snapshot - Collected metrics snapshot
+ *
+ * Returns:
+ *   Pointer past the last byte written
+ */
+static u_char *
+ngx_http_markdown_metrics_write_prometheus(
+    u_char *p,
+    u_char *end,
+    ngx_http_markdown_metrics_snapshot_t *snapshot)
+{
+    /* requests_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_requests_total "
+        "Total requests entering the module decision chain.\n"
+        "# TYPE nginx_markdown_requests_total counter\n"
+        "nginx_markdown_requests_total %uA\n"
+        "\n",
+        snapshot->requests_entered);
+
+    /* conversions_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_conversions_total "
+        "Successful HTML-to-Markdown conversions.\n"
+        "# TYPE nginx_markdown_conversions_total counter\n"
+        "nginx_markdown_conversions_total %uA\n"
+        "\n",
+        snapshot->conversions_succeeded);
+
+    /* passthrough_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_passthrough_total "
+        "Requests not converted (skipped or failed-open).\n"
+        "# TYPE nginx_markdown_passthrough_total counter\n"
+        "nginx_markdown_passthrough_total %uA\n"
+        "\n",
+        snapshot->conversions_bypassed);
+
+    /* skips_total{reason=...} */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_skips_total "
+        "Requests skipped by reason.\n"
+        "# TYPE nginx_markdown_skips_total counter\n"
+        "nginx_markdown_skips_total{reason=\"SKIP_METHOD\"}"
+        " %uA\n"
+        "nginx_markdown_skips_total{reason=\"SKIP_STATUS\"}"
+        " %uA\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_CONTENT_TYPE\"} %uA\n"
+        "nginx_markdown_skips_total{reason=\"SKIP_SIZE\"}"
+        " %uA\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_STREAMING\"} %uA\n"
+        "nginx_markdown_skips_total{reason=\"SKIP_AUTH\"}"
+        " %uA\n"
+        "nginx_markdown_skips_total{reason=\"SKIP_RANGE\"}"
+        " %uA\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_ACCEPT\"} %uA\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_CONFIG\"} %uA\n"
+        "\n",
+        snapshot->skips.method,
+        snapshot->skips.status,
+        snapshot->skips.content_type,
+        snapshot->skips.size,
+        snapshot->skips.streaming,
+        snapshot->skips.auth,
+        snapshot->skips.range,
+        snapshot->skips.accept,
+        snapshot->skips.config);
+
+    /* failures_total{stage=...} */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_failures_total "
+        "Conversion failures by stage.\n"
+        "# TYPE nginx_markdown_failures_total counter\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_CONVERSION\"} %uA\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_RESOURCE_LIMIT\"} %uA\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_SYSTEM\"} %uA\n"
+        "\n",
+        snapshot->failures_conversion,
+        snapshot->failures_resource_limit,
+        snapshot->failures_system);
+
+    /* failopen_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_failopen_total "
+        "Conversions failed with original HTML served "
+        "(fail-open).\n"
+        "# TYPE nginx_markdown_failopen_total counter\n"
+        "nginx_markdown_failopen_total %uA\n"
+        "\n",
+        snapshot->failopen_count);
+
+    /* large_response_path_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_large_response_path_total "
+        "Requests routed to incremental processing path.\n"
+        "# TYPE nginx_markdown_large_response_path_total "
+        "counter\n"
+        "nginx_markdown_large_response_path_total %uA\n"
+        "\n",
+        snapshot->incremental_path_hits);
+
+    /* input_bytes_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_input_bytes_total "
+        "Cumulative HTML input bytes from successful "
+        "conversions.\n"
+        "# TYPE nginx_markdown_input_bytes_total counter\n"
+        "nginx_markdown_input_bytes_total %uA\n"
+        "\n",
+        snapshot->input_bytes);
+
+    /* output_bytes_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_output_bytes_total "
+        "Cumulative Markdown output bytes from successful "
+        "conversions.\n"
+        "# TYPE nginx_markdown_output_bytes_total counter\n"
+        "nginx_markdown_output_bytes_total %uA\n"
+        "\n",
+        snapshot->output_bytes);
+
+    /* estimated_token_savings_total */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_estimated_token_savings_total"
+        " Estimated cumulative token savings "
+        "(requires markdown_token_estimate on).\n"
+        "# TYPE "
+        "nginx_markdown_estimated_token_savings_total "
+        "counter\n"
+        "nginx_markdown_estimated_token_savings_total"
+        " %uA\n"
+        "\n",
+        snapshot->estimated_token_savings);
+
+    /* decompressions_total{format=...} */
+    p = ngx_slprintf(p, end,
+        "# HELP nginx_markdown_decompressions_total "
+        "Decompression operations by format.\n"
+        "# TYPE nginx_markdown_decompressions_total "
+        "counter\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"gzip\"} %uA\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"deflate\"} %uA\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"brotli\"} %uA\n"
+        "\n",
+        snapshot->decompressions.gzip,
+        snapshot->decompressions.deflate,
+        snapshot->decompressions.brotli);
+
+    /* decompression_failures_total */
+    p = ngx_slprintf(p, end,
+        "# HELP "
+        "nginx_markdown_decompression_failures_total "
+        "Failed decompression attempts.\n"
+        "# TYPE "
+        "nginx_markdown_decompression_failures_total "
+        "counter\n"
+        "nginx_markdown_decompression_failures_total"
+        " %uA\n"
+        "\n",
+        snapshot->decompressions.failed);
+
+    /* conversion_duration_seconds{le=...} */
+    p = ngx_slprintf(p, end,
+        "# HELP "
+        "nginx_markdown_conversion_duration_seconds "
+        "Cumulative conversion count per latency bucket "
+        "(not a native Prometheus histogram; "
+        "no _sum/_count).\n"
+        "# TYPE "
+        "nginx_markdown_conversion_duration_seconds gauge\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"0.01\"} %uA\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"0.1\"} %uA\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"1.0\"} %uA\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"+Inf\"} %uA\n",
+        snapshot->conversion_latency_le_10ms,
+        snapshot->conversion_latency_le_100ms,
+        snapshot->conversion_latency_le_1000ms,
+        snapshot->conversion_latency_gt_1000ms);
+
+    return p;
+}
+
+#endif /* NGX_HTTP_MARKDOWN_PROMETHEUS_IMPL_H */

--- a/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
@@ -54,14 +54,17 @@ ngx_http_markdown_metrics_write_prometheus(
         "\n",
         snapshot->conversions_succeeded);
 
-    /* passthrough_total */
+    /* passthrough_total (derived: skips + fail-open) */
     p = ngx_slprintf(p, end,
         "# HELP nginx_markdown_passthrough_total "
-        "Requests not converted (skipped or failed-open).\n"
-        "# TYPE nginx_markdown_passthrough_total counter\n"
+        "Requests not converted "
+        "(skipped or failed-open).\n"
+        "# TYPE nginx_markdown_passthrough_total "
+        "counter\n"
         "nginx_markdown_passthrough_total %uA\n"
         "\n",
-        snapshot->conversions_bypassed);
+        snapshot->conversions_bypassed
+            + snapshot->failopen_count);
 
     /* skips_total{reason=...} */
     p = ngx_slprintf(p, end,
@@ -196,7 +199,13 @@ ngx_http_markdown_metrics_write_prometheus(
         "\n",
         snapshot->decompressions.failed);
 
-    /* conversion_duration_seconds{le=...} */
+    /*
+     * conversion_duration_seconds{le=...}
+     *
+     * Emitted as cumulative buckets: each le value includes
+     * all observations at or below that threshold.
+     * le="+Inf" equals the sum of all four discrete counters.
+     */
     p = ngx_slprintf(p, end,
         "# HELP "
         "nginx_markdown_conversion_duration_seconds "
@@ -214,9 +223,15 @@ ngx_http_markdown_metrics_write_prometheus(
         "nginx_markdown_conversion_duration_seconds"
         "{le=\"+Inf\"} %uA\n",
         snapshot->conversion_latency_le_10ms,
-        snapshot->conversion_latency_le_100ms,
-        snapshot->conversion_latency_le_1000ms,
-        snapshot->conversion_latency_gt_1000ms);
+        snapshot->conversion_latency_le_10ms
+            + snapshot->conversion_latency_le_100ms,
+        snapshot->conversion_latency_le_10ms
+            + snapshot->conversion_latency_le_100ms
+            + snapshot->conversion_latency_le_1000ms,
+        snapshot->conversion_latency_le_10ms
+            + snapshot->conversion_latency_le_100ms
+            + snapshot->conversion_latency_le_1000ms
+            + snapshot->conversion_latency_gt_1000ms);
 
     return p;
 }

--- a/components/nginx-module/src/ngx_http_markdown_request_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_request_impl.h
@@ -93,6 +93,8 @@ ngx_http_markdown_handle_unsupported_compression(
         return NGX_HTTP_BAD_GATEWAY;
     }
 
+    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+
     ngx_log_error(NGX_LOG_WARN,
         r->connection->log, 0,
         "markdown filter: unsupported "
@@ -147,6 +149,8 @@ ngx_http_markdown_handle_ctx_alloc_failure(ngx_http_request_t *r,
                 r->connection->log));
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
+
+    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
 
     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                  "markdown filter: context allocation "
@@ -261,6 +265,12 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
     }
 
     /*
+     * Decision chain entry point — increment requests_entered
+     * after scope enablement check passes.
+     */
+    NGX_HTTP_MARKDOWN_METRIC_INC(requests_entered);
+
+    /*
      * Check eligibility before Accept negotiation.
      *
      * The decision chain order (Requirement 2.1) is:
@@ -277,6 +287,7 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
                       "markdown filter: response not eligible: %V",
                       ngx_http_markdown_eligibility_string(
                           eligibility));
+        ngx_http_markdown_metric_inc_skip(eligibility);
         NGX_HTTP_MARKDOWN_METRIC_INC(conversions_bypassed);
         ngx_http_markdown_log_decision(r, conf,
             ngx_http_markdown_reason_from_eligibility(
@@ -291,6 +302,8 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
     if (conf->auth_policy == NGX_HTTP_MARKDOWN_AUTH_POLICY_DENY
         && ngx_http_markdown_is_authenticated(r, conf))
     {
+        ngx_http_markdown_metric_inc_skip(
+            NGX_HTTP_MARKDOWN_INELIGIBLE_AUTH);
         NGX_HTTP_MARKDOWN_METRIC_INC(conversions_bypassed);
         ngx_http_markdown_log_decision(r, conf,
             ngx_http_markdown_reason_from_eligibility(
@@ -303,6 +316,7 @@ ngx_http_markdown_header_filter(ngx_http_request_t *r)
     should_convert = ngx_http_markdown_should_convert(r, conf);
     if (!should_convert) {
         /* Client doesn't want Markdown, pass through */
+        NGX_HTTP_MARKDOWN_METRIC_INC(skips.accept);
         NGX_HTTP_MARKDOWN_METRIC_INC(conversions_bypassed);
         ngx_http_markdown_log_decision(r, conf,
             ngx_http_markdown_reason_skip_accept());

--- a/components/nginx-module/src/ngx_http_markdown_request_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_request_impl.h
@@ -93,7 +93,7 @@ ngx_http_markdown_handle_unsupported_compression(
         return NGX_HTTP_BAD_GATEWAY;
     }
 
-    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     ngx_log_error(NGX_LOG_WARN,
         r->connection->log, 0,
@@ -150,7 +150,7 @@ ngx_http_markdown_handle_ctx_alloc_failure(ngx_http_request_t *r,
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    NGX_HTTP_MARKDOWN_METRIC_INC(failopen_count);
+    ngx_http_markdown_metric_inc_failopen(conf);
 
     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                  "markdown filter: context allocation "

--- a/components/nginx-module/tests/Makefile
+++ b/components/nginx-module/tests/Makefile
@@ -19,7 +19,7 @@ SANITIZER_ENV ?= ASAN_OPTIONS=$(ASAN_OPTIONS_BASE) UBSAN_OPTIONS=print_stacktrac
 build/unit build/integration build/generated:
 	@mkdir -p $@
 
-build/unit/%: unit/%_test.c include/test_common.h | build/unit build/generated
+build/unit/%: unit/%_test.c include/test_common.h include/test_metrics_snapshot.h | build/unit build/generated
 	@extra_srcs=""; \
 	extra_cflags=""; \
 	extra_ldflags=""; \

--- a/components/nginx-module/tests/include/test_metrics_snapshot.h
+++ b/components/nginx-module/tests/include/test_metrics_snapshot.h
@@ -1,0 +1,58 @@
+/*
+ * Shared metrics snapshot type for standalone unit tests.
+ *
+ * Mirrors ngx_http_markdown_metrics_snapshot_t using unsigned long
+ * in place of ngx_atomic_t so tests compile without NGINX headers.
+ *
+ * Included by:
+ *   - metrics_snapshot_new_fields_test.c
+ *   - prometheus_format_test.c
+ */
+
+#ifndef TEST_METRICS_SNAPSHOT_H
+#define TEST_METRICS_SNAPSHOT_H
+
+typedef struct {
+    unsigned long conversions_attempted;
+    unsigned long conversions_succeeded;
+    unsigned long conversions_failed;
+    unsigned long conversions_bypassed;
+    unsigned long failures_conversion;
+    unsigned long failures_resource_limit;
+    unsigned long failures_system;
+    unsigned long conversion_time_sum_ms;
+    unsigned long input_bytes;
+    unsigned long output_bytes;
+    struct {
+        unsigned long le_10ms;
+        unsigned long le_100ms;
+        unsigned long le_1000ms;
+        unsigned long gt_1000ms;
+    } conversion_latency;
+    struct {
+        unsigned long attempted;
+        unsigned long succeeded;
+        unsigned long failed;
+        unsigned long gzip;
+        unsigned long deflate;
+        unsigned long brotli;
+    } decompressions;
+    unsigned long fullbuffer_path_hits;
+    unsigned long incremental_path_hits;
+    unsigned long requests_entered;
+    struct {
+        unsigned long config;
+        unsigned long method;
+        unsigned long status;
+        unsigned long content_type;
+        unsigned long size;
+        unsigned long streaming;
+        unsigned long auth;
+        unsigned long range;
+        unsigned long accept;
+    } skips;
+    unsigned long failopen_count;
+    unsigned long estimated_token_savings;
+} test_metrics_snapshot_t;
+
+#endif /* TEST_METRICS_SNAPSHOT_H */

--- a/components/nginx-module/tests/unit/config_parsing_test.c
+++ b/components/nginx-module/tests/unit/config_parsing_test.c
@@ -14,6 +14,8 @@
 #define COND_FULL_SUPPORT 0
 #define COND_IF_MODIFIED_SINCE_ONLY 1
 #define COND_DISABLED 2
+#define METRICS_FORMAT_AUTO 0
+#define METRICS_FORMAT_PROMETHEUS 1
 
 typedef struct {
     int markdown_filter;
@@ -29,6 +31,7 @@ typedef struct {
     int markdown_conditional_requests;
     int markdown_buffer_chunked;
     int markdown_auto_decompress;
+    int markdown_metrics_format;
 } default_conf_t;
 
 static int valid_on_error(const char *v) { return STR_EQ(v, "pass") || STR_EQ(v, "reject"); }
@@ -71,6 +74,19 @@ static int valid_conditional(const char *v) {
 }
 static int valid_cookie_pattern(const char *v) { return v != NULL && *v != '\0'; }
 static int valid_content_type_token(const char *v) { return v != NULL && strchr(v, '/') != NULL; }
+static int valid_metrics_format(const char *v) { return STR_EQ(v, "auto") || STR_EQ(v, "prometheus"); }
+
+static int
+parse_metrics_format(const char *v)
+{
+    if (STR_EQ(v, "auto")) {
+        return METRICS_FORMAT_AUTO;
+    }
+    if (STR_EQ(v, "prometheus")) {
+        return METRICS_FORMAT_PROMETHEUS;
+    }
+    return -1;
+}
 
 static default_conf_t
 module_defaults(void)
@@ -89,6 +105,7 @@ module_defaults(void)
     c.markdown_conditional_requests = COND_FULL_SUPPORT;
     c.markdown_buffer_chunked = 1;
     c.markdown_auto_decompress = 1;
+    c.markdown_metrics_format = METRICS_FORMAT_AUTO;
     return c;
 }
 
@@ -122,6 +139,11 @@ test_value_validation(void)
     TEST_ASSERT(!valid_content_type_token("texteventstream"), "stream type without slash is invalid");
     TEST_ASSERT(valid_cookie_pattern("session*"), "cookie pattern should accept non-empty");
     TEST_ASSERT(!valid_cookie_pattern(""), "cookie pattern should reject empty");
+    TEST_ASSERT(valid_metrics_format("auto"), "metrics_format should accept auto");
+    TEST_ASSERT(valid_metrics_format("prometheus"), "metrics_format should accept prometheus");
+    TEST_ASSERT(!valid_metrics_format("json"), "metrics_format should reject json");
+    TEST_ASSERT(!valid_metrics_format("text"), "metrics_format should reject text");
+    TEST_ASSERT(!valid_metrics_format(""), "metrics_format should reject empty");
     TEST_PASS("Directive validation passed");
 }
 
@@ -140,7 +162,52 @@ test_default_values(void)
     TEST_ASSERT(c.markdown_conditional_requests == COND_FULL_SUPPORT, "conditional default full_support");
     TEST_ASSERT(c.markdown_buffer_chunked == 1, "buffer_chunked default on");
     TEST_ASSERT(c.markdown_auto_decompress == 1, "auto_decompress default on");
+    TEST_ASSERT(c.markdown_metrics_format == METRICS_FORMAT_AUTO, "metrics_format default auto");
     TEST_PASS("Default values verified");
+}
+
+static void
+test_metrics_format_parsing(void)
+{
+    int result;
+
+    TEST_SUBSECTION("markdown_metrics_format directive parsing");
+
+    /* "auto" maps to METRICS_FORMAT_AUTO (0) */
+    result = parse_metrics_format("auto");
+    TEST_ASSERT(result == METRICS_FORMAT_AUTO,
+                "auto should parse to METRICS_FORMAT_AUTO");
+    TEST_PASS("auto -> METRICS_FORMAT_AUTO");
+
+    /* "prometheus" maps to METRICS_FORMAT_PROMETHEUS (1) */
+    result = parse_metrics_format("prometheus");
+    TEST_ASSERT(result == METRICS_FORMAT_PROMETHEUS,
+                "prometheus should parse to METRICS_FORMAT_PROMETHEUS");
+    TEST_PASS("prometheus -> METRICS_FORMAT_PROMETHEUS");
+
+    /* Invalid values are rejected */
+    result = parse_metrics_format("json");
+    TEST_ASSERT(result == -1, "json should be rejected");
+    TEST_PASS("json rejected");
+
+    result = parse_metrics_format("text");
+    TEST_ASSERT(result == -1, "text should be rejected");
+    TEST_PASS("text rejected");
+
+    result = parse_metrics_format("openmetrics");
+    TEST_ASSERT(result == -1, "openmetrics should be rejected");
+    TEST_PASS("openmetrics rejected");
+
+    result = parse_metrics_format("");
+    TEST_ASSERT(result == -1, "empty string should be rejected");
+    TEST_PASS("empty string rejected");
+
+    /* Verify constant values match design */
+    TEST_ASSERT(METRICS_FORMAT_AUTO == 0,
+                "METRICS_FORMAT_AUTO must be 0");
+    TEST_ASSERT(METRICS_FORMAT_PROMETHEUS == 1,
+                "METRICS_FORMAT_PROMETHEUS must be 1");
+    TEST_PASS("Constant values match design");
 }
 
 int
@@ -152,6 +219,7 @@ main(void)
 
     test_value_validation();
     test_default_values();
+    test_metrics_format_parsing();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/metrics_format_select_test.c
+++ b/components/nginx-module/tests/unit/metrics_format_select_test.c
@@ -33,12 +33,16 @@ accept_contains(const char *accept, const char *needle)
 {
     size_t  accept_len;
     size_t  needle_len;
-    size_t  i, j;
+    size_t  j;
 
     if (accept == NULL || needle == NULL) {
         return 0;
     }
 
+    /*
+     * Safe: both pointers are validated non-NULL above;
+     * all callers pass null-terminated string literals.
+     */
     accept_len = strlen(accept);
     needle_len = strlen(needle);
 
@@ -46,7 +50,7 @@ accept_contains(const char *accept, const char *needle)
         return 0;
     }
 
-    for (i = 0; i + needle_len <= accept_len; i++) {
+    for (size_t i = 0; i + needle_len <= accept_len; i++) {
         for (j = 0; j < needle_len; j++) {
             char a = accept[i + j];
             char n = needle[j];

--- a/components/nginx-module/tests/unit/metrics_format_select_test.c
+++ b/components/nginx-module/tests/unit/metrics_format_select_test.c
@@ -1,0 +1,306 @@
+/*
+ * Test: metrics_format_select
+ * Description: Content negotiation for metrics output format
+ *
+ * Uses a standalone test pattern (no NGINX dependencies).
+ * Tests all 8 rows of the content negotiation state machine
+ * from the design document.
+ */
+
+#include "test_common.h"
+
+/* ------------------------------------------------------------------ */
+/* Constants mirroring the NGINX module                                */
+/* ------------------------------------------------------------------ */
+
+#define METRICS_FORMAT_AUTO        0
+#define METRICS_FORMAT_PROMETHEUS  1
+
+#define OUTPUT_TEXT        0
+#define OUTPUT_JSON        1
+#define OUTPUT_PROMETHEUS  2
+
+/* ------------------------------------------------------------------ */
+/* Standalone format selection function                                */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Check if the Accept header value contains a substring
+ * (case-insensitive).
+ */
+static int
+accept_contains(const char *accept, const char *needle)
+{
+    size_t  accept_len;
+    size_t  needle_len;
+    size_t  i, j;
+
+    if (accept == NULL || needle == NULL) {
+        return 0;
+    }
+
+    accept_len = strlen(accept);
+    needle_len = strlen(needle);
+
+    if (needle_len == 0 || accept_len < needle_len) {
+        return 0;
+    }
+
+    for (i = 0; i + needle_len <= accept_len; i++) {
+        for (j = 0; j < needle_len; j++) {
+            char a = accept[i + j];
+            char n = needle[j];
+
+            /* lowercase for case-insensitive compare */
+            if (a >= 'A' && a <= 'Z') {
+                a = (char)(a + ('a' - 'A'));
+            }
+            if (n >= 'A' && n <= 'Z') {
+                n = (char)(n + ('a' - 'A'));
+            }
+            if (a != n) {
+                break;
+            }
+        }
+        if (j == needle_len) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Select metrics output format based on Accept header and
+ * metrics_format configuration.
+ *
+ * Mirrors ngx_http_markdown_metrics_select_format() logic.
+ *
+ * State machine:
+ *   auto       + Accept: application/json     -> JSON
+ *   auto       + Accept: text/plain           -> TEXT
+ *   auto       + (any other / none)           -> TEXT
+ *   prometheus + Accept: application/json     -> JSON
+ *   prometheus + Accept: text/plain           -> PROMETHEUS
+ *   prometheus + Accept: text/plain; v=0.0.4  -> PROMETHEUS
+ *   prometheus + Accept: openmetrics-text     -> PROMETHEUS
+ *   prometheus + (any other / none)           -> PROMETHEUS
+ */
+static int
+select_format(int metrics_format, const char *accept)
+{
+    if (accept_contains(accept, "application/json")) {
+        return OUTPUT_JSON;
+    }
+
+    if (metrics_format == METRICS_FORMAT_PROMETHEUS) {
+        return OUTPUT_PROMETHEUS;
+    }
+
+    return OUTPUT_TEXT;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: auto + Accept: application/json -> JSON                       */
+/* ------------------------------------------------------------------ */
+
+static void
+test_auto_json(void)
+{
+    int result;
+
+    TEST_SUBSECTION("auto + Accept: application/json -> JSON");
+
+    result = select_format(METRICS_FORMAT_AUTO,
+                           "application/json");
+    TEST_ASSERT(result == OUTPUT_JSON,
+                "auto + application/json should select JSON");
+    TEST_PASS("auto + application/json -> JSON");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: auto + Accept: text/plain -> plain text                       */
+/* ------------------------------------------------------------------ */
+
+static void
+test_auto_text_plain(void)
+{
+    int result;
+
+    TEST_SUBSECTION("auto + Accept: text/plain -> TEXT");
+
+    result = select_format(METRICS_FORMAT_AUTO,
+                           "text/plain");
+    TEST_ASSERT(result == OUTPUT_TEXT,
+                "auto + text/plain should select TEXT");
+    TEST_PASS("auto + text/plain -> TEXT");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: auto + (any other / none) -> plain text                       */
+/* ------------------------------------------------------------------ */
+
+static void
+test_auto_none(void)
+{
+    int result;
+
+    TEST_SUBSECTION("auto + no Accept -> TEXT");
+
+    result = select_format(METRICS_FORMAT_AUTO, NULL);
+    TEST_ASSERT(result == OUTPUT_TEXT,
+                "auto + no Accept should select TEXT");
+
+    result = select_format(METRICS_FORMAT_AUTO, "*/*");
+    TEST_ASSERT(result == OUTPUT_TEXT,
+                "auto + */* should select TEXT");
+
+    result = select_format(METRICS_FORMAT_AUTO, "text/html");
+    TEST_ASSERT(result == OUTPUT_TEXT,
+                "auto + text/html should select TEXT");
+
+    TEST_PASS("auto + (any other / none) -> TEXT");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + Accept: application/json -> JSON                  */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_json(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + Accept: application/json -> JSON");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+                           "application/json");
+    TEST_ASSERT(result == OUTPUT_JSON,
+                "prometheus + application/json "
+                "should select JSON");
+    TEST_PASS("prometheus + application/json -> JSON");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + Accept: text/plain -> Prometheus                  */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_text_plain(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + Accept: text/plain -> PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+                           "text/plain");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + text/plain "
+                "should select PROMETHEUS");
+    TEST_PASS("prometheus + text/plain -> PROMETHEUS");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + Accept: text/plain; version=0.0.4 -> Prometheus   */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_text_plain_versioned(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + Accept: text/plain; "
+        "version=0.0.4 -> PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+                           "text/plain; version=0.0.4");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + text/plain; version=0.0.4 "
+                "should select PROMETHEUS");
+    TEST_PASS(
+        "prometheus + text/plain; version=0.0.4 "
+        "-> PROMETHEUS");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + Accept: application/openmetrics-text -> Prometheus */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_openmetrics(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + Accept: "
+        "application/openmetrics-text -> PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+        "application/openmetrics-text");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + openmetrics-text "
+                "should select PROMETHEUS");
+    TEST_PASS(
+        "prometheus + openmetrics-text -> PROMETHEUS");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + (any other / none) -> Prometheus                  */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_none(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + no Accept -> PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS, NULL);
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + no Accept "
+                "should select PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS, "*/*");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + */* "
+                "should select PROMETHEUS");
+
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+                           "text/html");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+                "prometheus + text/html "
+                "should select PROMETHEUS");
+
+    TEST_PASS("prometheus + (any other / none) "
+              "-> PROMETHEUS");
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("metrics_format_select Tests\n");
+    printf("========================================\n");
+
+    test_auto_json();
+    test_auto_text_plain();
+    test_auto_none();
+    test_prometheus_json();
+    test_prometheus_text_plain();
+    test_prometheus_text_plain_versioned();
+    test_prometheus_openmetrics();
+    test_prometheus_none();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}

--- a/components/nginx-module/tests/unit/metrics_format_select_test.c
+++ b/components/nginx-module/tests/unit/metrics_format_select_test.c
@@ -70,6 +70,28 @@ accept_contains(const char *accept, const char *needle)
     return 0;
 }
 
+static const char *needle_openmetrics =
+    "application/openmetrics-text";
+static const char *needle_prom_ver = "version=0.0.4";
+static const char *needle_text_plain = "text/plain";
+
+static int
+prefers_prometheus(const char *accept)
+{
+    if (accept == NULL) {
+        return 0;
+    }
+    if (accept_contains(accept, needle_openmetrics)) {
+        return 1;
+    }
+    if (accept_contains(accept, needle_text_plain)
+        && accept_contains(accept, needle_prom_ver))
+    {
+        return 1;
+    }
+    return 0;
+}
+
 /*
  * Select metrics output format based on Accept header and
  * metrics_format configuration.
@@ -77,14 +99,14 @@ accept_contains(const char *accept, const char *needle)
  * Mirrors ngx_http_markdown_metrics_select_format() logic.
  *
  * State machine:
- *   auto       + Accept: application/json     -> JSON
- *   auto       + Accept: text/plain           -> TEXT
- *   auto       + (any other / none)           -> TEXT
- *   prometheus + Accept: application/json     -> JSON
- *   prometheus + Accept: text/plain           -> PROMETHEUS
- *   prometheus + Accept: text/plain; v=0.0.4  -> PROMETHEUS
- *   prometheus + Accept: openmetrics-text     -> PROMETHEUS
- *   prometheus + (any other / none)           -> PROMETHEUS
+ *   auto       + Accept: application/json          -> JSON
+ *   auto       + Accept: text/plain                -> TEXT
+ *   auto       + (any other / none)                -> TEXT
+ *   prometheus + Accept: application/json          -> JSON
+ *   prometheus + Accept: application/openmetrics   -> PROMETHEUS
+ *   prometheus + Accept: text/plain; v=0.0.4      -> PROMETHEUS
+ *   prometheus + Accept: text/plain                -> TEXT
+ *   prometheus + (any other / none)                -> TEXT
  */
 static int
 select_format(int metrics_format, const char *accept)
@@ -93,7 +115,9 @@ select_format(int metrics_format, const char *accept)
         return OUTPUT_JSON;
     }
 
-    if (metrics_format == METRICS_FORMAT_PROMETHEUS) {
+    if (metrics_format == METRICS_FORMAT_PROMETHEUS
+        && prefers_prometheus(accept))
+    {
         return OUTPUT_PROMETHEUS;
     }
 
@@ -183,7 +207,7 @@ test_prometheus_json(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Test: prometheus + Accept: text/plain -> Prometheus                  */
+/* Test: prometheus + Accept: text/plain -> TEXT (backward compat)      */
 /* ------------------------------------------------------------------ */
 
 static void
@@ -192,14 +216,14 @@ test_prometheus_text_plain(void)
     int result;
 
     TEST_SUBSECTION(
-        "prometheus + Accept: text/plain -> PROMETHEUS");
+        "prometheus + Accept: text/plain -> TEXT");
 
     result = select_format(METRICS_FORMAT_PROMETHEUS,
                            "text/plain");
-    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+    TEST_ASSERT(result == OUTPUT_TEXT,
                 "prometheus + text/plain "
-                "should select PROMETHEUS");
-    TEST_PASS("prometheus + text/plain -> PROMETHEUS");
+                "should select TEXT (backward compat)");
+    TEST_PASS("prometheus + text/plain -> TEXT");
 }
 
 /* ------------------------------------------------------------------ */
@@ -248,7 +272,7 @@ test_prometheus_openmetrics(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Test: prometheus + (any other / none) -> Prometheus                  */
+/* Test: prometheus + (any other / none) -> TEXT                        */
 /* ------------------------------------------------------------------ */
 
 static void
@@ -257,26 +281,70 @@ test_prometheus_none(void)
     int result;
 
     TEST_SUBSECTION(
-        "prometheus + no Accept -> PROMETHEUS");
+        "prometheus + no Accept -> TEXT");
 
     result = select_format(METRICS_FORMAT_PROMETHEUS, NULL);
-    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+    TEST_ASSERT(result == OUTPUT_TEXT,
                 "prometheus + no Accept "
-                "should select PROMETHEUS");
+                "should select TEXT");
 
     result = select_format(METRICS_FORMAT_PROMETHEUS, "*/*");
-    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+    TEST_ASSERT(result == OUTPUT_TEXT,
                 "prometheus + */* "
-                "should select PROMETHEUS");
+                "should select TEXT");
 
     result = select_format(METRICS_FORMAT_PROMETHEUS,
                            "text/html");
-    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+    TEST_ASSERT(result == OUTPUT_TEXT,
                 "prometheus + text/html "
-                "should select PROMETHEUS");
+                "should select TEXT");
 
     TEST_PASS("prometheus + (any other / none) "
-              "-> PROMETHEUS");
+              "-> TEXT");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: prometheus + version=0.0.4 without text/plain -> TEXT          */
+/* ------------------------------------------------------------------ */
+
+static void
+test_prometheus_false_positives(void)
+{
+    int result;
+
+    TEST_SUBSECTION(
+        "prometheus + version=0.0.4 false positives");
+
+    /* xml with version param — wrong media type */
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+        "application/xml; version=0.0.4");
+    TEST_ASSERT(result == OUTPUT_TEXT,
+        "application/xml; version=0.0.4 "
+        "should select TEXT");
+
+    /* bare version param — no media type */
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+        "version=0.0.4");
+    TEST_ASSERT(result == OUTPUT_TEXT,
+        "bare version=0.0.4 "
+        "should select TEXT");
+
+    /* text/plain with version — correct match */
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+        "text/plain; version=0.0.4");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+        "text/plain; version=0.0.4 "
+        "should select PROMETHEUS");
+
+    /* openmetrics — correct match */
+    result = select_format(METRICS_FORMAT_PROMETHEUS,
+        "application/openmetrics-text");
+    TEST_ASSERT(result == OUTPUT_PROMETHEUS,
+        "openmetrics-text "
+        "should select PROMETHEUS");
+
+    TEST_PASS("version=0.0.4 false positives "
+              "correctly rejected");
 }
 
 /* ------------------------------------------------------------------ */
@@ -298,6 +366,7 @@ main(void)
     test_prometheus_text_plain_versioned();
     test_prometheus_openmetrics();
     test_prometheus_none();
+    test_prometheus_false_positives();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
+++ b/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
@@ -4,104 +4,16 @@
  */
 
 #include "test_common.h"
+#include "test_metrics_snapshot.h"
 
 /*
- * Mirror of the shared-memory metrics struct with the new fields.
- * Uses unsigned long in place of ngx_atomic_t for standalone testing.
+ * In the real module the metrics struct and the snapshot struct
+ * have the same layout.  Reuse the shared type for both so the
+ * test verifies field-by-field copy without duplicating the
+ * struct definition.
  */
-typedef struct {
-    /* Existing fields */
-    unsigned long conversions_attempted;
-    unsigned long conversions_succeeded;
-    unsigned long conversions_failed;
-    unsigned long conversions_bypassed;
-    unsigned long failures_conversion;
-    unsigned long failures_resource_limit;
-    unsigned long failures_system;
-    unsigned long conversion_time_sum_ms;
-    unsigned long input_bytes;
-    unsigned long output_bytes;
-    struct {
-        unsigned long le_10ms;
-        unsigned long le_100ms;
-        unsigned long le_1000ms;
-        unsigned long gt_1000ms;
-    } conversion_latency;
-    struct {
-        unsigned long attempted;
-        unsigned long succeeded;
-        unsigned long failed;
-        unsigned long gzip;
-        unsigned long deflate;
-        unsigned long brotli;
-    } decompressions;
-    unsigned long fullbuffer_path_hits;
-    unsigned long incremental_path_hits;
-
-    /* New fields */
-    unsigned long requests_entered;
-    struct {
-        unsigned long config;
-        unsigned long method;
-        unsigned long status;
-        unsigned long content_type;
-        unsigned long size;
-        unsigned long streaming;
-        unsigned long auth;
-        unsigned long range;
-        unsigned long accept;
-    } skips;
-    unsigned long failopen_count;
-    unsigned long estimated_token_savings;
-} metrics_t;
-
-/*
- * Snapshot struct mirroring ngx_http_markdown_metrics_snapshot_t.
- */
-typedef struct {
-    unsigned long conversions_attempted;
-    unsigned long conversions_succeeded;
-    unsigned long conversions_failed;
-    unsigned long conversions_bypassed;
-    unsigned long failures_conversion;
-    unsigned long failures_resource_limit;
-    unsigned long failures_system;
-    unsigned long conversion_time_sum_ms;
-    unsigned long input_bytes;
-    unsigned long output_bytes;
-    struct {
-        unsigned long le_10ms;
-        unsigned long le_100ms;
-        unsigned long le_1000ms;
-        unsigned long gt_1000ms;
-    } conversion_latency;
-    struct {
-        unsigned long attempted;
-        unsigned long succeeded;
-        unsigned long failed;
-        unsigned long gzip;
-        unsigned long deflate;
-        unsigned long brotli;
-    } decompressions;
-    unsigned long fullbuffer_path_hits;
-    unsigned long incremental_path_hits;
-
-    /* New fields */
-    unsigned long requests_entered;
-    struct {
-        unsigned long config;
-        unsigned long method;
-        unsigned long status;
-        unsigned long content_type;
-        unsigned long size;
-        unsigned long streaming;
-        unsigned long auth;
-        unsigned long range;
-        unsigned long accept;
-    } skips;
-    unsigned long failopen_count;
-    unsigned long estimated_token_savings;
-} snapshot_t;
+typedef test_metrics_snapshot_t  metrics_t;
+typedef test_metrics_snapshot_t  snapshot_t;
 
 /* Global pointer simulating ngx_http_markdown_metrics */
 static metrics_t *g_metrics = NULL;

--- a/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
+++ b/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
@@ -1,0 +1,271 @@
+/*
+ * Test: metrics_snapshot_new_fields
+ * Description: snapshot collection of new Prometheus counter fields
+ */
+
+#include "test_common.h"
+
+/*
+ * Mirror of the shared-memory metrics struct with the new fields.
+ * Uses unsigned long in place of ngx_atomic_t for standalone testing.
+ */
+typedef struct {
+    /* Existing fields */
+    unsigned long conversions_attempted;
+    unsigned long conversions_succeeded;
+    unsigned long conversions_failed;
+    unsigned long conversions_bypassed;
+    unsigned long failures_conversion;
+    unsigned long failures_resource_limit;
+    unsigned long failures_system;
+    unsigned long conversion_time_sum_ms;
+    unsigned long input_bytes;
+    unsigned long output_bytes;
+    unsigned long conversion_latency_le_10ms;
+    unsigned long conversion_latency_le_100ms;
+    unsigned long conversion_latency_le_1000ms;
+    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long attempted;
+        unsigned long succeeded;
+        unsigned long failed;
+        unsigned long gzip;
+        unsigned long deflate;
+        unsigned long brotli;
+    } decompressions;
+    unsigned long fullbuffer_path_hits;
+    unsigned long incremental_path_hits;
+
+    /* New fields */
+    unsigned long requests_entered;
+    struct {
+        unsigned long config;
+        unsigned long method;
+        unsigned long status;
+        unsigned long content_type;
+        unsigned long size;
+        unsigned long streaming;
+        unsigned long auth;
+        unsigned long range;
+        unsigned long accept;
+    } skips;
+    unsigned long failopen_count;
+    unsigned long estimated_token_savings;
+} metrics_t;
+
+/*
+ * Snapshot struct mirroring ngx_http_markdown_metrics_snapshot_t.
+ */
+typedef struct {
+    unsigned long conversions_attempted;
+    unsigned long conversions_succeeded;
+    unsigned long conversions_failed;
+    unsigned long conversions_bypassed;
+    unsigned long failures_conversion;
+    unsigned long failures_resource_limit;
+    unsigned long failures_system;
+    unsigned long conversion_time_sum_ms;
+    unsigned long input_bytes;
+    unsigned long output_bytes;
+    unsigned long conversion_latency_le_10ms;
+    unsigned long conversion_latency_le_100ms;
+    unsigned long conversion_latency_le_1000ms;
+    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long attempted;
+        unsigned long succeeded;
+        unsigned long failed;
+        unsigned long gzip;
+        unsigned long deflate;
+        unsigned long brotli;
+    } decompressions;
+    unsigned long fullbuffer_path_hits;
+    unsigned long incremental_path_hits;
+
+    /* New fields */
+    unsigned long requests_entered;
+    struct {
+        unsigned long config;
+        unsigned long method;
+        unsigned long status;
+        unsigned long content_type;
+        unsigned long size;
+        unsigned long streaming;
+        unsigned long auth;
+        unsigned long range;
+        unsigned long accept;
+    } skips;
+    unsigned long failopen_count;
+    unsigned long estimated_token_savings;
+} snapshot_t;
+
+/* Global pointer simulating ngx_http_markdown_metrics */
+static metrics_t *g_metrics = NULL;
+
+static void
+collect_snapshot(snapshot_t *snap)
+{
+    metrics_t *m;
+
+    memset(snap, 0, sizeof(snapshot_t));
+
+    m = g_metrics;
+    if (m == NULL) {
+        return;
+    }
+
+    snap->conversions_attempted = m->conversions_attempted;
+    snap->conversions_succeeded = m->conversions_succeeded;
+    snap->conversions_failed = m->conversions_failed;
+    snap->conversions_bypassed = m->conversions_bypassed;
+    snap->failures_conversion = m->failures_conversion;
+    snap->failures_resource_limit = m->failures_resource_limit;
+    snap->failures_system = m->failures_system;
+    snap->conversion_time_sum_ms = m->conversion_time_sum_ms;
+    snap->input_bytes = m->input_bytes;
+    snap->output_bytes = m->output_bytes;
+    snap->conversion_latency_le_10ms = m->conversion_latency_le_10ms;
+    snap->conversion_latency_le_100ms = m->conversion_latency_le_100ms;
+    snap->conversion_latency_le_1000ms = m->conversion_latency_le_1000ms;
+    snap->conversion_latency_gt_1000ms = m->conversion_latency_gt_1000ms;
+    snap->decompressions.attempted = m->decompressions.attempted;
+    snap->decompressions.succeeded = m->decompressions.succeeded;
+    snap->decompressions.failed = m->decompressions.failed;
+    snap->decompressions.gzip = m->decompressions.gzip;
+    snap->decompressions.deflate = m->decompressions.deflate;
+    snap->decompressions.brotli = m->decompressions.brotli;
+    snap->fullbuffer_path_hits = m->fullbuffer_path_hits;
+    snap->incremental_path_hits = m->incremental_path_hits;
+    snap->requests_entered = m->requests_entered;
+    snap->skips.config = m->skips.config;
+    snap->skips.method = m->skips.method;
+    snap->skips.status = m->skips.status;
+    snap->skips.content_type = m->skips.content_type;
+    snap->skips.size = m->skips.size;
+    snap->skips.streaming = m->skips.streaming;
+    snap->skips.auth = m->skips.auth;
+    snap->skips.range = m->skips.range;
+    snap->skips.accept = m->skips.accept;
+    snap->failopen_count = m->failopen_count;
+    snap->estimated_token_savings = m->estimated_token_savings;
+}
+
+static void
+test_null_metrics_zeroes_new_fields(void)
+{
+    snapshot_t snap;
+
+    TEST_SUBSECTION("New fields zeroed when metrics pointer is NULL");
+
+    g_metrics = NULL;
+    collect_snapshot(&snap);
+
+    TEST_ASSERT(snap.requests_entered == 0,
+                "requests_entered should be zero");
+    TEST_ASSERT(snap.skips.config == 0,
+                "skips.config should be zero");
+    TEST_ASSERT(snap.skips.method == 0,
+                "skips.method should be zero");
+    TEST_ASSERT(snap.skips.status == 0,
+                "skips.status should be zero");
+    TEST_ASSERT(snap.skips.content_type == 0,
+                "skips.content_type should be zero");
+    TEST_ASSERT(snap.skips.size == 0,
+                "skips.size should be zero");
+    TEST_ASSERT(snap.skips.streaming == 0,
+                "skips.streaming should be zero");
+    TEST_ASSERT(snap.skips.auth == 0,
+                "skips.auth should be zero");
+    TEST_ASSERT(snap.skips.range == 0,
+                "skips.range should be zero");
+    TEST_ASSERT(snap.skips.accept == 0,
+                "skips.accept should be zero");
+    TEST_ASSERT(snap.failopen_count == 0,
+                "failopen_count should be zero");
+    TEST_ASSERT(snap.estimated_token_savings == 0,
+                "estimated_token_savings should be zero");
+
+    TEST_PASS("All new fields are zeroed when metrics is NULL");
+}
+
+static void
+test_new_fields_copied_correctly(void)
+{
+    metrics_t  m;
+    snapshot_t snap;
+
+    TEST_SUBSECTION("New fields copied from mock metrics struct");
+
+    memset(&m, 0, sizeof(m));
+
+    /* Set distinctive values for each new field */
+    m.requests_entered = 42;
+    m.skips.config = 1;
+    m.skips.method = 2;
+    m.skips.status = 3;
+    m.skips.content_type = 4;
+    m.skips.size = 5;
+    m.skips.streaming = 6;
+    m.skips.auth = 7;
+    m.skips.range = 8;
+    m.skips.accept = 9;
+    m.failopen_count = 10;
+    m.estimated_token_savings = 15000;
+
+    /* Also set some existing fields to verify no interference */
+    m.conversions_attempted = 100;
+    m.conversions_succeeded = 80;
+
+    g_metrics = &m;
+    collect_snapshot(&snap);
+    g_metrics = NULL;
+
+    TEST_ASSERT(snap.requests_entered == 42,
+                "requests_entered should be copied");
+    TEST_ASSERT(snap.skips.config == 1,
+                "skips.config should be copied");
+    TEST_ASSERT(snap.skips.method == 2,
+                "skips.method should be copied");
+    TEST_ASSERT(snap.skips.status == 3,
+                "skips.status should be copied");
+    TEST_ASSERT(snap.skips.content_type == 4,
+                "skips.content_type should be copied");
+    TEST_ASSERT(snap.skips.size == 5,
+                "skips.size should be copied");
+    TEST_ASSERT(snap.skips.streaming == 6,
+                "skips.streaming should be copied");
+    TEST_ASSERT(snap.skips.auth == 7,
+                "skips.auth should be copied");
+    TEST_ASSERT(snap.skips.range == 8,
+                "skips.range should be copied");
+    TEST_ASSERT(snap.skips.accept == 9,
+                "skips.accept should be copied");
+    TEST_ASSERT(snap.failopen_count == 10,
+                "failopen_count should be copied");
+    TEST_ASSERT(snap.estimated_token_savings == 15000,
+                "estimated_token_savings should be copied");
+
+    /* Verify existing fields still work */
+    TEST_ASSERT(snap.conversions_attempted == 100,
+                "existing conversions_attempted should be copied");
+    TEST_ASSERT(snap.conversions_succeeded == 80,
+                "existing conversions_succeeded should be copied");
+
+    TEST_PASS("All new fields are copied correctly");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("metrics_snapshot_new_fields Tests\n");
+    printf("========================================\n");
+
+    test_null_metrics_zeroes_new_fields();
+    test_new_fields_copied_correctly();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}

--- a/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
+++ b/components/nginx-module/tests/unit/metrics_snapshot_new_fields_test.c
@@ -21,10 +21,12 @@ typedef struct {
     unsigned long conversion_time_sum_ms;
     unsigned long input_bytes;
     unsigned long output_bytes;
-    unsigned long conversion_latency_le_10ms;
-    unsigned long conversion_latency_le_100ms;
-    unsigned long conversion_latency_le_1000ms;
-    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long le_10ms;
+        unsigned long le_100ms;
+        unsigned long le_1000ms;
+        unsigned long gt_1000ms;
+    } conversion_latency;
     struct {
         unsigned long attempted;
         unsigned long succeeded;
@@ -67,10 +69,12 @@ typedef struct {
     unsigned long conversion_time_sum_ms;
     unsigned long input_bytes;
     unsigned long output_bytes;
-    unsigned long conversion_latency_le_10ms;
-    unsigned long conversion_latency_le_100ms;
-    unsigned long conversion_latency_le_1000ms;
-    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long le_10ms;
+        unsigned long le_100ms;
+        unsigned long le_1000ms;
+        unsigned long gt_1000ms;
+    } conversion_latency;
     struct {
         unsigned long attempted;
         unsigned long succeeded;
@@ -105,7 +109,7 @@ static metrics_t *g_metrics = NULL;
 static void
 collect_snapshot(snapshot_t *snap)
 {
-    metrics_t *m;
+    const metrics_t *m;
 
     memset(snap, 0, sizeof(snapshot_t));
 
@@ -124,10 +128,10 @@ collect_snapshot(snapshot_t *snap)
     snap->conversion_time_sum_ms = m->conversion_time_sum_ms;
     snap->input_bytes = m->input_bytes;
     snap->output_bytes = m->output_bytes;
-    snap->conversion_latency_le_10ms = m->conversion_latency_le_10ms;
-    snap->conversion_latency_le_100ms = m->conversion_latency_le_100ms;
-    snap->conversion_latency_le_1000ms = m->conversion_latency_le_1000ms;
-    snap->conversion_latency_gt_1000ms = m->conversion_latency_gt_1000ms;
+    snap->conversion_latency.le_10ms = m->conversion_latency.le_10ms;
+    snap->conversion_latency.le_100ms = m->conversion_latency.le_100ms;
+    snap->conversion_latency.le_1000ms = m->conversion_latency.le_1000ms;
+    snap->conversion_latency.gt_1000ms = m->conversion_latency.gt_1000ms;
     snap->decompressions.attempted = m->decompressions.attempted;
     snap->decompressions.succeeded = m->decompressions.succeeded;
     snap->decompressions.failed = m->decompressions.failed;

--- a/components/nginx-module/tests/unit/prometheus_format_test.c
+++ b/components/nginx-module/tests/unit/prometheus_format_test.c
@@ -7,53 +7,10 @@
  */
 
 #include "test_common.h"
+#include "test_metrics_snapshot.h"
 
-/* ------------------------------------------------------------------ */
-/* Local snapshot struct mirroring ngx_http_markdown_metrics_snapshot_t */
-/* ------------------------------------------------------------------ */
-
-typedef struct {
-    unsigned long conversions_attempted;
-    unsigned long conversions_succeeded;
-    unsigned long conversions_failed;
-    unsigned long conversions_bypassed;
-    unsigned long failures_conversion;
-    unsigned long failures_resource_limit;
-    unsigned long failures_system;
-    unsigned long conversion_time_sum_ms;
-    unsigned long input_bytes;
-    unsigned long output_bytes;
-    struct {
-        unsigned long le_10ms;
-        unsigned long le_100ms;
-        unsigned long le_1000ms;
-        unsigned long gt_1000ms;
-    } conversion_latency;
-    struct {
-        unsigned long attempted;
-        unsigned long succeeded;
-        unsigned long failed;
-        unsigned long gzip;
-        unsigned long deflate;
-        unsigned long brotli;
-    } decompressions;
-    unsigned long fullbuffer_path_hits;
-    unsigned long incremental_path_hits;
-    unsigned long requests_entered;
-    struct {
-        unsigned long config;
-        unsigned long method;
-        unsigned long status;
-        unsigned long content_type;
-        unsigned long size;
-        unsigned long streaming;
-        unsigned long auth;
-        unsigned long range;
-        unsigned long accept;
-    } skips;
-    unsigned long failopen_count;
-    unsigned long estimated_token_savings;
-} snapshot_t;
+/* Re-export the shared type under the local name used throughout */
+typedef test_metrics_snapshot_t  snapshot_t;
 
 /* ------------------------------------------------------------------ */
 /* Local Prometheus renderer mirroring the NGINX implementation        */

--- a/components/nginx-module/tests/unit/prometheus_format_test.c
+++ b/components/nginx-module/tests/unit/prometheus_format_test.c
@@ -23,10 +23,12 @@ typedef struct {
     unsigned long conversion_time_sum_ms;
     unsigned long input_bytes;
     unsigned long output_bytes;
-    unsigned long conversion_latency_le_10ms;
-    unsigned long conversion_latency_le_100ms;
-    unsigned long conversion_latency_le_1000ms;
-    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long le_10ms;
+        unsigned long le_100ms;
+        unsigned long le_1000ms;
+        unsigned long gt_1000ms;
+    } conversion_latency;
     struct {
         unsigned long attempted;
         unsigned long succeeded;
@@ -256,16 +258,16 @@ format_prometheus(const snapshot_t *s, char *buf, size_t buf_len)
         "{le=\"1.0\"} %lu\n"
         "nginx_markdown_conversion_duration_seconds"
         "{le=\"+Inf\"} %lu\n",
-        s->conversion_latency_le_10ms,
-        s->conversion_latency_le_10ms
-            + s->conversion_latency_le_100ms,
-        s->conversion_latency_le_10ms
-            + s->conversion_latency_le_100ms
-            + s->conversion_latency_le_1000ms,
-        s->conversion_latency_le_10ms
-            + s->conversion_latency_le_100ms
-            + s->conversion_latency_le_1000ms
-            + s->conversion_latency_gt_1000ms);
+        s->conversion_latency.le_10ms,
+        s->conversion_latency.le_10ms
+            + s->conversion_latency.le_100ms,
+        s->conversion_latency.le_10ms
+            + s->conversion_latency.le_100ms
+            + s->conversion_latency.le_1000ms,
+        s->conversion_latency.le_10ms
+            + s->conversion_latency.le_100ms
+            + s->conversion_latency.le_1000ms
+            + s->conversion_latency.gt_1000ms);
 
 #undef PROM_WRITE
 
@@ -395,10 +397,10 @@ test_known_values(void)
     s.decompressions.deflate = 5;
     s.decompressions.brotli = 3;
     s.decompressions.failed = 1;
-    s.conversion_latency_le_10ms = 40;
-    s.conversion_latency_le_100ms = 30;
-    s.conversion_latency_le_1000ms = 8;
-    s.conversion_latency_gt_1000ms = 2;
+    s.conversion_latency.le_10ms = 40;
+    s.conversion_latency.le_100ms = 30;
+    s.conversion_latency.le_1000ms = 8;
+    s.conversion_latency.gt_1000ms = 2;
 
     format_prometheus(&s, buf, sizeof(buf));
 
@@ -461,7 +463,6 @@ test_help_and_type_lines(void)
     char help_prefix[128];
     char type_prefix[128];
     snapshot_t s;
-    size_t i;
 
     TEST_SUBSECTION("Every metric family has HELP and "
                     "TYPE lines");
@@ -469,7 +470,7 @@ test_help_and_type_lines(void)
     memset(&s, 0, sizeof(s));
     format_prometheus(&s, buf, sizeof(buf));
 
-    for (i = 0; i < NUM_FAMILIES; i++) {
+    for (size_t i = 0; i < NUM_FAMILIES; i++) {
         snprintf(help_prefix, sizeof(help_prefix),
                  "# HELP %s ", metric_families[i]);
         snprintf(type_prefix, sizeof(type_prefix),
@@ -495,18 +496,20 @@ test_counter_suffix(void)
     char buf[8192];
     char type_line[128];
     snapshot_t s;
-    size_t i;
 
     TEST_SUBSECTION("Counter metrics end with _total");
 
     memset(&s, 0, sizeof(s));
     format_prometheus(&s, buf, sizeof(buf));
 
-    for (i = 0; i < NUM_FAMILIES; i++) {
+    for (size_t i = 0; i < NUM_FAMILIES; i++) {
         snprintf(type_line, sizeof(type_line),
                  "# TYPE %s counter", metric_families[i]);
         if (contains(buf, type_line)) {
-            /* This is a counter — name must end with _total */
+            /*
+             * Safe: metric_families[] entries are
+             * compile-time string literals.
+             */
             size_t name_len = strlen(metric_families[i]);
             TEST_ASSERT(
                 name_len >= 6
@@ -529,7 +532,6 @@ test_label_values(void)
     char buf[8192];
     char label_str[128];
     snapshot_t s;
-    size_t i;
 
     TEST_SUBSECTION("Label values match defined sets");
 
@@ -537,7 +539,7 @@ test_label_values(void)
     format_prometheus(&s, buf, sizeof(buf));
 
     /* Check all reason labels present */
-    for (i = 0; i < NUM_REASONS; i++) {
+    for (size_t i = 0; i < NUM_REASONS; i++) {
         snprintf(label_str, sizeof(label_str),
                  "reason=\"%s\"", reason_values[i]);
         TEST_ASSERT(contains(buf, label_str),
@@ -545,7 +547,7 @@ test_label_values(void)
     }
 
     /* Check all stage labels present */
-    for (i = 0; i < NUM_STAGES; i++) {
+    for (size_t i = 0; i < NUM_STAGES; i++) {
         snprintf(label_str, sizeof(label_str),
                  "stage=\"%s\"", stage_values[i]);
         TEST_ASSERT(contains(buf, label_str),
@@ -553,7 +555,7 @@ test_label_values(void)
     }
 
     /* Check all format labels present */
-    for (i = 0; i < NUM_FORMATS; i++) {
+    for (size_t i = 0; i < NUM_FORMATS; i++) {
         snprintf(label_str, sizeof(label_str),
                  "format=\"%s\"", format_values[i]);
         TEST_ASSERT(contains(buf, label_str),
@@ -571,7 +573,7 @@ static void
 test_token_savings_help_text(void)
 {
     char buf[8192];
-    char *help_start;
+    const char *help_start;
     char *help_end;
     snapshot_t s;
 
@@ -588,8 +590,12 @@ test_token_savings_help_text(void)
                 "HELP line for estimated_token_savings_total "
                 "must exist");
 
-    /* Find end of this HELP line */
-    help_end = strchr(help_start, '\n');
+    /*
+     * Find end of this HELP line.  Derive the mutable pointer
+     * from buf so the temporary null-termination below is safe.
+     */
+    help_end = buf + (help_start - buf);
+    help_end = strchr(help_end, '\n');
     TEST_ASSERT(help_end != NULL,
                 "HELP line must end with newline");
 

--- a/components/nginx-module/tests/unit/prometheus_format_test.c
+++ b/components/nginx-module/tests/unit/prometheus_format_test.c
@@ -93,15 +93,16 @@ format_prometheus(const snapshot_t *s, char *buf, size_t buf_len)
         "\n",
         s->conversions_succeeded);
 
-    /* passthrough_total */
+    /* passthrough_total (derived: skips + fail-open) */
     PROM_WRITE(
         "# HELP nginx_markdown_passthrough_total "
         "Requests not converted "
         "(skipped or failed-open).\n"
-        "# TYPE nginx_markdown_passthrough_total counter\n"
+        "# TYPE nginx_markdown_passthrough_total "
+        "counter\n"
         "nginx_markdown_passthrough_total %lu\n"
         "\n",
-        s->conversions_bypassed);
+        s->conversions_bypassed + s->failopen_count);
 
     /* skips_total{reason=...} */
     PROM_WRITE(
@@ -238,7 +239,7 @@ format_prometheus(const snapshot_t *s, char *buf, size_t buf_len)
         "\n",
         s->decompressions.failed);
 
-    /* conversion_duration_seconds{le=...} */
+    /* conversion_duration_seconds{le=...} (cumulative) */
     PROM_WRITE(
         "# HELP "
         "nginx_markdown_conversion_duration_seconds "
@@ -256,9 +257,15 @@ format_prometheus(const snapshot_t *s, char *buf, size_t buf_len)
         "nginx_markdown_conversion_duration_seconds"
         "{le=\"+Inf\"} %lu\n",
         s->conversion_latency_le_10ms,
-        s->conversion_latency_le_100ms,
-        s->conversion_latency_le_1000ms,
-        s->conversion_latency_gt_1000ms);
+        s->conversion_latency_le_10ms
+            + s->conversion_latency_le_100ms,
+        s->conversion_latency_le_10ms
+            + s->conversion_latency_le_100ms
+            + s->conversion_latency_le_1000ms,
+        s->conversion_latency_le_10ms
+            + s->conversion_latency_le_100ms
+            + s->conversion_latency_le_1000ms
+            + s->conversion_latency_gt_1000ms);
 
 #undef PROM_WRITE
 
@@ -404,6 +411,10 @@ test_known_values(void)
         "conversions_total should be 80");
     TEST_ASSERT(
         contains(buf,
+            "nginx_markdown_passthrough_total 18"),
+        "passthrough_total should be 15+3=18");
+    TEST_ASSERT(
+        contains(buf,
             "nginx_markdown_skips_total"
             "{reason=\"SKIP_METHOD\"} 3"),
         "skips method should be 3");
@@ -433,8 +444,8 @@ test_known_values(void)
     TEST_ASSERT(
         contains(buf,
             "nginx_markdown_conversion_duration_seconds"
-            "{le=\"+Inf\"} 2"),
-        "latency le +Inf should be 2");
+            "{le=\"+Inf\"} 80"),
+        "latency le +Inf should be 40+30+8+2=80");
 
     TEST_PASS("Known-value snapshot matches expected text");
 }

--- a/components/nginx-module/tests/unit/prometheus_format_test.c
+++ b/components/nginx-module/tests/unit/prometheus_format_test.c
@@ -1,0 +1,617 @@
+/*
+ * Test: prometheus_format
+ * Description: Prometheus text exposition format renderer
+ *
+ * Uses a standalone test pattern (no NGINX dependencies).
+ * Mirrors the renderer logic using snprintf() and unsigned long.
+ */
+
+#include "test_common.h"
+
+/* ------------------------------------------------------------------ */
+/* Local snapshot struct mirroring ngx_http_markdown_metrics_snapshot_t */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    unsigned long conversions_attempted;
+    unsigned long conversions_succeeded;
+    unsigned long conversions_failed;
+    unsigned long conversions_bypassed;
+    unsigned long failures_conversion;
+    unsigned long failures_resource_limit;
+    unsigned long failures_system;
+    unsigned long conversion_time_sum_ms;
+    unsigned long input_bytes;
+    unsigned long output_bytes;
+    unsigned long conversion_latency_le_10ms;
+    unsigned long conversion_latency_le_100ms;
+    unsigned long conversion_latency_le_1000ms;
+    unsigned long conversion_latency_gt_1000ms;
+    struct {
+        unsigned long attempted;
+        unsigned long succeeded;
+        unsigned long failed;
+        unsigned long gzip;
+        unsigned long deflate;
+        unsigned long brotli;
+    } decompressions;
+    unsigned long fullbuffer_path_hits;
+    unsigned long incremental_path_hits;
+    unsigned long requests_entered;
+    struct {
+        unsigned long config;
+        unsigned long method;
+        unsigned long status;
+        unsigned long content_type;
+        unsigned long size;
+        unsigned long streaming;
+        unsigned long auth;
+        unsigned long range;
+        unsigned long accept;
+    } skips;
+    unsigned long failopen_count;
+    unsigned long estimated_token_savings;
+} snapshot_t;
+
+/* ------------------------------------------------------------------ */
+/* Local Prometheus renderer mirroring the NGINX implementation        */
+/* ------------------------------------------------------------------ */
+
+static int
+format_prometheus(const snapshot_t *s, char *buf, size_t buf_len)
+{
+    int n;
+    int total = 0;
+    char *p = buf;
+    size_t rem = buf_len;
+
+#define PROM_WRITE(...)                                     \
+    do {                                                    \
+        n = snprintf(p, rem, __VA_ARGS__);                  \
+        if (n < 0) return -1;                               \
+        if ((size_t)n >= rem) { rem = 0; p = buf + buf_len; } \
+        else { p += n; rem -= (size_t)n; }                  \
+        total += n;                                         \
+    } while (0)
+
+    /* requests_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_requests_total "
+        "Total requests entering the module "
+        "decision chain.\n"
+        "# TYPE nginx_markdown_requests_total counter\n"
+        "nginx_markdown_requests_total %lu\n"
+        "\n",
+        s->requests_entered);
+
+    /* conversions_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_conversions_total "
+        "Successful HTML-to-Markdown conversions.\n"
+        "# TYPE nginx_markdown_conversions_total counter\n"
+        "nginx_markdown_conversions_total %lu\n"
+        "\n",
+        s->conversions_succeeded);
+
+    /* passthrough_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_passthrough_total "
+        "Requests not converted "
+        "(skipped or failed-open).\n"
+        "# TYPE nginx_markdown_passthrough_total counter\n"
+        "nginx_markdown_passthrough_total %lu\n"
+        "\n",
+        s->conversions_bypassed);
+
+    /* skips_total{reason=...} */
+    PROM_WRITE(
+        "# HELP nginx_markdown_skips_total "
+        "Requests skipped by reason.\n"
+        "# TYPE nginx_markdown_skips_total counter\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_METHOD\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_STATUS\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_CONTENT_TYPE\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_SIZE\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_STREAMING\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_AUTH\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_RANGE\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_ACCEPT\"} %lu\n"
+        "nginx_markdown_skips_total"
+        "{reason=\"SKIP_CONFIG\"} %lu\n"
+        "\n",
+        s->skips.method,
+        s->skips.status,
+        s->skips.content_type,
+        s->skips.size,
+        s->skips.streaming,
+        s->skips.auth,
+        s->skips.range,
+        s->skips.accept,
+        s->skips.config);
+
+    /* failures_total{stage=...} */
+    PROM_WRITE(
+        "# HELP nginx_markdown_failures_total "
+        "Conversion failures by stage.\n"
+        "# TYPE nginx_markdown_failures_total counter\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_CONVERSION\"} %lu\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_RESOURCE_LIMIT\"} %lu\n"
+        "nginx_markdown_failures_total"
+        "{stage=\"FAIL_SYSTEM\"} %lu\n"
+        "\n",
+        s->failures_conversion,
+        s->failures_resource_limit,
+        s->failures_system);
+
+    /* failopen_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_failopen_total "
+        "Conversions failed with original HTML served "
+        "(fail-open).\n"
+        "# TYPE nginx_markdown_failopen_total counter\n"
+        "nginx_markdown_failopen_total %lu\n"
+        "\n",
+        s->failopen_count);
+
+    /* large_response_path_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_large_response_path_total "
+        "Requests routed to incremental "
+        "processing path.\n"
+        "# TYPE "
+        "nginx_markdown_large_response_path_total counter\n"
+        "nginx_markdown_large_response_path_total %lu\n"
+        "\n",
+        s->incremental_path_hits);
+
+    /* input_bytes_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_input_bytes_total "
+        "Cumulative HTML input bytes from "
+        "successful conversions.\n"
+        "# TYPE nginx_markdown_input_bytes_total counter\n"
+        "nginx_markdown_input_bytes_total %lu\n"
+        "\n",
+        s->input_bytes);
+
+    /* output_bytes_total */
+    PROM_WRITE(
+        "# HELP nginx_markdown_output_bytes_total "
+        "Cumulative Markdown output bytes from "
+        "successful conversions.\n"
+        "# TYPE nginx_markdown_output_bytes_total counter\n"
+        "nginx_markdown_output_bytes_total %lu\n"
+        "\n",
+        s->output_bytes);
+
+    /* estimated_token_savings_total */
+    PROM_WRITE(
+        "# HELP "
+        "nginx_markdown_estimated_token_savings_total "
+        "Estimated cumulative token savings "
+        "(requires markdown_token_estimate on).\n"
+        "# TYPE "
+        "nginx_markdown_estimated_token_savings_total "
+        "counter\n"
+        "nginx_markdown_estimated_token_savings_total"
+        " %lu\n"
+        "\n",
+        s->estimated_token_savings);
+
+    /* decompressions_total{format=...} */
+    PROM_WRITE(
+        "# HELP nginx_markdown_decompressions_total "
+        "Decompression operations by format.\n"
+        "# TYPE nginx_markdown_decompressions_total "
+        "counter\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"gzip\"} %lu\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"deflate\"} %lu\n"
+        "nginx_markdown_decompressions_total"
+        "{format=\"brotli\"} %lu\n"
+        "\n",
+        s->decompressions.gzip,
+        s->decompressions.deflate,
+        s->decompressions.brotli);
+
+    /* decompression_failures_total */
+    PROM_WRITE(
+        "# HELP "
+        "nginx_markdown_decompression_failures_total "
+        "Failed decompression attempts.\n"
+        "# TYPE "
+        "nginx_markdown_decompression_failures_total "
+        "counter\n"
+        "nginx_markdown_decompression_failures_total"
+        " %lu\n"
+        "\n",
+        s->decompressions.failed);
+
+    /* conversion_duration_seconds{le=...} */
+    PROM_WRITE(
+        "# HELP "
+        "nginx_markdown_conversion_duration_seconds "
+        "Cumulative conversion count per latency bucket "
+        "(not a native Prometheus histogram; "
+        "no _sum/_count).\n"
+        "# TYPE "
+        "nginx_markdown_conversion_duration_seconds gauge\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"0.01\"} %lu\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"0.1\"} %lu\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"1.0\"} %lu\n"
+        "nginx_markdown_conversion_duration_seconds"
+        "{le=\"+Inf\"} %lu\n",
+        s->conversion_latency_le_10ms,
+        s->conversion_latency_le_100ms,
+        s->conversion_latency_le_1000ms,
+        s->conversion_latency_gt_1000ms);
+
+#undef PROM_WRITE
+
+    return total;
+}
+
+/* ------------------------------------------------------------------ */
+/* Metric family names (13 families)                                   */
+/* ------------------------------------------------------------------ */
+
+static const char *metric_families[] = {
+    "nginx_markdown_requests_total",
+    "nginx_markdown_conversions_total",
+    "nginx_markdown_passthrough_total",
+    "nginx_markdown_skips_total",
+    "nginx_markdown_failures_total",
+    "nginx_markdown_failopen_total",
+    "nginx_markdown_large_response_path_total",
+    "nginx_markdown_input_bytes_total",
+    "nginx_markdown_output_bytes_total",
+    "nginx_markdown_estimated_token_savings_total",
+    "nginx_markdown_decompressions_total",
+    "nginx_markdown_decompression_failures_total",
+    "nginx_markdown_conversion_duration_seconds"
+};
+
+#define NUM_FAMILIES 13
+
+/* ------------------------------------------------------------------ */
+/* Reason, stage, and format label value sets                          */
+/* ------------------------------------------------------------------ */
+
+static const char *reason_values[] = {
+    "SKIP_METHOD", "SKIP_STATUS", "SKIP_CONTENT_TYPE",
+    "SKIP_SIZE", "SKIP_STREAMING", "SKIP_AUTH",
+    "SKIP_RANGE", "SKIP_ACCEPT", "SKIP_CONFIG"
+};
+#define NUM_REASONS 9
+
+static const char *stage_values[] = {
+    "FAIL_CONVERSION", "FAIL_RESOURCE_LIMIT",
+    "FAIL_SYSTEM"
+};
+#define NUM_STAGES 3
+
+static const char *format_values[] = {
+    "gzip", "deflate", "brotli"
+};
+#define NUM_FORMATS 3
+
+/* ------------------------------------------------------------------ */
+/* Helper: check if a string contains a substring                      */
+/* ------------------------------------------------------------------ */
+
+static int
+contains(const char *haystack, const char *needle)
+{
+    return strstr(haystack, needle) != NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: zeroed snapshot produces valid output with zero values         */
+/* ------------------------------------------------------------------ */
+
+static void
+test_zeroed_snapshot(void)
+{
+    char buf[8192];
+    snapshot_t s;
+
+    TEST_SUBSECTION("Zeroed snapshot produces valid "
+                    "Prometheus format");
+
+    memset(&s, 0, sizeof(s));
+    format_prometheus(&s, buf, sizeof(buf));
+
+    /* Every metric value line should have " 0" */
+    TEST_ASSERT(
+        contains(buf, "nginx_markdown_requests_total 0"),
+        "requests_total should be 0");
+    TEST_ASSERT(
+        contains(buf, "nginx_markdown_conversions_total 0"),
+        "conversions_total should be 0");
+    TEST_ASSERT(
+        contains(buf, "nginx_markdown_passthrough_total 0"),
+        "passthrough_total should be 0");
+    TEST_ASSERT(
+        contains(buf, "nginx_markdown_failopen_total 0"),
+        "failopen_total should be 0");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_estimated_token_savings_total 0"),
+        "estimated_token_savings_total should be 0");
+
+    TEST_PASS("Zeroed snapshot produces valid output");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: known-value snapshot matches expected text                     */
+/* ------------------------------------------------------------------ */
+
+static void
+test_known_values(void)
+{
+    char buf[8192];
+    snapshot_t s;
+
+    TEST_SUBSECTION("Known-value snapshot matches expected "
+                    "Prometheus text");
+
+    memset(&s, 0, sizeof(s));
+    s.requests_entered = 100;
+    s.conversions_succeeded = 80;
+    s.conversions_bypassed = 15;
+    s.skips.method = 3;
+    s.skips.status = 2;
+    s.skips.content_type = 5;
+    s.skips.accept = 1;
+    s.failures_conversion = 4;
+    s.failures_resource_limit = 1;
+    s.failopen_count = 3;
+    s.incremental_path_hits = 7;
+    s.input_bytes = 500000;
+    s.output_bytes = 250000;
+    s.estimated_token_savings = 12000;
+    s.decompressions.gzip = 20;
+    s.decompressions.deflate = 5;
+    s.decompressions.brotli = 3;
+    s.decompressions.failed = 1;
+    s.conversion_latency_le_10ms = 40;
+    s.conversion_latency_le_100ms = 30;
+    s.conversion_latency_le_1000ms = 8;
+    s.conversion_latency_gt_1000ms = 2;
+
+    format_prometheus(&s, buf, sizeof(buf));
+
+    TEST_ASSERT(
+        contains(buf, "nginx_markdown_requests_total 100"),
+        "requests_total should be 100");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_conversions_total 80"),
+        "conversions_total should be 80");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_skips_total"
+            "{reason=\"SKIP_METHOD\"} 3"),
+        "skips method should be 3");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_failures_total"
+            "{stage=\"FAIL_CONVERSION\"} 4"),
+        "failures conversion should be 4");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_failopen_total 3"),
+        "failopen_total should be 3");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_input_bytes_total 500000"),
+        "input_bytes_total should be 500000");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_decompressions_total"
+            "{format=\"gzip\"} 20"),
+        "decompressions gzip should be 20");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_conversion_duration_seconds"
+            "{le=\"0.01\"} 40"),
+        "latency le 0.01 should be 40");
+    TEST_ASSERT(
+        contains(buf,
+            "nginx_markdown_conversion_duration_seconds"
+            "{le=\"+Inf\"} 2"),
+        "latency le +Inf should be 2");
+
+    TEST_PASS("Known-value snapshot matches expected text");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: every metric family has HELP and TYPE lines                    */
+/* ------------------------------------------------------------------ */
+
+static void
+test_help_and_type_lines(void)
+{
+    char buf[8192];
+    char help_prefix[128];
+    char type_prefix[128];
+    snapshot_t s;
+    size_t i;
+
+    TEST_SUBSECTION("Every metric family has HELP and "
+                    "TYPE lines");
+
+    memset(&s, 0, sizeof(s));
+    format_prometheus(&s, buf, sizeof(buf));
+
+    for (i = 0; i < NUM_FAMILIES; i++) {
+        snprintf(help_prefix, sizeof(help_prefix),
+                 "# HELP %s ", metric_families[i]);
+        snprintf(type_prefix, sizeof(type_prefix),
+                 "# TYPE %s ", metric_families[i]);
+
+        TEST_ASSERT(contains(buf, help_prefix),
+                    "Missing HELP line for metric family");
+        TEST_ASSERT(contains(buf, type_prefix),
+                    "Missing TYPE line for metric family");
+    }
+
+    TEST_PASS("All 13 metric families have HELP and "
+              "TYPE lines");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: counter metrics end with _total                               */
+/* ------------------------------------------------------------------ */
+
+static void
+test_counter_suffix(void)
+{
+    char buf[8192];
+    char type_line[128];
+    snapshot_t s;
+    size_t i;
+
+    TEST_SUBSECTION("Counter metrics end with _total");
+
+    memset(&s, 0, sizeof(s));
+    format_prometheus(&s, buf, sizeof(buf));
+
+    for (i = 0; i < NUM_FAMILIES; i++) {
+        snprintf(type_line, sizeof(type_line),
+                 "# TYPE %s counter", metric_families[i]);
+        if (contains(buf, type_line)) {
+            /* This is a counter — name must end with _total */
+            size_t name_len = strlen(metric_families[i]);
+            TEST_ASSERT(
+                name_len >= 6
+                && strcmp(metric_families[i] + name_len - 6,
+                          "_total") == 0,
+                "Counter metric must end with _total");
+        }
+    }
+
+    TEST_PASS("All counter metrics end with _total");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: label values match defined sets                                */
+/* ------------------------------------------------------------------ */
+
+static void
+test_label_values(void)
+{
+    char buf[8192];
+    char label_str[128];
+    snapshot_t s;
+    size_t i;
+
+    TEST_SUBSECTION("Label values match defined sets");
+
+    memset(&s, 0, sizeof(s));
+    format_prometheus(&s, buf, sizeof(buf));
+
+    /* Check all reason labels present */
+    for (i = 0; i < NUM_REASONS; i++) {
+        snprintf(label_str, sizeof(label_str),
+                 "reason=\"%s\"", reason_values[i]);
+        TEST_ASSERT(contains(buf, label_str),
+                    "Missing reason label value");
+    }
+
+    /* Check all stage labels present */
+    for (i = 0; i < NUM_STAGES; i++) {
+        snprintf(label_str, sizeof(label_str),
+                 "stage=\"%s\"", stage_values[i]);
+        TEST_ASSERT(contains(buf, label_str),
+                    "Missing stage label value");
+    }
+
+    /* Check all format labels present */
+    for (i = 0; i < NUM_FORMATS; i++) {
+        snprintf(label_str, sizeof(label_str),
+                 "format=\"%s\"", format_values[i]);
+        TEST_ASSERT(contains(buf, label_str),
+                    "Missing format label value");
+    }
+
+    TEST_PASS("All label values match defined sets");
+}
+
+/* ------------------------------------------------------------------ */
+/* Test: estimated_token_savings_total HELP contains "estimate"        */
+/* ------------------------------------------------------------------ */
+
+static void
+test_token_savings_help_text(void)
+{
+    char buf[8192];
+    char *help_start;
+    char *help_end;
+    snapshot_t s;
+
+    TEST_SUBSECTION("estimated_token_savings_total HELP "
+                    "contains estimate");
+
+    memset(&s, 0, sizeof(s));
+    format_prometheus(&s, buf, sizeof(buf));
+
+    help_start = strstr(buf,
+        "# HELP "
+        "nginx_markdown_estimated_token_savings_total");
+    TEST_ASSERT(help_start != NULL,
+                "HELP line for estimated_token_savings_total "
+                "must exist");
+
+    /* Find end of this HELP line */
+    help_end = strchr(help_start, '\n');
+    TEST_ASSERT(help_end != NULL,
+                "HELP line must end with newline");
+
+    /* Temporarily null-terminate the line for search */
+    *help_end = '\0';
+    TEST_ASSERT(
+        strstr(help_start, "stimate") != NULL,
+        "HELP text must contain the word estimate");
+    *help_end = '\n';
+
+    TEST_PASS("HELP text contains estimate");
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("prometheus_format Tests\n");
+    printf("========================================\n");
+
+    test_zeroed_snapshot();
+    test_known_values();
+    test_help_and_type_lines();
+    test_counter_suffix();
+    test_label_values();
+    test_token_savings_help_text();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}

--- a/components/nginx-module/tests/unit/skip_counter_test.c
+++ b/components/nginx-module/tests/unit/skip_counter_test.c
@@ -62,7 +62,6 @@ metric_inc_skip(eligibility_t eligibility)
         return;
 
     case INELIGIBLE_CONFIG:
-    default:
         g_metrics->skips.config++;
         return;
 
@@ -92,6 +91,10 @@ metric_inc_skip(eligibility_t eligibility)
 
     case INELIGIBLE_RANGE:
         g_metrics->skips.range++;
+        return;
+
+    default:
+        g_metrics->skips.config++;
         return;
     }
 }

--- a/components/nginx-module/tests/unit/skip_counter_test.c
+++ b/components/nginx-module/tests/unit/skip_counter_test.c
@@ -1,0 +1,292 @@
+/*
+ * Test: skip_counter
+ * Description: skip-reason counter mapping from eligibility enum
+ *
+ * Verifies that ngx_http_markdown_metric_inc_skip() maps each
+ * ngx_http_markdown_eligibility_t enum value to the correct
+ * skips.* counter field.
+ */
+
+#include "test_common.h"
+
+/*
+ * Eligibility enum values mirroring
+ * ngx_http_markdown_eligibility_t from the module header.
+ */
+#define ELIGIBLE                0
+#define INELIGIBLE_METHOD       1
+#define INELIGIBLE_STATUS       2
+#define INELIGIBLE_CONTENT_TYPE 3
+#define INELIGIBLE_SIZE         4
+#define INELIGIBLE_STREAMING    5
+#define INELIGIBLE_AUTH         6
+#define INELIGIBLE_RANGE        7
+#define INELIGIBLE_CONFIG       8
+
+typedef int eligibility_t;
+
+/*
+ * Minimal metrics struct mirroring the skips sub-struct
+ * from ngx_http_markdown_metrics_t.
+ */
+typedef struct {
+    struct {
+        unsigned long config;
+        unsigned long method;
+        unsigned long status;
+        unsigned long content_type;
+        unsigned long size;
+        unsigned long streaming;
+        unsigned long auth;
+        unsigned long range;
+        unsigned long accept;
+    } skips;
+} metrics_t;
+
+static metrics_t *g_metrics = NULL;
+
+/*
+ * Standalone reimplementation of the skip-reason increment
+ * function matching the logic in module_state_impl.h.
+ */
+static void
+metric_inc_skip(eligibility_t eligibility)
+{
+    if (g_metrics == NULL) {
+        return;
+    }
+
+    switch (eligibility) {
+
+    case ELIGIBLE:
+        return;
+
+    case INELIGIBLE_CONFIG:
+        g_metrics->skips.config++;
+        return;
+
+    case INELIGIBLE_METHOD:
+        g_metrics->skips.method++;
+        return;
+
+    case INELIGIBLE_STATUS:
+        g_metrics->skips.status++;
+        return;
+
+    case INELIGIBLE_CONTENT_TYPE:
+        g_metrics->skips.content_type++;
+        return;
+
+    case INELIGIBLE_SIZE:
+        g_metrics->skips.size++;
+        return;
+
+    case INELIGIBLE_STREAMING:
+        g_metrics->skips.streaming++;
+        return;
+
+    case INELIGIBLE_AUTH:
+        g_metrics->skips.auth++;
+        return;
+
+    case INELIGIBLE_RANGE:
+        g_metrics->skips.range++;
+        return;
+
+    default:
+        g_metrics->skips.config++;
+        return;
+    }
+}
+
+static void
+reset_metrics(metrics_t *m)
+{
+    memset(m, 0, sizeof(metrics_t));
+}
+
+static void
+test_eligible_is_noop(void)
+{
+    metrics_t m;
+
+    TEST_SUBSECTION("ELIGIBLE is a no-op");
+
+    reset_metrics(&m);
+    g_metrics = &m;
+
+    metric_inc_skip(ELIGIBLE);
+
+    TEST_ASSERT(m.skips.config == 0,
+                "config should be 0");
+    TEST_ASSERT(m.skips.method == 0,
+                "method should be 0");
+    TEST_ASSERT(m.skips.status == 0,
+                "status should be 0");
+    TEST_ASSERT(m.skips.content_type == 0,
+                "content_type should be 0");
+    TEST_ASSERT(m.skips.size == 0,
+                "size should be 0");
+    TEST_ASSERT(m.skips.streaming == 0,
+                "streaming should be 0");
+    TEST_ASSERT(m.skips.auth == 0,
+                "auth should be 0");
+    TEST_ASSERT(m.skips.range == 0,
+                "range should be 0");
+    TEST_ASSERT(m.skips.accept == 0,
+                "accept should be 0");
+
+    g_metrics = NULL;
+    TEST_PASS("ELIGIBLE does not increment any counter");
+}
+
+static void
+test_each_enum_maps_correctly(void)
+{
+    metrics_t m;
+
+    TEST_SUBSECTION("Each eligibility enum maps to correct counter");
+
+    /* INELIGIBLE_METHOD -> skips.method */
+    reset_metrics(&m);
+    g_metrics = &m;
+    metric_inc_skip(INELIGIBLE_METHOD);
+    TEST_ASSERT(m.skips.method == 1,
+                "METHOD should increment skips.method");
+    TEST_ASSERT(m.skips.config == 0,
+                "METHOD should not touch config");
+
+    /* INELIGIBLE_STATUS -> skips.status */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_STATUS);
+    TEST_ASSERT(m.skips.status == 1,
+                "STATUS should increment skips.status");
+
+    /* INELIGIBLE_CONTENT_TYPE -> skips.content_type */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_CONTENT_TYPE);
+    TEST_ASSERT(m.skips.content_type == 1,
+                "CONTENT_TYPE should increment skips.content_type");
+
+    /* INELIGIBLE_SIZE -> skips.size */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_SIZE);
+    TEST_ASSERT(m.skips.size == 1,
+                "SIZE should increment skips.size");
+
+    /* INELIGIBLE_STREAMING -> skips.streaming */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_STREAMING);
+    TEST_ASSERT(m.skips.streaming == 1,
+                "STREAMING should increment skips.streaming");
+
+    /* INELIGIBLE_AUTH -> skips.auth */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_AUTH);
+    TEST_ASSERT(m.skips.auth == 1,
+                "AUTH should increment skips.auth");
+
+    /* INELIGIBLE_RANGE -> skips.range */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_RANGE);
+    TEST_ASSERT(m.skips.range == 1,
+                "RANGE should increment skips.range");
+
+    /* INELIGIBLE_CONFIG -> skips.config */
+    reset_metrics(&m);
+    metric_inc_skip(INELIGIBLE_CONFIG);
+    TEST_ASSERT(m.skips.config == 1,
+                "CONFIG should increment skips.config");
+
+    g_metrics = NULL;
+    TEST_PASS("All enum values map to correct counters");
+}
+
+static void
+test_unknown_falls_back_to_config(void)
+{
+    metrics_t m;
+
+    TEST_SUBSECTION("Unknown enum values fall back to skips.config");
+
+    reset_metrics(&m);
+    g_metrics = &m;
+
+    /* Use a value outside the known enum range */
+    metric_inc_skip(99);
+
+    TEST_ASSERT(m.skips.config == 1,
+                "unknown value should increment skips.config");
+    TEST_ASSERT(m.skips.method == 0,
+                "unknown value should not touch method");
+    TEST_ASSERT(m.skips.status == 0,
+                "unknown value should not touch status");
+
+    g_metrics = NULL;
+    TEST_PASS("Unknown enum falls back to skips.config");
+}
+
+static void
+test_null_metrics_is_safe(void)
+{
+    TEST_SUBSECTION("NULL metrics pointer is safe");
+
+    g_metrics = NULL;
+
+    /* Should not crash */
+    metric_inc_skip(INELIGIBLE_METHOD);
+    metric_inc_skip(INELIGIBLE_CONFIG);
+    metric_inc_skip(99);
+
+    TEST_PASS("No crash with NULL metrics pointer");
+}
+
+static void
+test_multiple_increments_accumulate(void)
+{
+    metrics_t m;
+
+    TEST_SUBSECTION("Multiple increments accumulate");
+
+    reset_metrics(&m);
+    g_metrics = &m;
+
+    metric_inc_skip(INELIGIBLE_METHOD);
+    metric_inc_skip(INELIGIBLE_METHOD);
+    metric_inc_skip(INELIGIBLE_METHOD);
+
+    TEST_ASSERT(m.skips.method == 3,
+                "three METHOD calls should give 3");
+
+    metric_inc_skip(INELIGIBLE_STATUS);
+    metric_inc_skip(INELIGIBLE_AUTH);
+
+    TEST_ASSERT(m.skips.status == 1,
+                "one STATUS call should give 1");
+    TEST_ASSERT(m.skips.auth == 1,
+                "one AUTH call should give 1");
+    TEST_ASSERT(m.skips.method == 3,
+                "method should still be 3");
+
+    g_metrics = NULL;
+    TEST_PASS("Counters accumulate correctly");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("skip_counter Tests\n");
+    printf("========================================\n");
+
+    test_eligible_is_noop();
+    test_each_enum_maps_correctly();
+    test_unknown_falls_back_to_config();
+    test_null_metrics_is_safe();
+    test_multiple_increments_accumulate();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}

--- a/components/nginx-module/tests/unit/skip_counter_test.c
+++ b/components/nginx-module/tests/unit/skip_counter_test.c
@@ -62,6 +62,7 @@ metric_inc_skip(eligibility_t eligibility)
         return;
 
     case INELIGIBLE_CONFIG:
+    default:
         g_metrics->skips.config++;
         return;
 
@@ -91,10 +92,6 @@ metric_inc_skip(eligibility_t eligibility)
 
     case INELIGIBLE_RANGE:
         g_metrics->skips.range++;
-        return;
-
-    default:
-        g_metrics->skips.config++;
         return;
     }
 }

--- a/components/nginx-module/tests/unit/skip_counter_test.c
+++ b/components/nginx-module/tests/unit/skip_counter_test.c
@@ -61,10 +61,6 @@ metric_inc_skip(eligibility_t eligibility)
     case ELIGIBLE:
         return;
 
-    case INELIGIBLE_CONFIG:
-        g_metrics->skips.config++;
-        return;
-
     case INELIGIBLE_METHOD:
         g_metrics->skips.method++;
         return;
@@ -93,6 +89,7 @@ metric_inc_skip(eligibility_t eligibility)
         g_metrics->skips.range++;
         return;
 
+    case INELIGIBLE_CONFIG:
     default:
         g_metrics->skips.config++;
         return;

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -74,10 +74,10 @@ When `markdown_metrics_format prometheus` is configured:
 | Accept Header | Output Format |
 |---|---|
 | `application/json` | JSON |
-| `text/plain` | Prometheus |
 | `text/plain; version=0.0.4` | Prometheus |
 | `application/openmetrics-text` | Prometheus |
-| (any other / none) | Prometheus |
+| `text/plain` | Plain text (backward compatible) |
+| (any other / none) | Plain text (backward compatible) |
 
 When `markdown_metrics_format auto` (default):
 
@@ -87,7 +87,7 @@ When `markdown_metrics_format auto` (default):
 | `text/plain` | Plain text (existing human-readable format) |
 | (any other / none) | Plain text (existing human-readable format) |
 
-No external dependencies, sidecars, or agents are required. The module renders Prometheus format directly.
+Prometheus format is served only when the client explicitly requests it via `Accept: text/plain; version=0.0.4` or `Accept: application/openmetrics-text`. Plain `text/plain` without the version parameter falls back to the legacy human-readable format, preserving backward compatibility for operators who curl without a specific Accept header. No external dependencies, sidecars, or agents are required.
 
 ---
 
@@ -102,8 +102,8 @@ scrape_configs:
     metrics_path: '/markdown-metrics'
     static_configs:
       - targets: ['localhost:80']
-    # No special Accept header needed — Prometheus format is the default
-    # when markdown_metrics_format is set to prometheus.
+    # Prometheus sends Accept: application/openmetrics-text by default,
+    # which the module recognizes when markdown_metrics_format is prometheus.
 ```
 
 If NGINX listens on a non-standard port or the metrics location uses a different path, adjust `targets` and `metrics_path` accordingly.
@@ -130,7 +130,7 @@ All metrics use the `nginx_markdown_` prefix. Counter metrics use the `_total` s
 |---|---|---|
 | `nginx_markdown_requests_total` | counter | Total requests entering the module decision chain. This is the denominator for conversion rate calculations. |
 | `nginx_markdown_conversions_total` | counter | Successful HTML-to-Markdown conversions. |
-| `nginx_markdown_passthrough_total` | counter | Requests not converted (skipped or failed-open). |
+| `nginx_markdown_passthrough_total` | counter | Requests not converted (skipped or failed-open). Derived as the sum of all skip-reason counters plus fail-open count. |
 | `nginx_markdown_failopen_total` | counter | Conversions failed with original HTML served (`markdown_on_error pass`). |
 | `nginx_markdown_large_response_path_total` | counter | Requests routed to the incremental processing path. |
 | `nginx_markdown_input_bytes_total` | counter | Cumulative HTML input bytes from successful conversions. |
@@ -173,8 +173,8 @@ Use `curl` to verify the endpoint is producing valid Prometheus output.
 ### Basic Scrape
 
 ```bash
-# Scrape Prometheus format (default when markdown_metrics_format is prometheus)
-curl http://localhost/markdown-metrics
+# Scrape Prometheus format (requires explicit Accept header)
+curl -H "Accept: text/plain; version=0.0.4" http://localhost/markdown-metrics
 ```
 
 ### Explicit Accept Header
@@ -216,7 +216,6 @@ nginx_markdown_passthrough_total 70
 
 # HELP nginx_markdown_skips_total Requests skipped by reason.
 # TYPE nginx_markdown_skips_total counter
-nginx_markdown_skips_total{reason="SKIP_CONFIG"} 5
 nginx_markdown_skips_total{reason="SKIP_METHOD"} 10
 nginx_markdown_skips_total{reason="SKIP_STATUS"} 3
 nginx_markdown_skips_total{reason="SKIP_CONTENT_TYPE"} 20
@@ -225,6 +224,7 @@ nginx_markdown_skips_total{reason="SKIP_STREAMING"} 0
 nginx_markdown_skips_total{reason="SKIP_AUTH"} 8
 nginx_markdown_skips_total{reason="SKIP_RANGE"} 0
 nginx_markdown_skips_total{reason="SKIP_ACCEPT"} 15
+nginx_markdown_skips_total{reason="SKIP_CONFIG"} 5
 
 # HELP nginx_markdown_failures_total Conversion failures by stage.
 # TYPE nginx_markdown_failures_total counter

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -1,0 +1,430 @@
+# Prometheus Metrics Guide
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Enabling Prometheus Format](#enabling-prometheus-format)
+3. [Scrape Configuration](#scrape-configuration)
+4. [Metric Catalog](#metric-catalog)
+5. [Verifying the Endpoint](#verifying-the-endpoint)
+6. [Prometheus Labels and Decision Log Reason Codes](#prometheus-labels-and-decision-log-reason-codes)
+7. [Interpreting Metrics for Rollout Judgment](#interpreting-metrics-for-rollout-judgment)
+8. [Token Savings Estimate](#token-savings-estimate)
+9. [Metric Stability Policy](#metric-stability-policy)
+
+---
+
+## Overview
+
+The NGINX Markdown filter module exposes module-level operational metrics via the existing `markdown_metrics` endpoint. Starting with version 0.4.0, the endpoint supports Prometheus text exposition format (`text/plain; version=0.0.4; charset=utf-8`) as an opt-in output format alongside the existing JSON and plain-text formats.
+
+These metrics help operators answer three questions:
+
+1. **Is the module working?** — Conversion success rate, failure breakdown, skip reasons.
+2. **How effective is it?** — Byte reduction ratio, estimated token savings, conversion throughput.
+3. **Is it safe to continue rollout?** — Fail-open rate, error trends, latency distribution.
+
+Only module-internal semantics that generic NGINX exporters (such as `nginx-prometheus-exporter`) cannot recover are exposed. This is not a replacement for general NGINX monitoring.
+
+### Target Audience
+
+- Site Reliability Engineers (SREs)
+- DevOps Engineers
+- System Administrators operating the NGINX Markdown filter module
+
+### Related Documents
+
+- [CONFIGURATION.md](CONFIGURATION.md) — Full directive reference
+- [OPERATIONS.md](OPERATIONS.md) — General operational guide and metrics reference
+- [ROLLOUT_COOKBOOK.md](ROLLOUT_COOKBOOK.md) — Rollout planning and phased deployment
+
+---
+
+## Enabling Prometheus Format
+
+Prometheus text exposition format is off by default. To enable it, add the `markdown_metrics_format` directive to the location block that serves the metrics endpoint.
+
+### Configuration
+
+```nginx
+location /markdown-metrics {
+    markdown_metrics;
+    markdown_metrics_format prometheus;
+
+    # Restrict access to localhost only
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+}
+```
+
+### Directive Reference
+
+| Directive | Values | Default | Context |
+|---|---|---|---|
+| `markdown_metrics_format` | `auto` \| `prometheus` | `auto` | http, server, location |
+
+- `auto` — Existing behavior. JSON for `Accept: application/json`, plain text otherwise. Backward compatible with 0.3.0.
+- `prometheus` — Prometheus text exposition format for non-JSON requests. `Accept: application/json` still returns JSON.
+
+### Content Negotiation Behavior
+
+When `markdown_metrics_format prometheus` is configured:
+
+| Accept Header | Output Format |
+|---|---|
+| `application/json` | JSON |
+| `text/plain` | Prometheus |
+| `text/plain; version=0.0.4` | Prometheus |
+| `application/openmetrics-text` | Prometheus |
+| (any other / none) | Prometheus |
+
+When `markdown_metrics_format auto` (default):
+
+| Accept Header | Output Format |
+|---|---|
+| `application/json` | JSON |
+| `text/plain` | Plain text (existing human-readable format) |
+| (any other / none) | Plain text (existing human-readable format) |
+
+No external dependencies, sidecars, or agents are required. The module renders Prometheus format directly.
+
+---
+
+## Scrape Configuration
+
+### Prometheus `prometheus.yml` Example
+
+```yaml
+scrape_configs:
+  - job_name: 'nginx-markdown'
+    scrape_interval: 15s
+    metrics_path: '/markdown-metrics'
+    static_configs:
+      - targets: ['localhost:80']
+    # No special Accept header needed — Prometheus format is the default
+    # when markdown_metrics_format is set to prometheus.
+```
+
+If NGINX listens on a non-standard port or the metrics location uses a different path, adjust `targets` and `metrics_path` accordingly.
+
+### Access Control
+
+The metrics endpoint enforces localhost-only access by default. Prometheus must scrape from the same host (or via a local proxy).
+
+**Security recommendations:**
+
+- Expose the metrics endpoint only on internal networks.
+- Use NGINX `allow`/`deny` directives for additional access control.
+- Do not expose the metrics endpoint on the public internet.
+
+---
+
+## Metric Catalog
+
+All metrics use the `nginx_markdown_` prefix. Counter metrics use the `_total` suffix. Byte-valued counters use `_bytes_total`.
+
+### Counter Metrics (no labels)
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `nginx_markdown_requests_total` | counter | Total requests entering the module decision chain. This is the denominator for conversion rate calculations. |
+| `nginx_markdown_conversions_total` | counter | Successful HTML-to-Markdown conversions. |
+| `nginx_markdown_passthrough_total` | counter | Requests not converted (skipped or failed-open). |
+| `nginx_markdown_failopen_total` | counter | Conversions failed with original HTML served (`markdown_on_error pass`). |
+| `nginx_markdown_large_response_path_total` | counter | Requests routed to the incremental processing path. |
+| `nginx_markdown_input_bytes_total` | counter | Cumulative HTML input bytes from successful conversions. |
+| `nginx_markdown_output_bytes_total` | counter | Cumulative Markdown output bytes from successful conversions. |
+| `nginx_markdown_estimated_token_savings_total` | counter | Estimated cumulative token savings. Requires `markdown_token_estimate on` to produce non-zero values. See [Token Savings Estimate](#token-savings-estimate). |
+| `nginx_markdown_decompression_failures_total` | counter | Failed decompression attempts. |
+
+### Counter Metrics (with labels)
+
+| Metric Name | Type | Label Key | Label Values | Description |
+|---|---|---|---|---|
+| `nginx_markdown_skips_total` | counter | `reason` | `SKIP_CONFIG`, `SKIP_METHOD`, `SKIP_STATUS`, `SKIP_CONTENT_TYPE`, `SKIP_SIZE`, `SKIP_STREAMING`, `SKIP_AUTH`, `SKIP_RANGE`, `SKIP_ACCEPT` | Requests skipped by reason. |
+| `nginx_markdown_failures_total` | counter | `stage` | `FAIL_CONVERSION`, `FAIL_RESOURCE_LIMIT`, `FAIL_SYSTEM` | Conversion failures by stage. |
+| `nginx_markdown_decompressions_total` | counter | `format` | `gzip`, `deflate`, `brotli` | Decompression operations by compression format. |
+
+### Gauge Metrics (latency buckets)
+
+| Metric Name | Type | Label Key | Label Values | Description |
+|---|---|---|---|---|
+| `nginx_markdown_conversion_duration_seconds` | gauge | `le` | `0.01`, `0.1`, `1.0`, `+Inf` | Cumulative conversion count per latency bucket. Each bucket value is an independent atomic counter, not a native Prometheus histogram. |
+
+### Total Time Series
+
+The endpoint produces exactly 32 unique time series:
+
+- 9 unlabeled counters
+- 9 skip reason labels
+- 3 failure stage labels
+- 3 decompression format labels
+- 4 latency bucket labels
+- 4 additional metric lines (decompression failures, failopen, large response path, token savings are counted in the 9 unlabeled above)
+
+This count is deterministic and bounded. No request-specific or high-cardinality labels are used.
+
+---
+
+## Verifying the Endpoint
+
+Use `curl` to verify the endpoint is producing valid Prometheus output.
+
+### Basic Scrape
+
+```bash
+# Scrape Prometheus format (default when markdown_metrics_format is prometheus)
+curl http://localhost/markdown-metrics
+```
+
+### Explicit Accept Header
+
+```bash
+# Request Prometheus format explicitly
+curl -H "Accept: text/plain; version=0.0.4" http://localhost/markdown-metrics
+```
+
+### JSON Format (still available)
+
+```bash
+# JSON output is always available regardless of markdown_metrics_format setting
+curl -H "Accept: application/json" http://localhost/markdown-metrics
+```
+
+### Validate with promtool
+
+If you have the Prometheus `promtool` CLI installed, validate the output:
+
+```bash
+curl -s http://localhost/markdown-metrics | promtool check metrics
+```
+
+### Example Output
+
+```
+# HELP nginx_markdown_requests_total Total requests entering the module decision chain.
+# TYPE nginx_markdown_requests_total counter
+nginx_markdown_requests_total 1250
+
+# HELP nginx_markdown_conversions_total Successful HTML-to-Markdown conversions.
+# TYPE nginx_markdown_conversions_total counter
+nginx_markdown_conversions_total 1180
+
+# HELP nginx_markdown_passthrough_total Requests not converted (skipped or failed-open).
+# TYPE nginx_markdown_passthrough_total counter
+nginx_markdown_passthrough_total 70
+
+# HELP nginx_markdown_skips_total Requests skipped by reason.
+# TYPE nginx_markdown_skips_total counter
+nginx_markdown_skips_total{reason="SKIP_CONFIG"} 5
+nginx_markdown_skips_total{reason="SKIP_METHOD"} 10
+nginx_markdown_skips_total{reason="SKIP_STATUS"} 3
+nginx_markdown_skips_total{reason="SKIP_CONTENT_TYPE"} 20
+nginx_markdown_skips_total{reason="SKIP_SIZE"} 2
+nginx_markdown_skips_total{reason="SKIP_STREAMING"} 0
+nginx_markdown_skips_total{reason="SKIP_AUTH"} 8
+nginx_markdown_skips_total{reason="SKIP_RANGE"} 0
+nginx_markdown_skips_total{reason="SKIP_ACCEPT"} 15
+
+# HELP nginx_markdown_failures_total Conversion failures by stage.
+# TYPE nginx_markdown_failures_total counter
+nginx_markdown_failures_total{stage="FAIL_CONVERSION"} 3
+nginx_markdown_failures_total{stage="FAIL_RESOURCE_LIMIT"} 4
+nginx_markdown_failures_total{stage="FAIL_SYSTEM"} 0
+
+# HELP nginx_markdown_failopen_total Conversions failed with original HTML served (fail-open).
+# TYPE nginx_markdown_failopen_total counter
+nginx_markdown_failopen_total 7
+
+# HELP nginx_markdown_large_response_path_total Requests routed to incremental processing path.
+# TYPE nginx_markdown_large_response_path_total counter
+nginx_markdown_large_response_path_total 12
+
+# HELP nginx_markdown_input_bytes_total Cumulative HTML input bytes from successful conversions.
+# TYPE nginx_markdown_input_bytes_total counter
+nginx_markdown_input_bytes_total 52428800
+
+# HELP nginx_markdown_output_bytes_total Cumulative Markdown output bytes from successful conversions.
+# TYPE nginx_markdown_output_bytes_total counter
+nginx_markdown_output_bytes_total 15728640
+
+# HELP nginx_markdown_estimated_token_savings_total Estimated cumulative token savings (requires markdown_token_estimate on).
+# TYPE nginx_markdown_estimated_token_savings_total counter
+nginx_markdown_estimated_token_savings_total 15000
+
+# HELP nginx_markdown_decompressions_total Decompression operations by format.
+# TYPE nginx_markdown_decompressions_total counter
+nginx_markdown_decompressions_total{format="gzip"} 160
+nginx_markdown_decompressions_total{format="deflate"} 25
+nginx_markdown_decompressions_total{format="brotli"} 20
+
+# HELP nginx_markdown_decompression_failures_total Failed decompression attempts.
+# TYPE nginx_markdown_decompression_failures_total counter
+nginx_markdown_decompression_failures_total 1
+
+# HELP nginx_markdown_conversion_duration_seconds Cumulative conversion count per latency bucket (not a native Prometheus histogram; no _sum/_count).
+# TYPE nginx_markdown_conversion_duration_seconds gauge
+nginx_markdown_conversion_duration_seconds{le="0.01"} 140
+nginx_markdown_conversion_duration_seconds{le="0.1"} 1030
+nginx_markdown_conversion_duration_seconds{le="1.0"} 1170
+nginx_markdown_conversion_duration_seconds{le="+Inf"} 1180
+```
+
+---
+
+## Prometheus Labels and Decision Log Reason Codes
+
+Prometheus metric label values use the same reason code strings as the module's decision log entries. This alignment allows operators to correlate metric spikes with specific log entries.
+
+### Skip Reason Codes
+
+| Prometheus Label Value | Decision Log Reason | Meaning |
+|---|---|---|
+| `SKIP_CONFIG` | `SKIP_CONFIG` | Module disabled by configuration (`markdown_filter off`) |
+| `SKIP_METHOD` | `SKIP_METHOD` | Request method is not GET or HEAD |
+| `SKIP_STATUS` | `SKIP_STATUS` | Response status is not 200 |
+| `SKIP_CONTENT_TYPE` | `SKIP_CONTENT_TYPE` | Response Content-Type is not `text/html` |
+| `SKIP_SIZE` | `SKIP_SIZE` | Response exceeds `markdown_max_size` |
+| `SKIP_STREAMING` | `SKIP_STREAMING` | Content-Type matches `markdown_stream_types` |
+| `SKIP_AUTH` | `SKIP_AUTH` | Authenticated request with `markdown_auth_policy deny` |
+| `SKIP_RANGE` | `SKIP_RANGE` | Range request (partial content) |
+| `SKIP_ACCEPT` | `SKIP_ACCEPT` | Client Accept header does not include `text/markdown` |
+
+### Failure Stage Codes
+
+| Prometheus Label Value | Decision Log Reason | Meaning |
+|---|---|---|
+| `FAIL_CONVERSION` | `FAIL_CONVERSION` | HTML parsing or Markdown generation failed |
+| `FAIL_RESOURCE_LIMIT` | `FAIL_RESOURCE_LIMIT` | Size limit or timeout exceeded during conversion |
+| `FAIL_SYSTEM` | `FAIL_SYSTEM` | Memory allocation or system error |
+
+### Correlation Example
+
+If `nginx_markdown_skips_total{reason="SKIP_CONTENT_TYPE"}` spikes, search the decision log for entries with `reason=SKIP_CONTENT_TYPE` to identify which specific requests are being skipped and from which upstream paths.
+
+```bash
+# Find decision log entries matching a specific reason code
+grep "SKIP_CONTENT_TYPE" /var/log/nginx/error.log | tail -20
+```
+
+---
+
+## Interpreting Metrics for Rollout Judgment
+
+Use these metrics to assess whether the module is operating correctly during a phased rollout.
+
+### Healthy Patterns
+
+These patterns indicate normal, healthy operation:
+
+- **Conversion rate is stable.** `nginx_markdown_conversions_total / nginx_markdown_requests_total` remains consistent over time (typically 60–90% depending on traffic mix).
+- **Fail-open rate is near zero.** `nginx_markdown_failopen_total` grows slowly or not at all. A small number of fail-opens is acceptable; a sustained rate above 1% warrants investigation.
+- **Skip reasons are expected.** The dominant skip reasons match your deployment (e.g., `SKIP_ACCEPT` is high because most clients do not request Markdown).
+- **Latency is concentrated in fast buckets.** Most conversions fall in the `le="0.01"` and `le="0.1"` buckets. Few or no conversions in the `le="+Inf"` (>1s) bucket.
+- **Byte reduction is positive.** `nginx_markdown_output_bytes_total < nginx_markdown_input_bytes_total`, indicating Markdown output is smaller than HTML input.
+
+### Problem Patterns
+
+These patterns indicate issues that may require action:
+
+- **Rising failure rate.** `sum(nginx_markdown_failures_total)` growing faster than `nginx_markdown_conversions_total`. Check the `stage` label breakdown to identify the failure category.
+- **Fail-open rate above 1%.** `nginx_markdown_failopen_total / nginx_markdown_requests_total > 0.01` sustained over 5 minutes. The module is silently serving HTML instead of Markdown.
+- **Latency drift to slow buckets.** Increasing counts in `le="1.0"` or `le="+Inf"` buckets. May indicate large documents, resource contention, or upstream slowness.
+- **Unexpected skip reason spikes.** A sudden increase in a specific skip reason (e.g., `SKIP_STATUS`) may indicate upstream issues returning non-200 responses.
+- **System errors.** Any non-zero `nginx_markdown_failures_total{stage="FAIL_SYSTEM"}` warrants immediate investigation — these indicate memory allocation or system-level failures.
+
+### Recommended Alerting Thresholds
+
+| Condition | Severity | Threshold | Action |
+|---|---|---|---|
+| Failure rate | Critical | > 10% for 5 min | Page on-call |
+| Failure rate | Warning | > 5% for 10 min | Notify team |
+| System error rate | Critical | > 1% for 5 min | Page on-call |
+| Fail-open rate | Warning | > 1% for 5 min | Investigate |
+| Slow conversions (>1s bucket) | Warning | > 5% of total for 10 min | Investigate |
+| Decompression failure rate | Warning | > 1% of decompressions for 10 min | Investigate |
+
+### PromQL Examples for Dashboards
+
+```promql
+# Conversion success rate (percentage)
+nginx_markdown_conversions_total / clamp_min(nginx_markdown_requests_total, 1) * 100
+
+# Failure rate (percentage)
+sum(nginx_markdown_failures_total) / clamp_min(nginx_markdown_requests_total, 1) * 100
+
+# Fail-open rate (percentage)
+nginx_markdown_failopen_total / clamp_min(nginx_markdown_requests_total, 1) * 100
+
+# Byte reduction ratio (percentage)
+(1 - nginx_markdown_output_bytes_total / clamp_min(nginx_markdown_input_bytes_total, 1)) * 100
+
+# Skip breakdown by reason
+nginx_markdown_skips_total
+
+# Slow conversion ratio (>1s bucket as percentage of total conversions)
+nginx_markdown_conversion_duration_seconds{le="+Inf"} - nginx_markdown_conversion_duration_seconds{le="1.0"}
+/ clamp_min(nginx_markdown_conversion_duration_seconds{le="+Inf"}, 1) * 100
+```
+
+---
+
+## Token Savings Estimate
+
+The `nginx_markdown_estimated_token_savings_total` metric provides a cumulative estimate of token savings achieved by serving Markdown instead of HTML.
+
+### Disclaimer
+
+**This value is an approximation, not a precise tokenizer count.** The estimate is computed using the module's built-in byte-ratio heuristic when `markdown_token_estimate on` is configured. Different LLM tokenizers produce different token counts for the same text. Use this metric as a directional indicator of value, not as an exact measurement.
+
+### Prerequisites
+
+The counter remains at zero unless `markdown_token_estimate on` is configured:
+
+```nginx
+location /docs {
+    markdown_filter on;
+    markdown_token_estimate on;
+}
+```
+
+### Interpretation
+
+- A growing `estimated_token_savings_total` indicates the module is reducing token consumption for AI agent consumers.
+- Compare the growth rate of this counter against `nginx_markdown_conversions_total` to estimate average per-request savings.
+- The estimate is most useful as a trend indicator over time, not as an absolute value.
+
+---
+
+## Metric Stability Policy
+
+The module follows a metric stability policy to protect operator alerting rules and dashboards across upgrades.
+
+### Guarantees
+
+1. **No renames or removals without notice.** Once a metric name and its label set are published in a release, the metric name will not be renamed or removed in any subsequent 0.x release without a deprecation notice in the prior release's changelog.
+2. **Label key sets are frozen.** For existing metrics, no label keys will be added or removed. The set of label keys for a metric is fixed at the release where the metric is introduced.
+3. **New metrics may be added.** New metric names may be introduced in any release without a deprecation period.
+4. **New label values may be added.** New values for existing label keys (e.g., a new `reason` code) may be added without a deprecation period. Operators should use label matchers that tolerate new values.
+5. **The `nginx_markdown_` prefix is reserved.** All module metrics use this prefix. No other module or exporter should use it.
+
+### Published Metrics (0.4.0)
+
+All metrics listed in the [Metric Catalog](#metric-catalog) section are considered stable as of the 0.4.0 release. Their names, types, and label key sets are covered by the stability policy above.
+
+| Metric Name | Type | Label Keys | Stability |
+|---|---|---|---|
+| `nginx_markdown_requests_total` | counter | — | Stable |
+| `nginx_markdown_conversions_total` | counter | — | Stable |
+| `nginx_markdown_passthrough_total` | counter | — | Stable |
+| `nginx_markdown_skips_total` | counter | `reason` | Stable |
+| `nginx_markdown_failures_total` | counter | `stage` | Stable |
+| `nginx_markdown_failopen_total` | counter | — | Stable |
+| `nginx_markdown_large_response_path_total` | counter | — | Stable |
+| `nginx_markdown_input_bytes_total` | counter | — | Stable |
+| `nginx_markdown_output_bytes_total` | counter | — | Stable |
+| `nginx_markdown_estimated_token_savings_total` | counter | — | Stable |
+| `nginx_markdown_decompressions_total` | counter | `format` | Stable |
+| `nginx_markdown_decompression_failures_total` | counter | — | Stable |
+| `nginx_markdown_conversion_duration_seconds` | gauge | `le` | Stable |

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -196,12 +196,14 @@ curl -H "Accept: application/json" http://localhost/markdown-metrics
 If you have the Prometheus `promtool` CLI installed, validate the output:
 
 ```bash
-curl -s http://localhost/markdown-metrics | promtool check metrics
+curl -s -H "Accept: text/plain; version=0.0.4" http://localhost/markdown-metrics | promtool check metrics
 ```
+
+Note: The explicit `Accept` header is required so the endpoint returns Prometheus text exposition format. Without it, the endpoint returns the legacy plain-text format, which `promtool` cannot parse. Alternatively, if `markdown_metrics_format prometheus` is configured and you prefer to omit the header, plain `text/plain` requests still return the legacy format — only `text/plain; version=0.0.4` or `application/openmetrics-text` triggers Prometheus output.
 
 ### Example Output
 
-```
+```text
 # HELP nginx_markdown_requests_total Total requests entering the module decision chain.
 # TYPE nginx_markdown_requests_total counter
 nginx_markdown_requests_total 1250

--- a/docs/guides/prometheus-metrics.md
+++ b/docs/guides/prometheus-metrics.md
@@ -154,14 +154,13 @@ All metrics use the `nginx_markdown_` prefix. Counter metrics use the `_total` s
 
 ### Total Time Series
 
-The endpoint produces exactly 32 unique time series:
+The endpoint produces exactly 28 unique time series:
 
-- 9 unlabeled counters
+- 9 unlabeled counters (requests, conversions, passthrough, failopen, large response path, input bytes, output bytes, token savings, decompression failures)
 - 9 skip reason labels
 - 3 failure stage labels
 - 3 decompression format labels
 - 4 latency bucket labels
-- 4 additional metric lines (decompression failures, failopen, large response path, token savings are counted in the 9 unlabeled above)
 
 This count is deterministic and bounded. No request-specific or high-cardinality labels are used.
 

--- a/tests/property/test_prometheus_metrics.py
+++ b/tests/property/test_prometheus_metrics.py
@@ -642,9 +642,7 @@ def _prefers_prometheus(accept: str | None) -> bool:
     lower = accept.lower()
     if "application/openmetrics-text" in lower:
         return True
-    if "text/plain" in lower and "version=0.0.4" in lower:
-        return True
-    return False
+    return "text/plain" in lower and "version=0.0.4" in lower
 
 
 def select_format(metrics_format: int, accept: str | None) -> int:

--- a/tests/property/test_prometheus_metrics.py
+++ b/tests/property/test_prometheus_metrics.py
@@ -92,16 +92,6 @@ def render_prometheus(snap: MetricsSnapshot) -> str:
     """
     lines = []
 
-    def emit(name, typ, help_text, value, labels=None):
-        """Emit a single metric value line."""
-        if labels:
-            lbl = ",".join(
-                f'{k}="{v}"' for k, v in labels.items()
-            )
-            lines.append(f"{name}{{{lbl}}} {value}")
-        else:
-            lines.append(f"{name} {value}")
-
     def emit_family(name, typ, help_text, entries):
         """Emit HELP, TYPE, and all value lines for a family."""
         lines.append(f"# HELP {name} {help_text}")

--- a/tests/property/test_prometheus_metrics.py
+++ b/tests/property/test_prometheus_metrics.py
@@ -1,0 +1,875 @@
+# Feature: prometheus-module-metrics — Property-based tests for Prometheus
+# text exposition format renderer.
+"""Property-based tests for the Prometheus metrics renderer.
+
+These tests use a Python reference model of the Prometheus renderer and
+verify properties of the output using the prometheus_client text parser.
+The reference model must stay in sync with the C implementation in
+ngx_http_markdown_prometheus_impl.h.
+
+Feature: prometheus-module-metrics
+Validates: Requirements 1.3, 6.2, 6.4, 7.2, 7.4, 12.1, 12.2, 12.3,
+           12.4, 13.1, 13.2, 13.3, 13.4, 17.1, 17.2, 19.1, 19.3, 19.4
+
+Run:
+    python3 -m pytest tests/property/test_prometheus_metrics.py -v
+"""
+
+import re
+from dataclasses import dataclass, field
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+from prometheus_client.parser import text_string_to_metric_families
+
+
+# -------------------------------------------------------------------
+# Python model of the metrics snapshot
+# -------------------------------------------------------------------
+
+@dataclass
+class DecompressionSnapshot:
+    """Decompression sub-struct counters."""
+    attempted: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    gzip: int = 0
+    deflate: int = 0
+    brotli: int = 0
+
+
+@dataclass
+class SkipsSnapshot:
+    """Skip counters by reason code."""
+    config: int = 0
+    method: int = 0
+    status: int = 0
+    content_type: int = 0
+    size: int = 0
+    streaming: int = 0
+    auth: int = 0
+    range: int = 0
+    accept: int = 0
+
+
+@dataclass
+class MetricsSnapshot:
+    """Mirrors ngx_http_markdown_metrics_snapshot_t."""
+    conversions_attempted: int = 0
+    conversions_succeeded: int = 0
+    conversions_failed: int = 0
+    conversions_bypassed: int = 0
+    failures_conversion: int = 0
+    failures_resource_limit: int = 0
+    failures_system: int = 0
+    conversion_time_sum_ms: int = 0
+    input_bytes: int = 0
+    output_bytes: int = 0
+    conversion_latency_le_10ms: int = 0
+    conversion_latency_le_100ms: int = 0
+    conversion_latency_le_1000ms: int = 0
+    conversion_latency_gt_1000ms: int = 0
+    decompressions: DecompressionSnapshot = field(
+        default_factory=DecompressionSnapshot
+    )
+    fullbuffer_path_hits: int = 0
+    incremental_path_hits: int = 0
+    requests_entered: int = 0
+    skips: SkipsSnapshot = field(default_factory=SkipsSnapshot)
+    failopen_count: int = 0
+    estimated_token_savings: int = 0
+
+
+# -------------------------------------------------------------------
+# Python reference renderer (mirrors C implementation)
+# -------------------------------------------------------------------
+
+def render_prometheus(snap: MetricsSnapshot) -> str:
+    """Render a MetricsSnapshot as Prometheus text exposition format.
+
+    This is the Python reference model that must stay in sync with
+    ngx_http_markdown_metrics_write_prometheus() in the C code.
+    """
+    lines = []
+
+    def emit(name, typ, help_text, value, labels=None):
+        """Emit a single metric value line."""
+        if labels:
+            lbl = ",".join(
+                f'{k}="{v}"' for k, v in labels.items()
+            )
+            lines.append(f"{name}{{{lbl}}} {value}")
+        else:
+            lines.append(f"{name} {value}")
+
+    def emit_family(name, typ, help_text, entries):
+        """Emit HELP, TYPE, and all value lines for a family."""
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {typ}")
+        for entry in entries:
+            if entry[1] is None:
+                lines.append(f"{name} {entry[0]}")
+            else:
+                lbl = ",".join(
+                    f'{k}="{v}"' for k, v in entry[1].items()
+                )
+                lines.append(f"{name}{{{lbl}}} {entry[0]}")
+        lines.append("")
+
+    emit_family(
+        "nginx_markdown_requests_total", "counter",
+        "Total requests entering the module decision chain.",
+        [(snap.requests_entered, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_conversions_total", "counter",
+        "Successful HTML-to-Markdown conversions.",
+        [(snap.conversions_succeeded, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_passthrough_total", "counter",
+        "Requests not converted (skipped or failed-open).",
+        [(snap.conversions_bypassed, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_skips_total", "counter",
+        "Requests skipped by reason.",
+        [
+            (snap.skips.method,
+             {"reason": "SKIP_METHOD"}),
+            (snap.skips.status,
+             {"reason": "SKIP_STATUS"}),
+            (snap.skips.content_type,
+             {"reason": "SKIP_CONTENT_TYPE"}),
+            (snap.skips.size,
+             {"reason": "SKIP_SIZE"}),
+            (snap.skips.streaming,
+             {"reason": "SKIP_STREAMING"}),
+            (snap.skips.auth,
+             {"reason": "SKIP_AUTH"}),
+            (snap.skips.range,
+             {"reason": "SKIP_RANGE"}),
+            (snap.skips.accept,
+             {"reason": "SKIP_ACCEPT"}),
+            (snap.skips.config,
+             {"reason": "SKIP_CONFIG"}),
+        ],
+    )
+
+    emit_family(
+        "nginx_markdown_failures_total", "counter",
+        "Conversion failures by stage.",
+        [
+            (snap.failures_conversion,
+             {"stage": "FAIL_CONVERSION"}),
+            (snap.failures_resource_limit,
+             {"stage": "FAIL_RESOURCE_LIMIT"}),
+            (snap.failures_system,
+             {"stage": "FAIL_SYSTEM"}),
+        ],
+    )
+
+    emit_family(
+        "nginx_markdown_failopen_total", "counter",
+        "Conversions failed with original HTML served "
+        "(fail-open).",
+        [(snap.failopen_count, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_large_response_path_total", "counter",
+        "Requests routed to incremental processing path.",
+        [(snap.incremental_path_hits, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_input_bytes_total", "counter",
+        "Cumulative HTML input bytes from successful "
+        "conversions.",
+        [(snap.input_bytes, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_output_bytes_total", "counter",
+        "Cumulative Markdown output bytes from successful "
+        "conversions.",
+        [(snap.output_bytes, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_estimated_token_savings_total",
+        "counter",
+        "Estimated cumulative token savings "
+        "(requires markdown_token_estimate on).",
+        [(snap.estimated_token_savings, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_decompressions_total", "counter",
+        "Decompression operations by format.",
+        [
+            (snap.decompressions.gzip,
+             {"format": "gzip"}),
+            (snap.decompressions.deflate,
+             {"format": "deflate"}),
+            (snap.decompressions.brotli,
+             {"format": "brotli"}),
+        ],
+    )
+
+    emit_family(
+        "nginx_markdown_decompression_failures_total",
+        "counter",
+        "Failed decompression attempts.",
+        [(snap.decompressions.failed, None)],
+    )
+
+    emit_family(
+        "nginx_markdown_conversion_duration_seconds", "gauge",
+        "Cumulative conversion count per latency bucket "
+        "(not a native Prometheus histogram; no _sum/_count).",
+        [
+            (snap.conversion_latency_le_10ms,
+             {"le": "0.01"}),
+            (snap.conversion_latency_le_100ms,
+             {"le": "0.1"}),
+            (snap.conversion_latency_le_1000ms,
+             {"le": "1.0"}),
+            (snap.conversion_latency_gt_1000ms,
+             {"le": "+Inf"}),
+        ],
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+# -------------------------------------------------------------------
+# Hypothesis strategies
+# -------------------------------------------------------------------
+
+counter_value = st.integers(min_value=0, max_value=2**32 - 1)
+
+
+@st.composite
+def snapshot_strategy(draw):
+    """Generate a random MetricsSnapshot with non-negative values."""
+    return MetricsSnapshot(
+        conversions_attempted=draw(counter_value),
+        conversions_succeeded=draw(counter_value),
+        conversions_failed=draw(counter_value),
+        conversions_bypassed=draw(counter_value),
+        failures_conversion=draw(counter_value),
+        failures_resource_limit=draw(counter_value),
+        failures_system=draw(counter_value),
+        conversion_time_sum_ms=draw(counter_value),
+        input_bytes=draw(counter_value),
+        output_bytes=draw(counter_value),
+        conversion_latency_le_10ms=draw(counter_value),
+        conversion_latency_le_100ms=draw(counter_value),
+        conversion_latency_le_1000ms=draw(counter_value),
+        conversion_latency_gt_1000ms=draw(counter_value),
+        decompressions=DecompressionSnapshot(
+            attempted=draw(counter_value),
+            succeeded=draw(counter_value),
+            failed=draw(counter_value),
+            gzip=draw(counter_value),
+            deflate=draw(counter_value),
+            brotli=draw(counter_value),
+        ),
+        fullbuffer_path_hits=draw(counter_value),
+        incremental_path_hits=draw(counter_value),
+        requests_entered=draw(counter_value),
+        skips=SkipsSnapshot(
+            config=draw(counter_value),
+            method=draw(counter_value),
+            status=draw(counter_value),
+            content_type=draw(counter_value),
+            size=draw(counter_value),
+            streaming=draw(counter_value),
+            auth=draw(counter_value),
+            range=draw(counter_value),
+            accept=draw(counter_value),
+        ),
+        failopen_count=draw(counter_value),
+        estimated_token_savings=draw(counter_value),
+    )
+
+
+# -------------------------------------------------------------------
+# Metric catalog constants
+# -------------------------------------------------------------------
+
+EXPECTED_FAMILIES = {
+    "nginx_markdown_requests_total",
+    "nginx_markdown_conversions_total",
+    "nginx_markdown_passthrough_total",
+    "nginx_markdown_skips_total",
+    "nginx_markdown_failures_total",
+    "nginx_markdown_failopen_total",
+    "nginx_markdown_large_response_path_total",
+    "nginx_markdown_input_bytes_total",
+    "nginx_markdown_output_bytes_total",
+    "nginx_markdown_estimated_token_savings_total",
+    "nginx_markdown_decompressions_total",
+    "nginx_markdown_decompression_failures_total",
+    "nginx_markdown_conversion_duration_seconds",
+}
+
+ALLOWED_LABEL_KEYS = {"reason", "stage", "format", "le"}
+
+FORBIDDEN_LABELS = {
+    "path", "url", "host", "ua", "query",
+    "referer", "remote_addr",
+}
+
+REASON_VALUES = {
+    "SKIP_CONFIG", "SKIP_METHOD", "SKIP_STATUS",
+    "SKIP_CONTENT_TYPE", "SKIP_SIZE", "SKIP_STREAMING",
+    "SKIP_AUTH", "SKIP_RANGE", "SKIP_ACCEPT",
+}
+
+STAGE_VALUES = {
+    "FAIL_CONVERSION", "FAIL_RESOURCE_LIMIT", "FAIL_SYSTEM",
+}
+
+FORMAT_VALUES = {"gzip", "deflate", "brotli"}
+
+LE_VALUES = {"0.01", "0.1", "1.0", "+Inf"}
+
+SNAKE_CASE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+EXPECTED_TIME_SERIES_COUNT = 28
+
+
+# -------------------------------------------------------------------
+# Helper: parse Prometheus text into a dict of metric values
+# -------------------------------------------------------------------
+
+def parse_prometheus(text):
+    """Parse Prometheus text format into a dict.
+
+    Returns a dict mapping (metric_name, frozenset(labels))
+    to the numeric value.
+    """
+    result = {}
+    families = list(text_string_to_metric_families(text))
+    for family in families:
+        for sample in family.samples:
+            key = (
+                sample.name,
+                frozenset(sample.labels.items()),
+            )
+            result[key] = sample.value
+    return result, families
+
+
+# -------------------------------------------------------------------
+# Property 1: Prometheus output round-trip
+# -------------------------------------------------------------------
+# **Validates: Requirements 19.4, 19.1, 19.3, 1.3**
+
+
+@given(snap=snapshot_strategy())
+@settings(max_examples=100)
+def test_property1_round_trip(snap):
+    """Property 1: Round-trip — generate random snapshots, render
+    via reference model, parse with prometheus_client text parser,
+    verify values match.
+
+    **Validates: Requirements 19.4, 19.1, 19.3, 1.3**
+    """
+    text = render_prometheus(snap)
+    parsed, _ = parse_prometheus(text)
+
+    def check(name, expected, labels=None):
+        lbl = frozenset(labels.items()) if labels else frozenset()
+        key = (name, lbl)
+        assert key in parsed, (
+            f"Missing metric {name} with labels {labels}"
+        )
+        assert parsed[key] == float(expected), (
+            f"{name}{labels or ''}: expected {expected}, "
+            f"got {parsed[key]}"
+        )
+
+    check("nginx_markdown_requests_total",
+          snap.requests_entered)
+    check("nginx_markdown_conversions_total",
+          snap.conversions_succeeded)
+    check("nginx_markdown_passthrough_total",
+          snap.conversions_bypassed)
+
+    for reason, val in [
+        ("SKIP_METHOD", snap.skips.method),
+        ("SKIP_STATUS", snap.skips.status),
+        ("SKIP_CONTENT_TYPE", snap.skips.content_type),
+        ("SKIP_SIZE", snap.skips.size),
+        ("SKIP_STREAMING", snap.skips.streaming),
+        ("SKIP_AUTH", snap.skips.auth),
+        ("SKIP_RANGE", snap.skips.range),
+        ("SKIP_ACCEPT", snap.skips.accept),
+        ("SKIP_CONFIG", snap.skips.config),
+    ]:
+        check("nginx_markdown_skips_total", val,
+              {"reason": reason})
+
+    for stage, val in [
+        ("FAIL_CONVERSION", snap.failures_conversion),
+        ("FAIL_RESOURCE_LIMIT",
+         snap.failures_resource_limit),
+        ("FAIL_SYSTEM", snap.failures_system),
+    ]:
+        check("nginx_markdown_failures_total", val,
+              {"stage": stage})
+
+    check("nginx_markdown_failopen_total",
+          snap.failopen_count)
+    check("nginx_markdown_large_response_path_total",
+          snap.incremental_path_hits)
+    check("nginx_markdown_input_bytes_total",
+          snap.input_bytes)
+    check("nginx_markdown_output_bytes_total",
+          snap.output_bytes)
+    check("nginx_markdown_estimated_token_savings_total",
+          snap.estimated_token_savings)
+
+    for fmt, val in [
+        ("gzip", snap.decompressions.gzip),
+        ("deflate", snap.decompressions.deflate),
+        ("brotli", snap.decompressions.brotli),
+    ]:
+        check("nginx_markdown_decompressions_total", val,
+              {"format": fmt})
+
+    check("nginx_markdown_decompression_failures_total",
+          snap.decompressions.failed)
+
+    for le_val, val in [
+        ("0.01", snap.conversion_latency_le_10ms),
+        ("0.1", snap.conversion_latency_le_100ms),
+        ("1.0", snap.conversion_latency_le_1000ms),
+        ("+Inf", snap.conversion_latency_gt_1000ms),
+    ]:
+        check("nginx_markdown_conversion_duration_seconds",
+              val, {"le": le_val})
+
+
+# -------------------------------------------------------------------
+# Property 2: Metric naming compliance
+# -------------------------------------------------------------------
+# **Validates: Requirements 12.1, 12.2, 12.3, 12.4**
+
+
+@given(snap=snapshot_strategy())
+@settings(max_examples=100)
+def test_property2_metric_naming_compliance(snap):
+    """Property 2: Metric naming compliance — all names start with
+    nginx_markdown_, use snake_case, counter-typed end with _total.
+
+    **Validates: Requirements 12.1, 12.2, 12.3, 12.4**
+
+    Note: prometheus_client strips _total from family.name for
+    counters, so we check sample.name instead for the _total
+    suffix requirement.
+    """
+    text = render_prometheus(snap)
+    _, families = parse_prometheus(text)
+
+    for family in families:
+        for sample in family.samples:
+            name = sample.name
+            assert name.startswith("nginx_markdown_"), (
+                f"Metric '{name}' does not start with "
+                f"nginx_markdown_"
+            )
+            assert SNAKE_CASE_RE.match(name), (
+                f"Metric '{name}' is not snake_case"
+            )
+            if family.type == "counter":
+                assert name.endswith("_total"), (
+                    f"Counter metric '{name}' does not "
+                    f"end with _total"
+                )
+
+
+# -------------------------------------------------------------------
+# Property 3: Label boundary enforcement
+# -------------------------------------------------------------------
+# **Validates: Requirements 13.1, 13.2, 13.3, 6.2, 6.4, 7.2, 7.4,
+#              17.1, 17.2**
+
+
+@given(snap=snapshot_strategy())
+@settings(max_examples=100)
+def test_property3_label_boundary_enforcement(snap):
+    """Property 3: Label boundary enforcement — all label keys in
+    {reason, stage, format, le}, no forbidden labels, values in
+    bounded sets.
+
+    **Validates: Requirements 13.1, 13.2, 13.3, 6.2, 6.4, 7.2,
+    7.4, 17.1, 17.2**
+    """
+    text = render_prometheus(snap)
+    _, families = parse_prometheus(text)
+
+    for family in families:
+        for sample in family.samples:
+            for key, value in sample.labels.items():
+                assert key in ALLOWED_LABEL_KEYS, (
+                    f"Forbidden label key '{key}' on "
+                    f"metric '{sample.name}'"
+                )
+                assert key not in FORBIDDEN_LABELS, (
+                    f"Forbidden label key '{key}'"
+                )
+                assert value not in FORBIDDEN_LABELS, (
+                    f"Forbidden label value '{value}'"
+                )
+
+                if key == "reason":
+                    assert value in REASON_VALUES, (
+                        f"Unknown reason value '{value}'"
+                    )
+                elif key == "stage":
+                    assert value in STAGE_VALUES, (
+                        f"Unknown stage value '{value}'"
+                    )
+                elif key == "format":
+                    assert value in FORMAT_VALUES, (
+                        f"Unknown format value '{value}'"
+                    )
+                elif key == "le":
+                    assert value in LE_VALUES, (
+                        f"Unknown le value '{value}'"
+                    )
+
+
+# -------------------------------------------------------------------
+# Property 6: HELP and TYPE annotation completeness
+# -------------------------------------------------------------------
+# **Validates: Requirements 1.3, 19.1**
+
+
+@given(snap=snapshot_strategy())
+@settings(max_examples=100)
+def test_property6_help_and_type_completeness(snap):
+    """Property 6: HELP and TYPE completeness — every metric family
+    has exactly one HELP and one TYPE line.
+
+    **Validates: Requirements 1.3, 19.1**
+    """
+    text = render_prometheus(snap)
+
+    found_families = set()
+    help_counts = {}
+    type_counts = {}
+
+    for line in text.splitlines():
+        if line.startswith("# HELP "):
+            parts = line.split(" ", 3)
+            name = parts[2]
+            found_families.add(name)
+            help_counts[name] = help_counts.get(name, 0) + 1
+        elif line.startswith("# TYPE "):
+            parts = line.split(" ", 3)
+            name = parts[2]
+            type_counts[name] = type_counts.get(name, 0) + 1
+
+    assert found_families == EXPECTED_FAMILIES, (
+        f"Family mismatch.\n"
+        f"Missing: {EXPECTED_FAMILIES - found_families}\n"
+        f"Extra: {found_families - EXPECTED_FAMILIES}"
+    )
+
+    for name in EXPECTED_FAMILIES:
+        assert help_counts.get(name, 0) == 1, (
+            f"Expected exactly 1 HELP for '{name}', "
+            f"got {help_counts.get(name, 0)}"
+        )
+        assert type_counts.get(name, 0) == 1, (
+            f"Expected exactly 1 TYPE for '{name}', "
+            f"got {type_counts.get(name, 0)}"
+        )
+
+
+# -------------------------------------------------------------------
+# Property 7: Time series count is bounded
+# -------------------------------------------------------------------
+# **Validates: Requirements 13.4**
+
+
+@given(snap=snapshot_strategy())
+@settings(max_examples=100)
+def test_property7_time_series_count_bounded(snap):
+    """Property 7: Time series count is bounded — exactly 28 unique
+    time series lines (9 unlabeled counters + 9 reason labels +
+    3 stage labels + 3 format labels + 4 le buckets).
+
+    **Validates: Requirements 13.4**
+    """
+    text = render_prometheus(snap)
+    parsed, _ = parse_prometheus(text)
+
+    assert len(parsed) == EXPECTED_TIME_SERIES_COUNT, (
+        f"Expected {EXPECTED_TIME_SERIES_COUNT} unique time "
+        f"series, got {len(parsed)}"
+    )
+
+
+# -------------------------------------------------------------------
+# Property 5: Content negotiation selects correct format
+# -------------------------------------------------------------------
+# **Validates: Requirements 2.4, 2.3, 2.2**
+
+OUTPUT_TEXT = 0
+OUTPUT_JSON = 1
+OUTPUT_PROMETHEUS = 2
+
+METRICS_FORMAT_AUTO = 0
+METRICS_FORMAT_PROMETHEUS = 1
+
+
+def select_format(metrics_format: int, accept: str | None) -> int:
+    """Python reference model of the content negotiation state
+    machine from the design document.
+
+    Mirrors ngx_http_markdown_metrics_select_format().
+    """
+    if accept is not None and "application/json" in accept.lower():
+        return OUTPUT_JSON
+
+    if metrics_format == METRICS_FORMAT_PROMETHEUS:
+        return OUTPUT_PROMETHEUS
+
+    return OUTPUT_TEXT
+
+
+# Strategy for Accept header values covering all branches
+accept_header_strategy = st.one_of(
+    st.just(None),
+    st.just("application/json"),
+    st.just("text/plain"),
+    st.just("text/plain; version=0.0.4"),
+    st.just("application/openmetrics-text"),
+    st.just("*/*"),
+    st.just("text/html"),
+    st.text(
+        alphabet=st.characters(
+            whitelist_categories=("L", "N", "P", "Z"),
+            whitelist_characters="/;,=",
+        ),
+        min_size=0,
+        max_size=100,
+    ),
+)
+
+metrics_format_strategy = st.sampled_from(
+    [METRICS_FORMAT_AUTO, METRICS_FORMAT_PROMETHEUS]
+)
+
+
+@given(
+    metrics_format=metrics_format_strategy,
+    accept=accept_header_strategy,
+)
+@settings(max_examples=200)
+def test_property5_content_negotiation(metrics_format, accept):
+    """Property 5: Content negotiation selects correct format.
+
+    For any combination of metrics_format setting and Accept
+    header value, the format selection matches the state machine:
+    - JSON when Accept contains application/json
+    - Prometheus when format is prometheus and Accept does not
+      contain application/json
+    - Plain text when format is auto and Accept does not
+      contain application/json
+
+    **Validates: Requirements 2.4, 2.3, 2.2**
+    """
+    result = select_format(metrics_format, accept)
+
+    has_json = (
+        accept is not None
+        and "application/json" in accept.lower()
+    )
+
+    if has_json:
+        assert result == OUTPUT_JSON, (
+            f"Expected JSON for Accept={accept!r}, "
+            f"got {result}"
+        )
+    elif metrics_format == METRICS_FORMAT_PROMETHEUS:
+        assert result == OUTPUT_PROMETHEUS, (
+            f"Expected PROMETHEUS for format=prometheus, "
+            f"Accept={accept!r}, got {result}"
+        )
+    else:
+        assert result == OUTPUT_TEXT, (
+            f"Expected TEXT for format=auto, "
+            f"Accept={accept!r}, got {result}"
+        )
+
+# -------------------------------------------------------------------
+# Property 4: Counter accounting invariant
+# -------------------------------------------------------------------
+# **Validates: Requirements 3.1, 4.1, 5.1, 5.2, 8.1, 8.2**
+
+
+@st.composite
+def constrained_snapshot_strategy(draw):
+    """Generate a MetricsSnapshot where the accounting invariants
+    hold by construction.
+
+    The invariants are:
+    - passthrough_total == sum(skips_total) + failopen_total
+    - requests_total >= conversions_total + passthrough_total
+    - sum(failures_total) >= failopen_total
+
+    We build the snapshot bottom-up so the invariants hold.
+    """
+    cv = st.integers(min_value=0, max_value=10000)
+
+    skip_config = draw(cv)
+    skip_method = draw(cv)
+    skip_status = draw(cv)
+    skip_content_type = draw(cv)
+    skip_size = draw(cv)
+    skip_streaming = draw(cv)
+    skip_auth = draw(cv)
+    skip_range = draw(cv)
+    skip_accept = draw(cv)
+
+    total_skips = (
+        skip_config + skip_method + skip_status
+        + skip_content_type + skip_size + skip_streaming
+        + skip_auth + skip_range + skip_accept
+    )
+
+    failopen_count = draw(cv)
+
+    # passthrough = sum(skips) + failopen
+    passthrough = total_skips + failopen_count
+
+    conversions_succeeded = draw(cv)
+
+    #
+    # requests_entered >= conversions + passthrough.
+    # Add a non-negative surplus for in-flight requests.
+    #
+    surplus = draw(cv)
+    requests_entered = conversions_succeeded + passthrough + surplus
+
+    #
+    # sum(failures) >= failopen.
+    # failures_total includes both fail-open and fail-closed.
+    #
+    extra_failures = draw(cv)
+    total_failures = failopen_count + extra_failures
+
+    # Distribute failures across categories
+    fail_conv = draw(
+        st.integers(min_value=0, max_value=total_failures)
+    )
+    remaining = total_failures - fail_conv
+    fail_res = draw(
+        st.integers(min_value=0, max_value=remaining)
+    )
+    fail_sys = remaining - fail_res
+
+    return MetricsSnapshot(
+        conversions_attempted=draw(cv),
+        conversions_succeeded=conversions_succeeded,
+        conversions_failed=total_failures,
+        conversions_bypassed=passthrough,
+        failures_conversion=fail_conv,
+        failures_resource_limit=fail_res,
+        failures_system=fail_sys,
+        conversion_time_sum_ms=draw(cv),
+        input_bytes=draw(cv),
+        output_bytes=draw(cv),
+        conversion_latency_le_10ms=draw(cv),
+        conversion_latency_le_100ms=draw(cv),
+        conversion_latency_le_1000ms=draw(cv),
+        conversion_latency_gt_1000ms=draw(cv),
+        decompressions=DecompressionSnapshot(
+            attempted=draw(cv),
+            succeeded=draw(cv),
+            failed=draw(cv),
+            gzip=draw(cv),
+            deflate=draw(cv),
+            brotli=draw(cv),
+        ),
+        fullbuffer_path_hits=draw(cv),
+        incremental_path_hits=draw(cv),
+        requests_entered=requests_entered,
+        skips=SkipsSnapshot(
+            config=skip_config,
+            method=skip_method,
+            status=skip_status,
+            content_type=skip_content_type,
+            size=skip_size,
+            streaming=skip_streaming,
+            auth=skip_auth,
+            range=skip_range,
+            accept=skip_accept,
+        ),
+        failopen_count=failopen_count,
+        estimated_token_savings=draw(cv),
+    )
+
+
+@given(snap=constrained_snapshot_strategy())
+@settings(max_examples=200)
+def test_property4_counter_accounting_invariant(snap):
+    """Property 4: Counter accounting invariant.
+
+    For constrained snapshots where the arithmetic invariants
+    hold by construction, render to Prometheus, parse, and
+    verify:
+    - passthrough_total == sum(skips_total) + failopen_total
+    - requests_total >= conversions_total + passthrough_total
+    - sum(failures_total) >= failopen_total
+
+    **Validates: Requirements 3.1, 4.1, 5.1, 5.2, 8.1, 8.2**
+    """
+    text = render_prometheus(snap)
+    parsed, _ = parse_prometheus(text)
+
+    def get(name, labels=None):
+        lbl = frozenset(labels.items()) if labels else frozenset()
+        return parsed[(name, lbl)]
+
+    requests = get("nginx_markdown_requests_total")
+    conversions = get("nginx_markdown_conversions_total")
+    passthrough = get("nginx_markdown_passthrough_total")
+    failopen = get("nginx_markdown_failopen_total")
+
+    sum_skips = sum(
+        get("nginx_markdown_skips_total", {"reason": r})
+        for r in REASON_VALUES
+    )
+
+    sum_failures = sum(
+        get("nginx_markdown_failures_total", {"stage": s})
+        for s in STAGE_VALUES
+    )
+
+    assert passthrough == sum_skips + failopen, (
+        f"passthrough ({passthrough}) != "
+        f"sum(skips) ({sum_skips}) + "
+        f"failopen ({failopen})"
+    )
+
+    assert requests >= conversions + passthrough, (
+        f"requests ({requests}) < "
+        f"conversions ({conversions}) + "
+        f"passthrough ({passthrough})"
+    )
+
+    assert sum_failures >= failopen, (
+        f"sum(failures) ({sum_failures}) < "
+        f"failopen ({failopen})"
+    )

--- a/tests/property/test_prometheus_metrics.py
+++ b/tests/property/test_prometheus_metrics.py
@@ -121,7 +121,8 @@ def render_prometheus(snap: MetricsSnapshot) -> str:
     emit_family(
         "nginx_markdown_passthrough_total", "counter",
         "Requests not converted (skipped or failed-open).",
-        [(snap.conversions_bypassed, None)],
+        [(snap.conversions_bypassed + snap.failopen_count,
+          None)],
     )
 
     emit_family(
@@ -217,19 +218,20 @@ def render_prometheus(snap: MetricsSnapshot) -> str:
         [(snap.decompressions.failed, None)],
     )
 
+    le_10 = snap.conversion_latency_le_10ms
+    le_100 = le_10 + snap.conversion_latency_le_100ms
+    le_1000 = le_100 + snap.conversion_latency_le_1000ms
+    le_inf = le_1000 + snap.conversion_latency_gt_1000ms
+
     emit_family(
         "nginx_markdown_conversion_duration_seconds", "gauge",
         "Cumulative conversion count per latency bucket "
         "(not a native Prometheus histogram; no _sum/_count).",
         [
-            (snap.conversion_latency_le_10ms,
-             {"le": "0.01"}),
-            (snap.conversion_latency_le_100ms,
-             {"le": "0.1"}),
-            (snap.conversion_latency_le_1000ms,
-             {"le": "1.0"}),
-            (snap.conversion_latency_gt_1000ms,
-             {"le": "+Inf"}),
+            (le_10, {"le": "0.01"}),
+            (le_100, {"le": "0.1"}),
+            (le_1000, {"le": "1.0"}),
+            (le_inf, {"le": "+Inf"}),
         ],
     )
 
@@ -390,7 +392,7 @@ def test_property1_round_trip(snap):
     check("nginx_markdown_conversions_total",
           snap.conversions_succeeded)
     check("nginx_markdown_passthrough_total",
-          snap.conversions_bypassed)
+          snap.conversions_bypassed + snap.failopen_count)
 
     for reason, val in [
         ("SKIP_METHOD", snap.skips.method),
@@ -437,11 +439,16 @@ def test_property1_round_trip(snap):
     check("nginx_markdown_decompression_failures_total",
           snap.decompressions.failed)
 
+    le_10 = snap.conversion_latency_le_10ms
+    le_100 = le_10 + snap.conversion_latency_le_100ms
+    le_1000 = le_100 + snap.conversion_latency_le_1000ms
+    le_inf = le_1000 + snap.conversion_latency_gt_1000ms
+
     for le_val, val in [
-        ("0.01", snap.conversion_latency_le_10ms),
-        ("0.1", snap.conversion_latency_le_100ms),
-        ("1.0", snap.conversion_latency_le_1000ms),
-        ("+Inf", snap.conversion_latency_gt_1000ms),
+        ("0.01", le_10),
+        ("0.1", le_100),
+        ("1.0", le_1000),
+        ("+Inf", le_inf),
     ]:
         check("nginx_markdown_conversion_duration_seconds",
               val, {"le": le_val})
@@ -622,6 +629,24 @@ METRICS_FORMAT_AUTO = 0
 METRICS_FORMAT_PROMETHEUS = 1
 
 
+def _prefers_prometheus(accept: str | None) -> bool:
+    """Check if Accept explicitly requests Prometheus format.
+
+    Matches application/openmetrics-text, or text/plain with
+    version=0.0.4.  Bare version=0.0.4 without text/plain
+    does not match (avoids false positives from unrelated
+    media types).
+    """
+    if accept is None:
+        return False
+    lower = accept.lower()
+    if "application/openmetrics-text" in lower:
+        return True
+    if "text/plain" in lower and "version=0.0.4" in lower:
+        return True
+    return False
+
+
 def select_format(metrics_format: int, accept: str | None) -> int:
     """Python reference model of the content negotiation state
     machine from the design document.
@@ -631,7 +656,8 @@ def select_format(metrics_format: int, accept: str | None) -> int:
     if accept is not None and "application/json" in accept.lower():
         return OUTPUT_JSON
 
-    if metrics_format == METRICS_FORMAT_PROMETHEUS:
+    if (metrics_format == METRICS_FORMAT_PROMETHEUS
+            and _prefers_prometheus(accept)):
         return OUTPUT_PROMETHEUS
 
     return OUTPUT_TEXT
@@ -646,6 +672,8 @@ accept_header_strategy = st.one_of(
     st.just("application/openmetrics-text"),
     st.just("*/*"),
     st.just("text/html"),
+    st.just("application/xml; version=0.0.4"),
+    st.just("version=0.0.4"),
     st.text(
         alphabet=st.characters(
             whitelist_categories=("L", "N", "P", "Z"),
@@ -686,19 +714,22 @@ def test_property5_content_negotiation(metrics_format, accept):
         and "application/json" in accept.lower()
     )
 
+    is_prom_accept = _prefers_prometheus(accept)
+
     if has_json:
         assert result == OUTPUT_JSON, (
             f"Expected JSON for Accept={accept!r}, "
             f"got {result}"
         )
-    elif metrics_format == METRICS_FORMAT_PROMETHEUS:
+    elif (metrics_format == METRICS_FORMAT_PROMETHEUS
+          and is_prom_accept):
         assert result == OUTPUT_PROMETHEUS, (
             f"Expected PROMETHEUS for format=prometheus, "
             f"Accept={accept!r}, got {result}"
         )
     else:
         assert result == OUTPUT_TEXT, (
-            f"Expected TEXT for format=auto, "
+            f"Expected TEXT for format={metrics_format}, "
             f"Accept={accept!r}, got {result}"
         )
 
@@ -740,7 +771,15 @@ def constrained_snapshot_strategy(draw):
 
     failopen_count = draw(cv)
 
-    # passthrough = sum(skips) + failopen
+    #
+    # passthrough_total is derived in the renderer as
+    # conversions_bypassed + failopen_count.
+    # conversions_bypassed tracks only skip-path requests
+    # at runtime; the renderer adds failopen to produce
+    # the spec-compliant passthrough value.
+    #
+    # passthrough = total_skips + failopen
+    #
     passthrough = total_skips + failopen_count
 
     conversions_succeeded = draw(cv)
@@ -773,7 +812,7 @@ def constrained_snapshot_strategy(draw):
         conversions_attempted=draw(cv),
         conversions_succeeded=conversions_succeeded,
         conversions_failed=total_failures,
-        conversions_bypassed=passthrough,
+        conversions_bypassed=total_skips,
         failures_conversion=fail_conv,
         failures_resource_limit=fail_res,
         failures_system=fail_sys,


### PR DESCRIPTION
## Summary by Sourcery

Add configurable Prometheus-compatible metrics output to the nginx markdown metrics endpoint, extend shared metrics with decision-chain and fail-open counters, and tighten content negotiation for JSON, text, and Prometheus formats.

New Features:
- Introduce a Prometheus text exposition renderer for markdown metrics and wire it into the nginx module with Accept-header-based content negotiation.
- Add a markdown_metrics_format configuration directive to control metrics output format (auto or prometheus).
- Expose new shared-memory counters for decision-chain entry, skip reasons, fail-open events, and estimated token savings, surfaced in JSON, text, and Prometheus metrics output.
- Document Prometheus metrics usage, configuration, and stability guarantees in a dedicated guide.

Enhancements:
- Refine metrics endpoint content negotiation logic to prioritize JSON, support Prometheus formats when enabled, and maintain backward-compatible plain-text behavior.
- Improve configuration logging to include the selected metrics format for easier observability.

Tests:
- Add property-based Python tests validating Prometheus metrics format correctness, label sets, invariants, and content negotiation behavior.
- Add C unit tests for the Prometheus renderer, metrics format selection state machine, skip-reason counter mapping, and snapshot collection of new metric fields.
- Extend existing configuration parsing unit tests to cover the new markdown_metrics_format directive and its validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Prometheus text exposition format support for the metrics endpoint via new `markdown_metrics_format` directive
* Implemented content negotiation for metrics output format selection (JSON, plain text, or Prometheus)
* Enhanced metrics collection with detailed tracking: request entry points, skip reason breakdown, failure modes, and estimated token savings

**Documentation**
* Added comprehensive guide for enabling and scraping Prometheus metrics, including configuration examples and operational guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->