### PR TITLE
chore(deps): bump the rust-patch-minor group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ If two rules conflict, follow the higher-priority source.
   `int`, and declarations without proper prototypes).
 - Use `u_char *`, `ngx_str_t`, and NGINX helpers (`ngx_snprintf`, `ngx_memcpy`, etc.) consistently.
 - Use `NULL` pointer comparisons (not `0`).
+- For POSIX string helpers (for example `strcasecmp`, `strncasecmp`), include
+  `<strings.h>` explicitly in the translation unit or shared header. Do not
+  rely on transitive includes or implicit declarations.
 - **Never dereference or perform relational operations on values that may be uninitialized, NULL, or invalid without an explicit guard.** This includes: pointer comparisons (`p > q`, `p < q`), pointer arithmetic, field access through pointers, array indexing with unvalidated bounds. When the validity of a value depends on runtime state (for example `pos/last` may both be NULL in empty buffers), use an explicit boolean flag set at the production site rather than inferring state from value relationships.
 
 ## Frequent Error Patterns and Required Prevention
@@ -325,6 +328,11 @@ Required:
   `tests/corpus/**/.meta.json -> streaming_notes.known_diff_ids` synchronized
   with `tests/streaming/known-differences.toml` IDs to avoid silent metadata
   drift.
+- Any new `tests/corpus/**/*.html` fixture must include a same-basename
+  `.meta.json` sidecar in the same change set, with all required fields:
+  `fixture-id`, `page-type`, `expected-conversion-result`, `input-size-bytes`,
+  `source-description`, and `failure-corpus`. Run
+  `tools/corpus/validate_corpus.sh` (or `make test-benchmark`) before merge.
 - Regression tests for classification logic, routing decisions, or metrics
   increments must exercise code that mirrors the production branching — not
   manually set expected values in a local struct and assert them.  A test
@@ -487,6 +495,9 @@ Required:
   - **Public API entry points** (for example `StreamingConverter`, `MemoryBudget`, `StreamingResult`):
     use `no_run` or runnable doctests with full `nginx_markdown_converter::...` imports to maintain
     compile-time regression protection.
+  - Public API doctests that exercise feature-gated runtime paths must not
+    assume `Result::unwrap()` success across all feature sets; either keep them
+    `no_run` or match expected fallback/error variants explicitly.
   - **Internal implementation details** (for example `CharsetState`, `IncrementalEmitter`,
     `StructuralStateMachine`, `StreamingTokenizer`, helper methods): use `ignore` mode to keep
     documentation illustrative without causing compilation failures. These should have their

--- a/components/nginx-module/tests/include/test_common.h
+++ b/components/nginx-module/tests/include/test_common.h
@@ -17,6 +17,7 @@
 #include <stdio.h>    /* For printf, fprintf */
 #include <stdlib.h>   /* For malloc, free, exit */
 #include <string.h>   /* For memset, memcpy, strcmp */
+#include <strings.h>  /* For strcasecmp */
 #include <stdint.h>   /* For uint8_t, uint32_t, etc. */
 
 #ifndef ngx_inline

--- a/components/rust-converter/Cargo.lock
+++ b/components/rust-converter/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -221,9 +221,9 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -492,9 +492,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"

--- a/components/rust-converter/Cargo.toml
+++ b/components/rust-converter/Cargo.toml
@@ -18,7 +18,7 @@ html5ever = "0.38"
 # DOM tree representation
 markup5ever_rcdom = "0.38"
 # Fast hashing for ETags (using version compatible with older Rust)
-blake3 = "1.2"
+blake3 = "1.8"
 # Hex encoding for ETag generation
 hex = "0.4"
 # Regular expressions for charset detection

--- a/components/rust-converter/src/streaming/mod.rs
+++ b/components/rust-converter/src/streaming/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! # Usage
 //!
-//! ```
+//! ```no_run
 //! use nginx_markdown_converter::converter::ConversionOptions;
 //! use nginx_markdown_converter::streaming::{StreamingConverter, MemoryBudget};
 //!

--- a/tests/corpus/streaming-perf/chunked-mixed.meta.json
+++ b/tests/corpus/streaming-perf/chunked-mixed.meta.json
@@ -1,0 +1,12 @@
+{
+  "fixture-id": "streaming-perf/chunked-mixed",
+  "page-type": "clean-article",
+  "expected-conversion-result": "converted",
+  "input-size-bytes": 1328,
+  "source-description": "Mixed-content streaming benchmark fixture with headings, paragraphs, and lists",
+  "failure-corpus": false,
+  "streaming_notes": {
+    "expected_fallback": false,
+    "known_diff_ids": []
+  }
+}

--- a/tests/corpus/streaming-perf/code-heavy.meta.json
+++ b/tests/corpus/streaming-perf/code-heavy.meta.json
@@ -1,0 +1,12 @@
+{
+  "fixture-id": "streaming-perf/code-heavy",
+  "page-type": "documentation",
+  "expected-conversion-result": "converted",
+  "input-size-bytes": 1902,
+  "source-description": "Streaming benchmark fixture with multiple code blocks and mixed prose",
+  "failure-corpus": false,
+  "streaming_notes": {
+    "expected_fallback": false,
+    "known_diff_ids": []
+  }
+}

--- a/tests/corpus/streaming-perf/malformed-large.meta.json
+++ b/tests/corpus/streaming-perf/malformed-large.meta.json
@@ -1,0 +1,12 @@
+{
+  "fixture-id": "streaming-perf/malformed-large",
+  "page-type": "complex-common",
+  "expected-conversion-result": "converted",
+  "input-size-bytes": 631,
+  "source-description": "Malformed HTML streaming benchmark fixture for parser recovery behavior",
+  "failure-corpus": true,
+  "streaming_notes": {
+    "expected_fallback": false,
+    "known_diff_ids": []
+  }
+}

--- a/tests/corpus/streaming-perf/mixed-charset.meta.json
+++ b/tests/corpus/streaming-perf/mixed-charset.meta.json
@@ -1,0 +1,12 @@
+{
+  "fixture-id": "streaming-perf/mixed-charset",
+  "page-type": "clean-article",
+  "expected-conversion-result": "converted",
+  "input-size-bytes": 702,
+  "source-description": "Streaming benchmark fixture with mixed declared charset and multibyte content",
+  "failure-corpus": false,
+  "streaming_notes": {
+    "expected_fallback": false,
+    "known_diff_ids": []
+  }
+}

--- a/tests/corpus/streaming-perf/tables-heavy.meta.json
+++ b/tests/corpus/streaming-perf/tables-heavy.meta.json
@@ -1,0 +1,12 @@
+{
+  "fixture-id": "streaming-perf/tables-heavy",
+  "page-type": "complex-common",
+  "expected-conversion-result": "converted",
+  "input-size-bytes": 1099,
+  "source-description": "Streaming benchmark fixture with table-heavy markup that exercises fallback paths",
+  "failure-corpus": false,
+  "streaming_notes": {
+    "expected_fallback": true,
+    "known_diff_ids": []
+  }
+}


### PR DESCRIPTION
Bumps the rust-patch-minor group in /components/rust-converter with 2 updates: [blake3](https://github.com/BLAKE3-team/BLAKE3) and [libc](https://github.com/rust-lang/libc).


Updates `blake3` from 1.8.3 to 1.8.4
- [Release notes](https://github.com/BLAKE3-team/BLAKE3/releases)
- [Commits](https://github.com/BLAKE3-team/BLAKE3/compare/1.8.3...1.8.4)

Updates `libc` from 0.2.183 to 0.2.184
- [Release notes](https://github.com/rust-lang/libc/releases)
- [Changelog](https://github.com/rust-lang/libc/blob/0.2.184/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/libc/compare/0.2.183...0.2.184)

---
updated-dependencies:
- dependency-name: blake3 dependency-version: 1.8.4 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-patch-minor
- dependency-name: libc dependency-version: 0.2.184 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-patch-minor ...

## Summary by Sourcery

Update Rust converter component dependencies to newer patch/minor-compatible versions.

Build:
- Bump blake3 dependency for the rust-converter component from 1.2 to 1.8.
- Update locked Rust dependencies, including libc, to their latest compatible patch versions.