### PR TITLE
fix: resolve validated streaming and release-gate findings

### DIFF
--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -312,6 +312,9 @@ typedef struct {
 
         /* Deferred terminal last_buf (backpressure during finalize) */
         ngx_flag_t                        finalize_pending_lastbuf;
+
+        /* Continue finalize() after tail-output backpressure drains */
+        ngx_flag_t                        finalize_after_pending;
     } streaming;
 #endif
 } ngx_http_markdown_ctx_t;

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -314,6 +314,7 @@ typedef struct {
         ngx_buf_t                       **failopen_consumed_bufs;
         u_char                          **failopen_consumed_pos;
         ngx_uint_t                        failopen_consumed_capacity;
+        ngx_uint_t                        failopen_consumed_count;
 
         /* Deferred terminal last_buf (backpressure during finalize) */
         ngx_flag_t                        finalize_pending_lastbuf;

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -310,6 +310,11 @@ typedef struct {
         size_t                            prebuffer_limit;
         ngx_flag_t                        prebuffer_initialized;
 
+        /* Reused fail-open restoration slots (avoid per-call allocations) */
+        ngx_buf_t                       **failopen_consumed_bufs;
+        u_char                          **failopen_consumed_pos;
+        ngx_uint_t                        failopen_consumed_capacity;
+
         /* Deferred terminal last_buf (backpressure during finalize) */
         ngx_flag_t                        finalize_pending_lastbuf;
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -735,6 +735,126 @@ ngx_http_markdown_streaming_decomp_feed(
 }
 
 
+static void
+ngx_http_markdown_streaming_decomp_finish_free_heap(
+    u_char **heap_buf_ptr)
+{
+    if (*heap_buf_ptr != NULL) {
+        ngx_free(*heap_buf_ptr);
+        *heap_buf_ptr = NULL;
+    }
+}
+
+
+static ngx_int_t
+ngx_http_markdown_streaming_decomp_finish_zlib(
+    ngx_http_markdown_streaming_decomp_t *decomp,
+    u_char **buf_ptr,
+    size_t *buf_size_ptr,
+    size_t *produced_ptr,
+    ngx_pool_t *pool,
+    ngx_log_t *log)
+{
+    u_char      *heap_buf;
+    ngx_flag_t   using_heap;
+    int          zrc;
+
+    heap_buf = NULL;
+    using_heap = 0;
+
+    decomp->state.zlib.next_in = Z_NULL;
+    decomp->state.zlib.avail_in = 0;
+    decomp->state.zlib.next_out = *buf_ptr;
+    decomp->state.zlib.avail_out = (uInt) *buf_size_ptr;
+
+    for ( ;; ) {
+        zrc = inflate(&decomp->state.zlib, Z_FINISH);
+
+        if (zrc != Z_STREAM_END && zrc != Z_OK
+            && zrc != Z_BUF_ERROR)
+        {
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                "markdown streaming decomp: "
+                "finish inflate error %d", zrc);
+            ngx_http_markdown_streaming_decomp_finish_free_heap(
+                &heap_buf);
+            return NGX_ERROR;
+        }
+
+        *produced_ptr = *buf_size_ptr
+                        - decomp->state.zlib.avail_out;
+
+        if (ngx_http_markdown_streaming_decomp_check_limit(
+                decomp, *produced_ptr))
+        {
+            ngx_log_error(NGX_LOG_WARN, log, 0,
+                "markdown streaming decomp: "
+                "decompressed size %uz exceeds limit %uz",
+                decomp->total_decompressed + *produced_ptr,
+                decomp->max_decompressed_size);
+            ngx_http_markdown_streaming_decomp_finish_free_heap(
+                &heap_buf);
+            return NGX_ERROR;
+        }
+
+        if (zrc == Z_STREAM_END) {
+            decomp->finished = 1;
+            break;
+        }
+
+        if (zrc == Z_BUF_ERROR
+            && decomp->state.zlib.avail_out != 0)
+        {
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                "markdown streaming decomp: "
+                "finish inflate incomplete stream");
+            ngx_http_markdown_streaming_decomp_finish_free_heap(
+                &heap_buf);
+            return NGX_ERROR;
+        }
+
+        if (decomp->state.zlib.avail_out != 0) {
+            continue;
+        }
+
+        {
+            size_t  old_size;
+
+            old_size = *buf_size_ptr;
+            /*
+             * expand_buf() frees any previous heap buffer if expansion fails,
+             * so we can safely return directly on NGX_ERROR here.
+             */
+            if (ngx_http_markdown_streaming_decomp_expand_buf(
+                    &heap_buf, buf_ptr, buf_size_ptr, log)
+                != NGX_OK)
+            {
+                return NGX_ERROR;
+            }
+
+            using_heap = 1;
+            decomp->state.zlib.next_out = *buf_ptr + old_size;
+            decomp->state.zlib.avail_out =
+                (uInt) (*buf_size_ptr - old_size);
+        }
+    }
+
+    if (!using_heap) {
+        return NGX_OK;
+    }
+
+    if (ngx_http_markdown_streaming_decomp_finalize_buf(
+            heap_buf, buf_ptr, buf_size_ptr,
+            *produced_ptr, pool)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
 /*
  * Finish decompression (handle last_buf).
  *
@@ -782,97 +902,14 @@ ngx_http_markdown_streaming_decomp_finish(
 
     case NGX_HTTP_MARKDOWN_COMPRESSION_GZIP:
     case NGX_HTTP_MARKDOWN_COMPRESSION_DEFLATE:
-    {
-        u_char  *heap_buf;
-        int      using_heap;
-        int  zrc;
-
-        heap_buf = NULL;
-        using_heap = 0;
-
-        decomp->state.zlib.next_in = Z_NULL;
-        decomp->state.zlib.avail_in = 0;
-        decomp->state.zlib.next_out = buf;
-        decomp->state.zlib.avail_out = (uInt) buf_size;
-
-        for ( ;; ) {
-            zrc = inflate(&decomp->state.zlib, Z_FINISH);
-
-            if (zrc != Z_STREAM_END && zrc != Z_OK
-                && zrc != Z_BUF_ERROR)
-            {
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                    "markdown streaming decomp: "
-                    "finish inflate error %d", zrc);
-                if (heap_buf != NULL) {
-                    ngx_free(heap_buf);
-                }
-                return NGX_ERROR;
-            }
-
-            produced = buf_size
-                       - decomp->state.zlib.avail_out;
-
-            if (ngx_http_markdown_streaming_decomp_check_limit(
-                    decomp, produced))
-            {
-                ngx_log_error(NGX_LOG_WARN, log, 0,
-                    "markdown streaming decomp: "
-                    "decompressed size %uz exceeds limit %uz",
-                    decomp->total_decompressed + produced,
-                    decomp->max_decompressed_size);
-                if (heap_buf != NULL) {
-                    ngx_free(heap_buf);
-                }
-                return NGX_ERROR;
-            }
-
-            if (zrc == Z_STREAM_END) {
-                decomp->finished = 1;
-                break;
-            }
-
-            if (decomp->state.zlib.avail_out == 0) {
-                size_t  old_size;
-
-                old_size = buf_size;
-                if (ngx_http_markdown_streaming_decomp_expand_buf(
-                        &heap_buf, &buf, &buf_size, log)
-                    != NGX_OK)
-                {
-                    return NGX_ERROR;
-                }
-
-                using_heap = 1;
-                decomp->state.zlib.next_out = buf + old_size;
-                decomp->state.zlib.avail_out =
-                    (uInt) (buf_size - old_size);
-                continue;
-            }
-
-            if (zrc == Z_BUF_ERROR) {
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                    "markdown streaming decomp: "
-                    "finish inflate incomplete stream");
-                if (heap_buf != NULL) {
-                    ngx_free(heap_buf);
-                }
-                return NGX_ERROR;
-            }
+        if (ngx_http_markdown_streaming_decomp_finish_zlib(
+                decomp, &buf, &buf_size,
+                &produced, pool, log)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
         }
-
-        if (using_heap) {
-            if (ngx_http_markdown_streaming_decomp_finalize_buf(
-                    heap_buf, &buf, &buf_size,
-                    produced, pool)
-                != NGX_OK)
-            {
-                return NGX_ERROR;
-            }
-        }
-
         break;
-    }
 
 #ifdef NGX_HTTP_BROTLI
     case NGX_HTTP_MARKDOWN_COMPRESSION_BROTLI:

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -318,6 +318,11 @@ ngx_http_markdown_streaming_decomp_inflate_step(
 
     zrc = inflate(&decomp->state.zlib, Z_SYNC_FLUSH);
 
+    /*
+     * Z_BUF_ERROR is non-fatal here: it can mean "need more output space"
+     * while still holding valid intermediate state. Treat it like a
+     * continue signal and let the caller grow the buffer when needed.
+     */
     if (zrc != Z_OK && zrc != Z_STREAM_END
         && zrc != Z_BUF_ERROR)
     {
@@ -527,6 +532,10 @@ ngx_http_markdown_streaming_decomp_brotli_step(
         }
 
         *using_heap_ptr = 1;
+        /*
+         * Expansion doubles the buffer. Resume writing at the old end so
+         * already-produced bytes remain intact at [0, old_size).
+         */
         decomp->brotli_next_out = *buf_ptr + old_size;
         decomp->brotli_avail_out = *buf_size_ptr - old_size;
         return 0;
@@ -774,27 +783,94 @@ ngx_http_markdown_streaming_decomp_finish(
     case NGX_HTTP_MARKDOWN_COMPRESSION_GZIP:
     case NGX_HTTP_MARKDOWN_COMPRESSION_DEFLATE:
     {
+        u_char  *heap_buf;
+        int      using_heap;
         int  zrc;
+
+        heap_buf = NULL;
+        using_heap = 0;
 
         decomp->state.zlib.next_in = Z_NULL;
         decomp->state.zlib.avail_in = 0;
         decomp->state.zlib.next_out = buf;
         decomp->state.zlib.avail_out = (uInt) buf_size;
 
-        zrc = inflate(&decomp->state.zlib, Z_FINISH);
+        for ( ;; ) {
+            zrc = inflate(&decomp->state.zlib, Z_FINISH);
 
-        if (zrc != Z_STREAM_END && zrc != Z_OK
-            && zrc != Z_BUF_ERROR)
-        {
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                "markdown streaming decomp: "
-                "finish inflate error %d", zrc);
-            return NGX_ERROR;
+            if (zrc != Z_STREAM_END && zrc != Z_OK
+                && zrc != Z_BUF_ERROR)
+            {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                    "markdown streaming decomp: "
+                    "finish inflate error %d", zrc);
+                if (heap_buf != NULL) {
+                    ngx_free(heap_buf);
+                }
+                return NGX_ERROR;
+            }
+
+            produced = buf_size
+                       - decomp->state.zlib.avail_out;
+
+            if (ngx_http_markdown_streaming_decomp_check_limit(
+                    decomp, produced))
+            {
+                ngx_log_error(NGX_LOG_WARN, log, 0,
+                    "markdown streaming decomp: "
+                    "decompressed size %uz exceeds limit %uz",
+                    decomp->total_decompressed + produced,
+                    decomp->max_decompressed_size);
+                if (heap_buf != NULL) {
+                    ngx_free(heap_buf);
+                }
+                return NGX_ERROR;
+            }
+
+            if (zrc == Z_STREAM_END) {
+                decomp->finished = 1;
+                break;
+            }
+
+            if (decomp->state.zlib.avail_out == 0) {
+                size_t  old_size;
+
+                old_size = buf_size;
+                if (ngx_http_markdown_streaming_decomp_expand_buf(
+                        &heap_buf, &buf, &buf_size, log)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+
+                using_heap = 1;
+                decomp->state.zlib.next_out = buf + old_size;
+                decomp->state.zlib.avail_out =
+                    (uInt) (buf_size - old_size);
+                continue;
+            }
+
+            if (zrc == Z_BUF_ERROR) {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                    "markdown streaming decomp: "
+                    "finish inflate incomplete stream");
+                if (heap_buf != NULL) {
+                    ngx_free(heap_buf);
+                }
+                return NGX_ERROR;
+            }
         }
 
-        produced = buf_size
-                   - decomp->state.zlib.avail_out;
-        decomp->finished = 1;
+        if (using_heap) {
+            if (ngx_http_markdown_streaming_decomp_finalize_buf(
+                    heap_buf, &buf, &buf_size,
+                    produced, pool)
+                != NGX_OK)
+            {
+                return NGX_ERROR;
+            }
+        }
+
         break;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -438,6 +438,27 @@ ngx_http_markdown_streaming_handle_backpressure(
 }
 
 
+static ngx_int_t
+ngx_http_markdown_streaming_send_deferred_lastbuf(
+    ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx)
+{
+    ngx_int_t  rc;
+
+    ctx->streaming.finalize_pending_lastbuf = 0;
+    rc = ngx_http_markdown_streaming_send_output(
+        r, ctx, NULL, 0, /* last_buf */ 1);
+
+    if (rc == NGX_AGAIN) {
+        ctx->streaming.finalize_pending_lastbuf = 1;
+        return ngx_http_markdown_streaming_handle_backpressure(
+            r, ctx);
+    }
+
+    return rc;
+}
+
+
 /*
  * Resume sending pending output after backpressure clears.
  */
@@ -459,9 +480,8 @@ ngx_http_markdown_streaming_resume_pending(
          * has been drained.
          */
         if (ctx->streaming.finalize_pending_lastbuf) {
-            ctx->streaming.finalize_pending_lastbuf = 0;
-            return ngx_http_markdown_streaming_send_output(
-                r, ctx, NULL, 0, /* last_buf */ 1);
+            return ngx_http_markdown_streaming_send_deferred_lastbuf(
+                r, ctx);
         }
 
         return NGX_OK;
@@ -486,9 +506,8 @@ ngx_http_markdown_streaming_resume_pending(
      * terminal last_buf, send it now.
      */
     if (ctx->streaming.finalize_pending_lastbuf) {
-        ctx->streaming.finalize_pending_lastbuf = 0;
-        return ngx_http_markdown_streaming_send_output(
-            r, ctx, NULL, 0, /* last_buf */ 1);
+        return ngx_http_markdown_streaming_send_deferred_lastbuf(
+            r, ctx);
     }
 
     return rc;
@@ -520,6 +539,7 @@ ngx_http_markdown_streaming_fallback_to_fullbuffer(
     /* Switch to full-buffer path */
     ctx->processing_path =
         NGX_HTTP_MARKDOWN_PATH_FULLBUFFER;
+    ctx->streaming.failopen_consumed_count = 0;
 
     /*
      * Clear conversion_attempted so the full-buffer body
@@ -690,6 +710,7 @@ ngx_http_markdown_streaming_commit(
 
     ctx->streaming.commit_state =
         NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx->streaming.failopen_consumed_count = 0;
     ctx->headers_forwarded = 1;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP,
@@ -1287,6 +1308,7 @@ ngx_http_markdown_streaming_init_handle(
 
     ctx->streaming.commit_state =
         NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx->streaming.failopen_consumed_count = 0;
 
     ctx->conversion_attempted = 1;
     NGX_HTTP_MARKDOWN_METRIC_INC(
@@ -1321,8 +1343,11 @@ ngx_http_markdown_streaming_failopen_passthrough(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in,
-    ngx_uint_t consumed_n)
+    ngx_uint_t invocation_start)
 {
+    ngx_chain_t *head;
+    ngx_chain_t **tail;
+    ngx_chain_t *cl;
     ngx_uint_t  i;
 
     /*
@@ -1330,7 +1355,7 @@ ngx_http_markdown_streaming_failopen_passthrough(
      * this chain were already marked consumed, restore their positions before
      * forwarding the chain downstream.
      */
-    for (i = 0; i < consumed_n; i++) {
+    for (i = 0; i < ctx->streaming.failopen_consumed_count; i++) {
         ctx->streaming.failopen_consumed_bufs[i]->pos =
             ctx->streaming.failopen_consumed_pos[i];
     }
@@ -1341,7 +1366,30 @@ ngx_http_markdown_streaming_failopen_passthrough(
         }
     }
 
-    return ngx_http_next_body_filter(r, in);
+    if (invocation_start == 0) {
+        return ngx_http_next_body_filter(r, in);
+    }
+
+    /*
+     * Previous invocations may already have consumed pre-commit buffers that are
+     * not part of the current `in` chain. Rebuild a prefix chain from durable
+     * per-request bookkeeping so fail-open can forward the full original body.
+     */
+    head = NULL;
+    tail = &head;
+    for (i = 0; i < invocation_start; i++) {
+        cl = ngx_alloc_chain_link(r->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+        cl->buf = ctx->streaming.failopen_consumed_bufs[i];
+        cl->next = NULL;
+        *tail = cl;
+        tail = &cl->next;
+    }
+    *tail = in;
+
+    return ngx_http_next_body_filter(r, head);
 }
 
 
@@ -1351,7 +1399,7 @@ ngx_http_markdown_streaming_handle_chunk_result(
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in,
     ngx_int_t rc,
-    ngx_uint_t consumed_n)
+    ngx_uint_t invocation_start)
 {
     if (rc == NGX_AGAIN) {
         return NGX_AGAIN;
@@ -1374,7 +1422,7 @@ ngx_http_markdown_streaming_handle_chunk_result(
 
     if (!ctx->eligible) {
         return ngx_http_markdown_streaming_failopen_passthrough(
-            r, ctx, in, consumed_n);
+            r, ctx, in, invocation_start);
     }
 
     return rc;
@@ -1578,31 +1626,46 @@ ngx_http_markdown_streaming_prepare_failopen_tracking(
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in)
 {
-    ngx_uint_t  chain_bufs;
+    ngx_buf_t  **new_bufs;
+    u_char     **new_pos;
+    ngx_uint_t   chain_bufs;
+    ngx_uint_t   required;
 
     chain_bufs = ngx_http_markdown_streaming_count_chain_bufs(
         in);
+    required = ctx->streaming.failopen_consumed_count
+               + chain_bufs;
 
-    if (chain_bufs == 0
-        || chain_bufs <= ctx->streaming.failopen_consumed_capacity)
+    if (required == 0
+        || required <= ctx->streaming.failopen_consumed_capacity)
     {
         return NGX_OK;
     }
 
-    ctx->streaming.failopen_consumed_bufs =
-        ngx_pnalloc(r->pool,
-            chain_bufs * sizeof(ngx_buf_t *));
-    ctx->streaming.failopen_consumed_pos =
-        ngx_pnalloc(r->pool,
-            chain_bufs * sizeof(u_char *));
+    new_bufs = ngx_pnalloc(r->pool,
+        required * sizeof(ngx_buf_t *));
+    new_pos = ngx_pnalloc(r->pool,
+        required * sizeof(u_char *));
 
-    if (ctx->streaming.failopen_consumed_bufs == NULL
-        || ctx->streaming.failopen_consumed_pos == NULL)
+    if (new_bufs == NULL || new_pos == NULL)
     {
         return NGX_ERROR;
     }
 
-    ctx->streaming.failopen_consumed_capacity = chain_bufs;
+    if (ctx->streaming.failopen_consumed_count > 0) {
+        ngx_memcpy(new_bufs,
+            ctx->streaming.failopen_consumed_bufs,
+            ctx->streaming.failopen_consumed_count
+                * sizeof(ngx_buf_t *));
+        ngx_memcpy(new_pos,
+            ctx->streaming.failopen_consumed_pos,
+            ctx->streaming.failopen_consumed_count
+                * sizeof(u_char *));
+    }
+
+    ctx->streaming.failopen_consumed_bufs = new_bufs;
+    ctx->streaming.failopen_consumed_pos = new_pos;
+    ctx->streaming.failopen_consumed_capacity = required;
     return NGX_OK;
 }
 
@@ -1614,14 +1677,14 @@ ngx_http_markdown_streaming_process_chain(
     ngx_http_markdown_conf_t *conf,
     ngx_chain_t *in,
     ngx_flag_t *last_buf,
-    ngx_uint_t *consumed_n,
+    ngx_uint_t invocation_start,
     ngx_chain_t **fallback_cl)
 {
+    ngx_uint_t   idx;
     ngx_chain_t  *cl;
     ngx_int_t     rc;
 
     *last_buf = 0;
-    *consumed_n = 0;
     *fallback_cl = NULL;
 
     for (cl = in; cl != NULL; cl = cl->next) {
@@ -1639,7 +1702,7 @@ ngx_http_markdown_streaming_process_chain(
             r, ctx, conf, cl->buf);
 
         rc = ngx_http_markdown_streaming_handle_chunk_result(
-            r, ctx, in, rc, *consumed_n);
+            r, ctx, in, rc, invocation_start);
 
         if (rc != NGX_OK) {
             if (rc == NGX_DONE) {
@@ -1648,11 +1711,10 @@ ngx_http_markdown_streaming_process_chain(
             return rc;
         }
 
-        ctx->streaming.failopen_consumed_bufs[*consumed_n] =
-            cl->buf;
-        ctx->streaming.failopen_consumed_pos[*consumed_n] =
-            cl->buf->pos;
-        (*consumed_n)++;
+        idx = ctx->streaming.failopen_consumed_count;
+        ctx->streaming.failopen_consumed_bufs[idx] = cl->buf;
+        ctx->streaming.failopen_consumed_pos[idx] = cl->buf->pos;
+        ctx->streaming.failopen_consumed_count++;
 
         /* Mark buffer as consumed */
         cl->buf->pos = cl->buf->last;
@@ -1678,7 +1740,7 @@ ngx_http_markdown_streaming_body_filter(
     ngx_chain_t               *fallback_cl;
     ngx_int_t                  rc;
     ngx_flag_t                 last_buf;
-    ngx_uint_t                 consumed_n;
+    ngx_uint_t                 invocation_start;
 
     ctx = ngx_http_get_module_ctx(r,
         ngx_http_markdown_filter_module);
@@ -1717,6 +1779,8 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, in);
     }
 
+    invocation_start = ctx->streaming.failopen_consumed_count;
+
     rc = ngx_http_markdown_streaming_prepare_failopen_tracking(
         r, ctx, in);
     if (rc != NGX_OK) {
@@ -1724,7 +1788,7 @@ ngx_http_markdown_streaming_body_filter(
     }
 
     rc = ngx_http_markdown_streaming_process_chain(
-        r, ctx, conf, in, &last_buf, &consumed_n,
+        r, ctx, conf, in, &last_buf, invocation_start,
         &fallback_cl);
     if (rc == NGX_DONE) {
         return ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
@@ -1741,7 +1805,7 @@ ngx_http_markdown_streaming_body_filter(
 
         if (rc == NGX_DECLINED && !ctx->eligible) {
             return ngx_http_markdown_streaming_failopen_passthrough(
-                r, ctx, in, consumed_n);
+                r, ctx, in, invocation_start);
         }
 
         return rc;

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -1321,8 +1321,6 @@ ngx_http_markdown_streaming_failopen_passthrough(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in,
-    ngx_buf_t **consumed_bufs,
-    u_char **consumed_pos,
     ngx_uint_t consumed_n)
 {
     ngx_uint_t  i;
@@ -1333,7 +1331,8 @@ ngx_http_markdown_streaming_failopen_passthrough(
      * forwarding the chain downstream.
      */
     for (i = 0; i < consumed_n; i++) {
-        consumed_bufs[i]->pos = consumed_pos[i];
+        ctx->streaming.failopen_consumed_bufs[i]->pos =
+            ctx->streaming.failopen_consumed_pos[i];
     }
 
     if (!ctx->headers_forwarded) {
@@ -1352,8 +1351,6 @@ ngx_http_markdown_streaming_handle_chunk_result(
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in,
     ngx_int_t rc,
-    ngx_buf_t **consumed_bufs,
-    u_char **consumed_pos,
     ngx_uint_t consumed_n)
 {
     if (rc == NGX_AGAIN) {
@@ -1377,8 +1374,7 @@ ngx_http_markdown_streaming_handle_chunk_result(
 
     if (!ctx->eligible) {
         return ngx_http_markdown_streaming_failopen_passthrough(
-            r, ctx, in,
-            consumed_bufs, consumed_pos, consumed_n);
+            r, ctx, in, consumed_n);
     }
 
     return rc;
@@ -1534,6 +1530,138 @@ ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
 }
 
 
+static ngx_int_t
+ngx_http_markdown_streaming_handle_null_input(
+    ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx,
+    ngx_http_markdown_conf_t *conf)
+{
+    ngx_int_t  rc;
+
+    rc = ngx_http_markdown_streaming_resume_pending(
+        r, ctx);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    if (ctx->streaming.finalize_after_pending) {
+        ctx->streaming.finalize_after_pending = 0;
+        return ngx_http_markdown_streaming_finalize_request(
+            r, ctx, conf);
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_uint_t
+ngx_http_markdown_streaming_count_chain_bufs(
+    ngx_chain_t *in)
+{
+    ngx_chain_t *cl;
+    ngx_uint_t   chain_bufs;
+
+    chain_bufs = 0;
+    for (cl = in; cl != NULL; cl = cl->next) {
+        if (cl->buf != NULL) {
+            chain_bufs++;
+        }
+    }
+
+    return chain_bufs;
+}
+
+
+static ngx_int_t
+ngx_http_markdown_streaming_prepare_failopen_tracking(
+    ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx,
+    ngx_chain_t *in)
+{
+    ngx_uint_t  chain_bufs;
+
+    chain_bufs = ngx_http_markdown_streaming_count_chain_bufs(
+        in);
+
+    if (chain_bufs == 0
+        || chain_bufs <= ctx->streaming.failopen_consumed_capacity)
+    {
+        return NGX_OK;
+    }
+
+    ctx->streaming.failopen_consumed_bufs =
+        ngx_pnalloc(r->pool,
+            chain_bufs * sizeof(ngx_buf_t *));
+    ctx->streaming.failopen_consumed_pos =
+        ngx_pnalloc(r->pool,
+            chain_bufs * sizeof(u_char *));
+
+    if (ctx->streaming.failopen_consumed_bufs == NULL
+        || ctx->streaming.failopen_consumed_pos == NULL)
+    {
+        return NGX_ERROR;
+    }
+
+    ctx->streaming.failopen_consumed_capacity = chain_bufs;
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_markdown_streaming_process_chain(
+    ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx,
+    ngx_http_markdown_conf_t *conf,
+    ngx_chain_t *in,
+    ngx_flag_t *last_buf,
+    ngx_uint_t *consumed_n,
+    ngx_chain_t **fallback_cl)
+{
+    ngx_chain_t  *cl;
+    ngx_int_t     rc;
+
+    *last_buf = 0;
+    *consumed_n = 0;
+    *fallback_cl = NULL;
+
+    for (cl = in; cl != NULL; cl = cl->next) {
+        if (cl->buf == NULL) {
+            continue;
+        }
+
+        if (cl->buf->last_buf
+            || (r != r->main && cl->buf->last_in_chain))
+        {
+            *last_buf = 1;
+        }
+
+        rc = ngx_http_markdown_streaming_process_chunk(
+            r, ctx, conf, cl->buf);
+
+        rc = ngx_http_markdown_streaming_handle_chunk_result(
+            r, ctx, in, rc, *consumed_n);
+
+        if (rc != NGX_OK) {
+            if (rc == NGX_DONE) {
+                *fallback_cl = cl;
+            }
+            return rc;
+        }
+
+        ctx->streaming.failopen_consumed_bufs[*consumed_n] =
+            cl->buf;
+        ctx->streaming.failopen_consumed_pos[*consumed_n] =
+            cl->buf->pos;
+        (*consumed_n)++;
+
+        /* Mark buffer as consumed */
+        cl->buf->pos = cl->buf->last;
+    }
+
+    return NGX_OK;
+}
+
+
 /*
  * Streaming body filter main entry point.
  *
@@ -1547,12 +1675,9 @@ ngx_http_markdown_streaming_body_filter(
 {
     ngx_http_markdown_ctx_t   *ctx;
     ngx_http_markdown_conf_t  *conf;
-    ngx_chain_t               *cl;
-    ngx_buf_t               **consumed_bufs;
-    u_char                  **consumed_pos;
+    ngx_chain_t               *fallback_cl;
     ngx_int_t                  rc;
     ngx_flag_t                 last_buf;
-    ngx_uint_t                 chain_bufs;
     ngx_uint_t                 consumed_n;
 
     ctx = ngx_http_get_module_ctx(r,
@@ -1576,19 +1701,8 @@ ngx_http_markdown_streaming_body_filter(
 
     /* Resume pending output (backpressure recovery) */
     if (in == NULL) {
-        rc = ngx_http_markdown_streaming_resume_pending(
-            r, ctx);
-        if (rc != NGX_OK) {
-            return rc;
-        }
-
-        if (ctx->streaming.finalize_after_pending) {
-            ctx->streaming.finalize_after_pending = 0;
-            return ngx_http_markdown_streaming_finalize_request(
-                r, ctx, conf);
-        }
-
-        return NGX_OK;
+        return ngx_http_markdown_streaming_handle_null_input(
+            r, ctx, conf);
     }
 
     /* Initialize streaming handle on first call */
@@ -1603,62 +1717,21 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, in);
     }
 
-    chain_bufs = 0;
-    for (cl = in; cl != NULL; cl = cl->next) {
-        if (cl->buf != NULL) {
-            chain_bufs++;
-        }
+    rc = ngx_http_markdown_streaming_prepare_failopen_tracking(
+        r, ctx, in);
+    if (rc != NGX_OK) {
+        return rc;
     }
 
-    consumed_bufs = NULL;
-    consumed_pos = NULL;
-    consumed_n = 0;
-    if (chain_bufs > 0) {
-        consumed_bufs = ngx_pnalloc(r->pool,
-            chain_bufs * sizeof(ngx_buf_t *));
-        consumed_pos = ngx_pnalloc(r->pool,
-            chain_bufs * sizeof(u_char *));
-        if (consumed_bufs == NULL || consumed_pos == NULL) {
-            return NGX_ERROR;
-        }
+    rc = ngx_http_markdown_streaming_process_chain(
+        r, ctx, conf, in, &last_buf, &consumed_n,
+        &fallback_cl);
+    if (rc == NGX_DONE) {
+        return ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+            r, fallback_cl, last_buf);
     }
-
-    /* Process each chunk in the input chain */
-    last_buf = 0;
-    for (cl = in; cl != NULL; cl = cl->next) {
-        if (cl->buf == NULL) {
-            continue;
-        }
-
-        if (cl->buf->last_buf
-            || (r != r->main && cl->buf->last_in_chain))
-        {
-            last_buf = 1;
-        }
-
-        rc = ngx_http_markdown_streaming_process_chunk(
-            r, ctx, conf, cl->buf);
-
-        rc = ngx_http_markdown_streaming_handle_chunk_result(
-            r, ctx, in, rc,
-            consumed_bufs, consumed_pos, consumed_n);
-
-        if (rc == NGX_DONE) {
-            return
-                ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
-                    r, cl, last_buf);
-        }
-
-        if (rc != NGX_OK) {
-            return rc;
-        }
-
-        consumed_bufs[consumed_n] = cl->buf;
-        consumed_pos[consumed_n] = cl->buf->pos;
-        consumed_n++;
-
-        /* Mark buffer as consumed */
-        cl->buf->pos = cl->buf->last;
+    if (rc != NGX_OK) {
+        return rc;
     }
 
     /* Handle last_buf: finalize */
@@ -1668,8 +1741,7 @@ ngx_http_markdown_streaming_body_filter(
 
         if (rc == NGX_DECLINED && !ctx->eligible) {
             return ngx_http_markdown_streaming_failopen_passthrough(
-                r, ctx, in,
-                consumed_bufs, consumed_pos, consumed_n);
+                r, ctx, in, consumed_n);
         }
 
         return rc;

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -450,7 +450,6 @@ ngx_http_markdown_streaming_send_deferred_lastbuf(
         r, ctx, NULL, 0, /* last_buf */ 1);
 
     if (rc == NGX_AGAIN) {
-        ctx->streaming.finalize_pending_lastbuf = 1;
         return ngx_http_markdown_streaming_handle_backpressure(
             r, ctx);
     }
@@ -1631,6 +1630,12 @@ ngx_http_markdown_streaming_prepare_failopen_tracking(
     ngx_uint_t   chain_bufs;
     ngx_uint_t   required;
 
+    if (ctx->streaming.commit_state
+        == NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST)
+    {
+        return NGX_OK;
+    }
+
     chain_bufs = ngx_http_markdown_streaming_count_chain_bufs(
         in);
     required = ctx->streaming.failopen_consumed_count
@@ -1680,7 +1685,6 @@ ngx_http_markdown_streaming_process_chain(
     ngx_uint_t invocation_start,
     ngx_chain_t **fallback_cl)
 {
-    ngx_uint_t   idx;
     ngx_chain_t  *cl;
     ngx_int_t     rc;
 
@@ -1711,10 +1715,16 @@ ngx_http_markdown_streaming_process_chain(
             return rc;
         }
 
-        idx = ctx->streaming.failopen_consumed_count;
-        ctx->streaming.failopen_consumed_bufs[idx] = cl->buf;
-        ctx->streaming.failopen_consumed_pos[idx] = cl->buf->pos;
-        ctx->streaming.failopen_consumed_count++;
+        if (ctx->streaming.commit_state
+            == NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE)
+        {
+            ngx_uint_t idx;
+
+            idx = ctx->streaming.failopen_consumed_count;
+            ctx->streaming.failopen_consumed_bufs[idx] = cl->buf;
+            ctx->streaming.failopen_consumed_pos[idx] = cl->buf->pos;
+            ctx->streaming.failopen_consumed_count++;
+        }
 
         /* Mark buffer as consumed */
         cl->buf->pos = cl->buf->last;

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -407,6 +407,11 @@ ngx_http_markdown_streaming_send_output(
     }
 
     if (rc == NGX_AGAIN) {
+        /*
+         * Keep exactly one outstanding pending chain owned by this
+         * request context. The retry path (resume_pending) will submit
+         * this same chain again once downstream write readiness returns.
+         */
         ctx->streaming.pending_output = out;
     }
 
@@ -463,6 +468,10 @@ ngx_http_markdown_streaming_resume_pending(
     }
 
     ctx->streaming.pending_output = NULL;
+    /*
+     * Retry the exact buffered chain first; only after it drains do we
+     * allow finalize() to emit a terminal empty last_buf.
+     */
     rc = ngx_http_next_body_filter(r, out);
 
     if (rc == NGX_AGAIN) {
@@ -1043,9 +1052,15 @@ ngx_http_markdown_streaming_finalize_request(
             r, ctx, NULL, 0, /* last_buf */ 1);
     }
 
+    ctx->streaming.finalize_after_pending = 0;
+
     /* Finish decompression and feed tail data if any */
     rc = ngx_http_markdown_streaming_finalize_decomp(
         r, ctx, conf);
+    if (rc == NGX_AGAIN) {
+        ctx->streaming.finalize_after_pending = 1;
+        return NGX_AGAIN;
+    }
     if (rc != NGX_OK) {
         return rc;
     }
@@ -1080,10 +1095,9 @@ ngx_http_markdown_streaming_finalize_request(
                 r, ctx, NULL, 0, /* last_buf */ 1);
         }
 
-        /* Pre-Commit finalize error */
-        NGX_HTTP_MARKDOWN_METRIC_INC(
-            streaming.failed_total);
-        return NGX_ERROR;
+        /* Pre-Commit finalize error follows configured policy */
+        return ngx_http_markdown_streaming_precommit_error(
+            r, ctx, conf, /* inc_failopen */ 1);
     }
 
     /* Send final Markdown output if any */
@@ -1303,11 +1317,44 @@ ngx_http_markdown_streaming_init_handle(
  *   other        - return value to propagate
  */
 static ngx_int_t
+ngx_http_markdown_streaming_failopen_passthrough(
+    ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx,
+    ngx_chain_t *in,
+    ngx_buf_t **consumed_bufs,
+    u_char **consumed_pos,
+    ngx_uint_t consumed_n)
+{
+    ngx_uint_t  i;
+
+    /*
+     * Fail-open must preserve the original upstream bytes. If earlier chunks in
+     * this chain were already marked consumed, restore their positions before
+     * forwarding the chain downstream.
+     */
+    for (i = 0; i < consumed_n; i++) {
+        consumed_bufs[i]->pos = consumed_pos[i];
+    }
+
+    if (!ctx->headers_forwarded) {
+        if (ngx_http_markdown_forward_headers(r, ctx) != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    return ngx_http_next_body_filter(r, in);
+}
+
+
+static ngx_int_t
 ngx_http_markdown_streaming_handle_chunk_result(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
     ngx_chain_t *in,
-    ngx_int_t rc)
+    ngx_int_t rc,
+    ngx_buf_t **consumed_bufs,
+    u_char **consumed_pos,
+    ngx_uint_t consumed_n)
 {
     if (rc == NGX_AGAIN) {
         return NGX_AGAIN;
@@ -1329,13 +1376,9 @@ ngx_http_markdown_streaming_handle_chunk_result(
     }
 
     if (!ctx->eligible) {
-        /* Fail-open: forward remaining */
-        if (!ctx->headers_forwarded) {
-            ngx_http_markdown_forward_headers(
-                r, ctx);
-        }
-        return ngx_http_next_body_filter(
-            r, in);
+        return ngx_http_markdown_streaming_failopen_passthrough(
+            r, ctx, in,
+            consumed_bufs, consumed_pos, consumed_n);
     }
 
     return rc;
@@ -1505,8 +1548,12 @@ ngx_http_markdown_streaming_body_filter(
     ngx_http_markdown_ctx_t   *ctx;
     ngx_http_markdown_conf_t  *conf;
     ngx_chain_t               *cl;
+    ngx_buf_t               **consumed_bufs;
+    u_char                  **consumed_pos;
     ngx_int_t                  rc;
     ngx_flag_t                 last_buf;
+    ngx_uint_t                 chain_bufs;
+    ngx_uint_t                 consumed_n;
 
     ctx = ngx_http_get_module_ctx(r,
         ngx_http_markdown_filter_module);
@@ -1529,8 +1576,19 @@ ngx_http_markdown_streaming_body_filter(
 
     /* Resume pending output (backpressure recovery) */
     if (in == NULL) {
-        return ngx_http_markdown_streaming_resume_pending(
+        rc = ngx_http_markdown_streaming_resume_pending(
             r, ctx);
+        if (rc != NGX_OK) {
+            return rc;
+        }
+
+        if (ctx->streaming.finalize_after_pending) {
+            ctx->streaming.finalize_after_pending = 0;
+            return ngx_http_markdown_streaming_finalize_request(
+                r, ctx, conf);
+        }
+
+        return NGX_OK;
     }
 
     /* Initialize streaming handle on first call */
@@ -1543,6 +1601,26 @@ ngx_http_markdown_streaming_body_filter(
     if (!ctx->eligible || ctx->streaming.handle == NULL) {
         return ngx_http_markdown_streaming_passthrough(
             r, ctx, in);
+    }
+
+    chain_bufs = 0;
+    for (cl = in; cl != NULL; cl = cl->next) {
+        if (cl->buf != NULL) {
+            chain_bufs++;
+        }
+    }
+
+    consumed_bufs = NULL;
+    consumed_pos = NULL;
+    consumed_n = 0;
+    if (chain_bufs > 0) {
+        consumed_bufs = ngx_pnalloc(r->pool,
+            chain_bufs * sizeof(ngx_buf_t *));
+        consumed_pos = ngx_pnalloc(r->pool,
+            chain_bufs * sizeof(u_char *));
+        if (consumed_bufs == NULL || consumed_pos == NULL) {
+            return NGX_ERROR;
+        }
     }
 
     /* Process each chunk in the input chain */
@@ -1562,7 +1640,8 @@ ngx_http_markdown_streaming_body_filter(
             r, ctx, conf, cl->buf);
 
         rc = ngx_http_markdown_streaming_handle_chunk_result(
-            r, ctx, in, rc);
+            r, ctx, in, rc,
+            consumed_bufs, consumed_pos, consumed_n);
 
         if (rc == NGX_DONE) {
             return
@@ -1574,15 +1653,26 @@ ngx_http_markdown_streaming_body_filter(
             return rc;
         }
 
+        consumed_bufs[consumed_n] = cl->buf;
+        consumed_pos[consumed_n] = cl->buf->pos;
+        consumed_n++;
+
         /* Mark buffer as consumed */
         cl->buf->pos = cl->buf->last;
     }
 
     /* Handle last_buf: finalize */
     if (last_buf) {
-        return
-            ngx_http_markdown_streaming_finalize_request(
-                r, ctx, conf);
+        rc = ngx_http_markdown_streaming_finalize_request(
+            r, ctx, conf);
+
+        if (rc == NGX_DECLINED && !ctx->eligible) {
+            return ngx_http_markdown_streaming_failopen_passthrough(
+                r, ctx, in,
+                consumed_bufs, consumed_pos, consumed_n);
+        }
+
+        return rc;
     }
 
     return NGX_OK;

--- a/components/rust-converter/src/streaming/state_machine.rs
+++ b/components/rust-converter/src/streaming/state_machine.rs
@@ -349,9 +349,9 @@ impl StructuralStateMachine {
                 }
             }
             "ol" => {
-                self.list_depth = self.list_depth.saturating_sub(1);
-                self.ordered_list_counters.pop();
                 if let Some(ctx) = self.pop_matching_context(name) {
+                    self.list_depth = self.list_depth.saturating_sub(1);
+                    self.ordered_list_counters.pop();
                     self.needs_block_separator = true;
                     Ok(StateMachineAction::Exit(ctx))
                 } else {
@@ -359,8 +359,8 @@ impl StructuralStateMachine {
                 }
             }
             "ul" => {
-                self.list_depth = self.list_depth.saturating_sub(1);
                 if let Some(ctx) = self.pop_matching_context(name) {
+                    self.list_depth = self.list_depth.saturating_sub(1);
                     self.needs_block_separator = true;
                     Ok(StateMachineAction::Exit(ctx))
                 } else {
@@ -771,6 +771,20 @@ mod tests {
         sm.process_event(&end_tag("li")).unwrap();
         sm.process_event(&end_tag("ul")).unwrap();
         assert_eq!(sm.list_depth, 0);
+    }
+
+    #[test]
+    fn test_unmatched_list_end_tag_does_not_mutate_state() {
+        let mut sm = default_sm();
+
+        sm.process_event(&start_tag("ol")).unwrap();
+        assert_eq!(sm.list_depth, 1);
+        assert_eq!(sm.next_ordered_item_number(), 1);
+
+        let action = sm.process_event(&end_tag("ul")).unwrap();
+        assert_eq!(action, StateMachineAction::None);
+        assert_eq!(sm.list_depth, 1);
+        assert_eq!(sm.next_ordered_item_number(), 2);
     }
 
     #[test]

--- a/tools/release_gates/tests/test_naming_properties.py
+++ b/tools/release_gates/tests/test_naming_properties.py
@@ -9,7 +9,7 @@ Each property runs at least 100 iterations.
 Validates: Requirements 18.1, 18.2, 18.3, 18.4
 """
 
-from hypothesis import given, settings, assume
+from hypothesis import given, settings, assume, example
 from hypothesis import strategies as st
 
 import sys
@@ -137,6 +137,36 @@ def test_invalid_c_macro_no_prefix(name):
 def test_forbidden_labels_detected(label):
     """All forbidden labels must be detected."""
     assert is_forbidden_label(label), f"should detect forbidden: {label}"
+
+
+def _alternating_case(label: str) -> str:
+    """Return a deterministic mixed-case variant of *label*."""
+    return "".join(
+        ch.upper() if i % 2 == 0 else ch.lower()
+        for i, ch in enumerate(label)
+    )
+
+
+@settings(max_examples=100)
+@example(label="url", casing="upper")
+@example(label="host", casing="capitalized")
+@example(label="referer", casing="alternating")
+@given(
+    label=st.sampled_from(sorted(FORBIDDEN_LABELS)),
+    casing=st.sampled_from(["upper", "capitalized", "alternating"]),
+)
+def test_forbidden_labels_detected_case_insensitive(label, casing):
+    """Forbidden labels must still be detected under case variants."""
+    if casing == "upper":
+        candidate = label.upper()
+    elif casing == "capitalized":
+        candidate = label.capitalize()
+    else:
+        candidate = _alternating_case(label)
+
+    assert is_forbidden_label(candidate), (
+        f"should detect forbidden case variant: {candidate}"
+    )
 
 
 @settings(max_examples=100)

--- a/tools/release_gates/validate_naming.py
+++ b/tools/release_gates/validate_naming.py
@@ -54,7 +54,7 @@ def is_valid_c_macro(name: str) -> bool:
 
 def is_forbidden_label(label: str) -> bool:
     """Return True if *label* is in the forbidden high-cardinality set."""
-    return label in FORBIDDEN_LABELS
+    return label.casefold() in FORBIDDEN_LABELS
 
 
 def validate_names(

--- a/tools/release_gates/validate_release_gates.py
+++ b/tools/release_gates/validate_release_gates.py
@@ -126,22 +126,32 @@ class ValidationResult:
     """Collects pass/fail/skip results for structured output."""
 
     def __init__(self) -> None:
+        """Initialize an empty result list.
+
+        Each entry is stored as ``(status, check_name, detail)`` where status
+        is one of ``PASS``, ``FAIL``, or ``SKIP``.
+        """
         self.results: list[tuple[str, str, str]] = []
 
     def passed(self, check: str, detail: str = "") -> None:
+        """Record a successful check result."""
         self.results.append(("PASS", check, detail))
 
     def failed(self, check: str, detail: str = "") -> None:
+        """Record a failed check result."""
         self.results.append(("FAIL", check, detail))
 
     def skipped(self, check: str, detail: str = "") -> None:
+        """Record a skipped check result."""
         self.results.append(("SKIP", check, detail))
 
     @property
     def has_failures(self) -> bool:
+        """Return ``True`` when at least one recorded result is ``FAIL``."""
         return any(s == "FAIL" for s, _, _ in self.results)
 
     def print_report(self) -> None:
+        """Print one human-readable line per recorded validation result."""
         for status, check, detail in self.results:
             suffix = f" — {detail}" if detail else ""
             print(f"  [{status}] {check}{suffix}")
@@ -725,9 +735,12 @@ def check_non_goals(result: ValidationResult) -> None:
         result.failed("non-goals", "release-gates-0-5-0.md not found")
         return
 
-    # Key non-goal keywords that should be present
+    # Key non-goal keywords that should be present (case-insensitive)
+    content_folded = content.casefold()
     non_goal_keywords = ["JSON", "OpenTelemetry", "GUI", "Helm", "tokenizer"]
-    if missing := [kw for kw in non_goal_keywords if kw not in content]:
+    if missing := [
+        kw for kw in non_goal_keywords if kw.casefold() not in content_folded
+    ]:
         result.failed("non-goals", f"missing non-goal keywords: {', '.join(missing)}")
     else:
         result.passed("non-goals")

--- a/tools/release_gates/validate_release_gates.py
+++ b/tools/release_gates/validate_release_gates.py
@@ -28,6 +28,7 @@ validation (path traversal prevention).
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -735,11 +736,17 @@ def check_non_goals(result: ValidationResult) -> None:
         result.failed("non-goals", "release-gates-0-5-0.md not found")
         return
 
-    # Key non-goal keywords that should be present (case-insensitive)
-    content_folded = content.casefold()
+    # Key non-goal keywords that should be present (case-insensitive, whole word)
     non_goal_keywords = ["JSON", "OpenTelemetry", "GUI", "Helm", "tokenizer"]
     if missing := [
-        kw for kw in non_goal_keywords if kw.casefold() not in content_folded
+        kw
+        for kw in non_goal_keywords
+        if re.search(
+            rf"(?<![0-9A-Za-z_]){re.escape(kw)}(?![0-9A-Za-z_])",
+            content,
+            flags=re.IGNORECASE,
+        )
+        is None
     ]:
         result.failed("non-goals", f"missing non-goal keywords: {', '.join(missing)}")
     else:


### PR DESCRIPTION
## Summary
This PR re-validates and fixes the previously raised C/Rust streaming and release-tool findings.

### Streaming runtime (P1)
- preserve original body on fail-open by restoring previously consumed buffer positions before passthrough
- resume `finalize()` after tail-feed backpressure (`NGX_AGAIN`) via explicit pending-finalize state
- make `decomp_finish` loop `inflate(Z_FINISH)` until `Z_STREAM_END` (with buffer growth + size-limit checks)
- make Pre-Commit finalize errors follow configured `on_error` policy instead of unconditional `NGX_ERROR`

### Release/Rust tooling (P2)
- non-goal keyword check is now case-insensitive
- forbidden label check is now case-insensitive
- state machine only decrements list depth / pops ordered counters when a matching `</ol>`/`</ul>` context is actually found
- add regression test for unmatched list end tags

## Validation
- `python3 -m py_compile tools/release_gates/validate_release_gates.py tools/release_gates/validate_naming.py`
- `cd components/rust-converter && cargo test -q --features streaming streaming::state_machine::tests::test_unmatched_list_end_tag_does_not_mutate_state`
- `cd components/rust-converter && cargo test -q --features streaming streaming::converter::tests::test_commit_state_transitions`
- `make test-nginx-unit-streaming`
- `make -C components/nginx-module/tests unit-header_compile`

## Notes
- `python3 tools/release_gates/validate_naming.py` cannot run in this environment because the local interpreter is Python 3.9.6 and this script uses 3.10+ `|` type-union annotations.
- `python3 tools/release_gates/validate_release_gates.py` currently reports one pre-existing docs-directory failure unrelated to this patch (`docs-exist:12-overall-scope-release-gates-0-5-0`).

## Summary by Sourcery

Improve markdown streaming fail-open behavior, decompression finalization, and backpressure handling, and tighten release validation and Rust streaming state machine correctness.

Bug Fixes:
- Preserve original upstream response bytes when failing open in the markdown streaming filter instead of forwarding partially consumed buffers.
- Ensure finalize() in the streaming filter resumes correctly after tail-output backpressure by deferring finalization until pending output drains.
- Make gzip/deflate decompression finish logic loop until Z_STREAM_END with proper buffer growth, size-limit enforcement, and robust handling of Z_BUF_ERROR.
- Align Pre-Commit finalize error handling in the streaming filter with the configured on_error policy instead of always returning NGX_ERROR.
- Fix the Rust structural state machine so list depth and ordered counters are only mutated when a matching </ol>/<ul> context is found, avoiding state corruption on unmatched tags.
- Make non-goal keyword validation case-insensitive so content is correctly detected regardless of casing.
- Make the forbidden label check case-insensitive to catch labels irrespective of case variations.

Enhancements:
- Clarify and document validation result handling in the release gate tooling with docstrings and a structured result printer.
- Improve Brotli decompression buffer expansion comments and behavior to ensure output continuity when resizing buffers.

Tests:
- Add a Rust regression test ensuring unmatched list end tags do not change list depth or ordered list counters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed list state machine to avoid state corruption on unmatched end tags.

* **Improvements**
  * Improved streaming output buffering and backpressure handling for more reliable delivery.
  * Enhanced decompression error recovery and fail-open passthrough to preserve bytes across retries.
  * Made release-gates name/keyword checks case-insensitive for more consistent validation.

* **Refactor**
  * Reworked internal decompression finish logic for robust incremental output and buffer growth.

* **Tests**
  * Added unit/property tests for unmatched list end tags and case-insensitive forbidden-label detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->