### PR TITLE
fix(release): refresh nginx matrix and harden workflows

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: '3.14.3'
 
       - name: Check matrix freshness
-        if: inputs.matrix_freshness != 'off'
+        if: github.event_name == 'workflow_dispatch' && inputs.matrix_freshness != 'off'
         env:
           FRESHNESS_MODE: ${{ inputs.matrix_freshness }}
         run: |

--- a/.github/workflows/update-matrix.yml
+++ b/.github/workflows/update-matrix.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Create or update Pull Request
         if: steps.changes.outputs.has_changes == 'true'
+        id: create_pr
+        continue-on-error: true
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           branch: auto/update-matrix
@@ -108,3 +110,8 @@ jobs:
             automated
             release-matrix
           commit-message: ${{ steps.pr_meta.outputs.title }}
+
+      - name: Report manual PR fallback
+        if: steps.changes.outputs.has_changes == 'true' && steps.create_pr.outcome == 'failure'
+        run: |
+          echo "::warning::Matrix update branch pushed, but automatic PR creation is blocked. Open https://github.com/${{ github.repository }}/pull/new/auto/update-matrix to finish the update manually."

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -571,14 +571,14 @@ If your NGINX version is >= 1.24.0 but not listed in the matrix below, use the [
 | 1.26.3 | glibc | x86_64 | Full |
 | 1.26.3 | musl | aarch64 | Full |
 | 1.26.3 | musl | x86_64 | Full |
-| 1.28.2 | glibc | aarch64 | Full |
-| 1.28.2 | glibc | x86_64 | Full |
-| 1.28.2 | musl | aarch64 | Full |
-| 1.28.2 | musl | x86_64 | Full |
-| 1.29.6 | glibc | aarch64 | Full |
-| 1.29.6 | glibc | x86_64 | Full |
-| 1.29.6 | musl | aarch64 | Full |
-| 1.29.6 | musl | x86_64 | Full |
+| 1.28.3 | glibc | aarch64 | Full |
+| 1.28.3 | glibc | x86_64 | Full |
+| 1.28.3 | musl | aarch64 | Full |
+| 1.28.3 | musl | x86_64 | Full |
+| 1.29.7 | glibc | aarch64 | Full |
+| 1.29.7 | glibc | x86_64 | Full |
+| 1.29.7 | musl | aarch64 | Full |
+| 1.29.7 | musl | x86_64 | Full |
 <!-- END AUTO-GENERATED MATRIX -->
 
 ---

--- a/tools/release-matrix.json
+++ b/tools/release-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "updated_at": "2026-03-15T13:35:30Z",
+  "updated_at": "2026-03-31T03:29:47Z",
   "support_tiers": {
     "full": "Prebuilt binary + install script + CI verification",
     "source_only": "Build from source required"
@@ -55,49 +55,49 @@
       "support_tier": "full"
     },
     {
-      "nginx": "1.28.2",
+      "nginx": "1.28.3",
       "os_type": "glibc",
       "arch": "aarch64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.28.2",
-      "os_type": "glibc",
-      "arch": "x86_64",
-      "support_tier": "full"
-    },
-    {
-      "nginx": "1.28.2",
-      "os_type": "musl",
-      "arch": "aarch64",
-      "support_tier": "full"
-    },
-    {
-      "nginx": "1.28.2",
-      "os_type": "musl",
-      "arch": "x86_64",
-      "support_tier": "full"
-    },
-    {
-      "nginx": "1.29.6",
-      "os_type": "glibc",
-      "arch": "aarch64",
-      "support_tier": "full"
-    },
-    {
-      "nginx": "1.29.6",
+      "nginx": "1.28.3",
       "os_type": "glibc",
       "arch": "x86_64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.6",
+      "nginx": "1.28.3",
       "os_type": "musl",
       "arch": "aarch64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.6",
+      "nginx": "1.28.3",
+      "os_type": "musl",
+      "arch": "x86_64",
+      "support_tier": "full"
+    },
+    {
+      "nginx": "1.29.7",
+      "os_type": "glibc",
+      "arch": "aarch64",
+      "support_tier": "full"
+    },
+    {
+      "nginx": "1.29.7",
+      "os_type": "glibc",
+      "arch": "x86_64",
+      "support_tier": "full"
+    },
+    {
+      "nginx": "1.29.7",
+      "os_type": "musl",
+      "arch": "aarch64",
+      "support_tier": "full"
+    },
+    {
+      "nginx": "1.29.7",
       "os_type": "musl",
       "arch": "x86_64",
       "support_tier": "full"

--- a/tools/release/tests/test_workflow_regressions.py
+++ b/tools/release/tests/test_workflow_regressions.py
@@ -1,0 +1,24 @@
+"""Regression guards for release-related GitHub workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _workflow_text(name: str) -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    path = repo_root / ".github" / "workflows" / name
+    return path.read_text(encoding="utf-8")
+
+
+def test_release_binaries_only_checks_matrix_freshness_on_manual_dispatch() -> None:
+    """Release-triggered binary builds must not run workflow-dispatch freshness logic."""
+    text = _workflow_text("release-binaries.yml")
+    assert "if: github.event_name == 'workflow_dispatch' && inputs.matrix_freshness != 'off'" in text
+
+
+def test_update_matrix_pr_creation_is_non_blocking_when_repo_disallows_actions_prs() -> None:
+    """Scheduled matrix refreshes should succeed even if PR creation is policy-blocked."""
+    text = _workflow_text("update-matrix.yml")
+    assert "continue-on-error: true" in text
+    assert "Matrix update branch pushed, but automatic PR creation is blocked." in text


### PR DESCRIPTION
## Summary
- refresh release matrix entries from nginx.org to 1.28.3 and 1.29.7
- only run matrix freshness checks on manual release-binaries dispatches
- make update-matrix degrade to a warning when repo policy blocks automatic PR creation
- add regression tests for both workflow behaviors

## Verification
- pytest -q tools/release/tests/test_workflow_regressions.py tools/release/tests/test_update_matrix.py tools/release/tests/test_validate_doc_matrix_sync.py
- python3 tools/release/validate_doc_matrix_sync.py
- python3 tools/release/validate_matrix_install_consistency.py

## Summary by Sourcery

Refresh NGINX release matrix versions and harden release-related GitHub workflows while adding regression tests to guard the new behavior.

Bug Fixes:
- Prevent release-triggered binary builds from running matrix freshness checks intended only for manually dispatched runs.
- Ensure scheduled matrix refresh workflows succeed even when repository policies block automatic pull request creation.

Enhancements:
- Update release matrix entries and corresponding installation documentation to NGINX versions 1.28.3 and 1.29.7.
- Add a fallback warning message guiding manual pull request creation when automatic PR creation is blocked in the matrix update workflow.

Documentation:
- Refresh the installation guide’s supported NGINX version matrix to reflect the latest 1.28.3 and 1.29.7 releases.

Tests:
- Introduce regression tests to assert release-binaries only checks matrix freshness on manual dispatch and that update-matrix PR creation is non-blocking and emits the expected warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Updated NGINX compatibility matrix: versions 1.28.3 and 1.29.7 now fully supported across all OS and architecture combinations

* **Improvements**
  * Enhanced release workflow reliability with improved error handling

* **Tests**
  * Added regression tests for workflow stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->