### PR TITLE
fix: address streaming fallback control-flow review findings

### DIFF
--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -1400,9 +1400,8 @@ ngx_http_markdown_streaming_passthrough(
  * chain downstream.
  *
  * Returns:
- *   NGX_OK       - handle ready, continue processing
- *   NGX_DONE     - fail-open handled, caller should return NGX_OK
- *   NGX_ERROR    - fatal error
+ *   NGX_OK    - handle ready, continue processing
+ *   otherwise - status propagated from passthrough/error path
  */
 static ngx_int_t
 ngx_http_markdown_streaming_ensure_handle(
@@ -1438,8 +1437,7 @@ ngx_http_markdown_streaming_ensure_handle(
             }
         }
 
-        (void) ngx_http_next_body_filter(r, in);
-        return NGX_DONE;
+        return ngx_http_next_body_filter(r, in);
     }
 
     return NGX_OK;
@@ -1491,11 +1489,8 @@ ngx_http_markdown_streaming_body_filter(
     /* Initialize streaming handle on first call */
     rc = ngx_http_markdown_streaming_ensure_handle(
         r, ctx, conf, in);
-    if (rc == NGX_ERROR) {
-        return NGX_ERROR;
-    }
-    if (rc == NGX_DONE) {
-        return NGX_OK;
+    if (rc != NGX_OK) {
+        return rc;
     }
 
     if (!ctx->eligible || ctx->streaming.handle == NULL) {
@@ -1523,8 +1518,13 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, in, rc);
 
         if (rc == NGX_DONE) {
-            /* Fallback: path switched, re-enter filter */
-            return NGX_OK;
+            /*
+             * Fallback switched processing_path to full-buffer.
+             * Re-enter the main body filter with the current
+             * unconsumed chain node so remaining buffers are
+             * not dropped in this invocation.
+             */
+            return ngx_http_markdown_body_filter(r, cl);
         }
 
         if (rc != NGX_OK) {

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -91,6 +91,11 @@ ngx_http_markdown_streaming_ensure_handle(
     ngx_http_markdown_ctx_t *ctx,
     ngx_http_markdown_conf_t *conf,
     ngx_chain_t *in);
+static ngx_int_t
+ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+    ngx_http_request_t *r,
+    ngx_chain_t *cl,
+    ngx_flag_t last_buf);
 
 
 /*
@@ -1443,6 +1448,48 @@ ngx_http_markdown_streaming_ensure_handle(
     return NGX_OK;
 }
 
+/*
+ * Re-enter full-buffer body filter after streaming fallback.
+ *
+ * The current chain node was already consumed into prebuffer by
+ * the streaming path, so re-entry starts at cl->next. If this was
+ * the terminal node and there is no next link, synthesize an empty
+ * terminal chain node to preserve end-of-stream signaling.
+ */
+static ngx_int_t
+ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+    ngx_http_request_t *r,
+    ngx_chain_t *cl,
+    ngx_flag_t last_buf)
+{
+    ngx_chain_t  *reentry_in;
+
+    reentry_in = cl->next;
+    if (reentry_in == NULL && last_buf) {
+        ngx_buf_t    *term_buf;
+        ngx_chain_t  *term_cl;
+
+        term_buf = ngx_calloc_buf(r->pool);
+        if (term_buf == NULL) {
+            return NGX_ERROR;
+        }
+
+        term_buf->last_buf = (r == r->main) ? 1 : 0;
+        term_buf->last_in_chain = (r != r->main) ? 1 : 0;
+
+        term_cl = ngx_alloc_chain_link(r->pool);
+        if (term_cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        term_cl->buf = term_buf;
+        term_cl->next = NULL;
+        reentry_in = term_cl;
+    }
+
+    return ngx_http_markdown_body_filter(r, reentry_in);
+}
+
 
 /*
  * Streaming body filter main entry point.
@@ -1518,41 +1565,9 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, in, rc);
 
         if (rc == NGX_DONE) {
-            ngx_chain_t  *reentry_in;
-
-            /*
-             * Fallback switched processing_path to full-buffer.
-             * The current node has already been consumed into
-             * the streaming prebuffer, so re-enter from cl->next
-             * to avoid duplicating that chunk in full-buffer mode.
-             *
-             * If this node carried the terminal flag and there is no
-             * following node, synthesize an empty terminal chain so the
-             * full-buffer path can observe end-of-stream immediately.
-             */
-            reentry_in = cl->next;
-            if (reentry_in == NULL && last_buf) {
-                ngx_buf_t    *term_buf;
-                ngx_chain_t  *term_cl;
-
-                term_buf = ngx_calloc_buf(r->pool);
-                if (term_buf == NULL) {
-                    return NGX_ERROR;
-                }
-
-                term_buf->last_buf = (r == r->main) ? 1 : 0;
-                term_buf->last_in_chain = (r != r->main) ? 1 : 0;
-
-                term_cl = ngx_alloc_chain_link(r->pool);
-                if (term_cl == NULL) {
-                    return NGX_ERROR;
-                }
-                term_cl->buf = term_buf;
-                term_cl->next = NULL;
-                reentry_in = term_cl;
-            }
-
-            return ngx_http_markdown_body_filter(r, reentry_in);
+            return
+                ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+                    r, cl, last_buf);
         }
 
         if (rc != NGX_OK) {

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -1518,13 +1518,41 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, in, rc);
 
         if (rc == NGX_DONE) {
+            ngx_chain_t  *reentry_in;
+
             /*
              * Fallback switched processing_path to full-buffer.
-             * Re-enter the main body filter with the current
-             * unconsumed chain node so remaining buffers are
-             * not dropped in this invocation.
+             * The current node has already been consumed into
+             * the streaming prebuffer, so re-enter from cl->next
+             * to avoid duplicating that chunk in full-buffer mode.
+             *
+             * If this node carried the terminal flag and there is no
+             * following node, synthesize an empty terminal chain so the
+             * full-buffer path can observe end-of-stream immediately.
              */
-            return ngx_http_markdown_body_filter(r, cl);
+            reentry_in = cl->next;
+            if (reentry_in == NULL && last_buf) {
+                ngx_buf_t    *term_buf;
+                ngx_chain_t  *term_cl;
+
+                term_buf = ngx_calloc_buf(r->pool);
+                if (term_buf == NULL) {
+                    return NGX_ERROR;
+                }
+
+                term_buf->last_buf = (r == r->main) ? 1 : 0;
+                term_buf->last_in_chain = (r != r->main) ? 1 : 0;
+
+                term_cl = ngx_alloc_chain_link(r->pool);
+                if (term_cl == NULL) {
+                    return NGX_ERROR;
+                }
+                term_cl->buf = term_buf;
+                term_cl->next = NULL;
+                reentry_in = term_cl;
+            }
+
+            return ngx_http_markdown_body_filter(r, reentry_in);
         }
 
         if (rc != NGX_OK) {


### PR DESCRIPTION
## Summary
- fix streaming fallback loop behavior by re-entering main body filter with the current unconsumed chain node after path switch
- propagate downstream body filter return code in fail-open initialization path instead of swallowing `NGX_AGAIN`/`NGX_ERROR`
- simplify ensure-handle callsite to propagate non-`NGX_OK` statuses directly

## Why
This addresses two review findings:
1. tail buffers could be dropped when fallback switched from streaming to full-buffer mid-chain
2. downstream status could be masked on fail-open init passthrough

## Validation
- `make -C components/nginx-module/tests unit-streaming`
- `make -C components/nginx-module/tests unit`
- `cd components/rust-converter && cargo test --features streaming --tests`

## Summary by Sourcery

Fix markdown streaming body filter fallback and error propagation behavior in the NGINX module.

Bug Fixes:
- Preserve remaining buffers when switching from streaming to full-buffer fallback by re-entering the main body filter with the current unconsumed chain node.
- Propagate downstream body filter return codes during fail-open initialization instead of masking NGX_AGAIN or NGX_ERROR statuses.

Enhancements:
- Simplify streaming handle initialization by having the ensure-handle helper propagate non-NGX_OK statuses directly to callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter result propagation in streaming operations to ensure proper status handling and edge case management for end-of-stream conditions.
  * Simplified initialization logic for more reliable fallback behavior in markdown streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->