### PR TITLE
Address verified review findings for streaming

### DIFF
--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -487,7 +487,7 @@ typedef struct {
         ngx_atomic_t  shadow_total;              /* Shadow mode runs */
         ngx_atomic_t  shadow_diff_total;         /* Shadow output diffs */
         ngx_atomic_t  last_ttfb_ms;              /* Last streaming TTFB (milliseconds) */
-        ngx_atomic_t  last_peak_memory_bytes;    /* Last streaming peak memory estimate (bytes) */
+        ngx_atomic_t  last_peak_memory_bytes;    /* Last streaming peak estimate (bytes; not RSS) */
     } streaming;
 #endif
 

--- a/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_prometheus_impl.h
@@ -238,7 +238,8 @@ ngx_http_markdown_metrics_write_prometheus(
     p = ngx_slprintf(p, end,
         "# HELP "
         "nginx_markdown_streaming_peak_memory_bytes "
-        "Last streaming conversion peak memory estimate.\n"
+        "Last streaming conversion peak working-set estimate; "
+        "not process RSS.\n"
         "# TYPE "
         "nginx_markdown_streaming_peak_memory_bytes gauge\n"
         "nginx_markdown_streaming_peak_memory_bytes "

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -451,6 +451,10 @@ ngx_http_markdown_streaming_send_output(
         /*
          * Copy Rust-allocated data into pool memory so we
          * can free the Rust buffer immediately.
+         *
+         * Trade-off: this introduces a transient double-buffer
+         * window (Rust buffer + pool copy) up to `len` bytes
+         * for this chunk.
          */
         b->pos = ngx_palloc(r->pool, len);
         if (b->pos == NULL) {

--- a/components/rust-converter/include/markdown_converter.h
+++ b/components/rust-converter/include/markdown_converter.h
@@ -131,7 +131,10 @@ typedef struct MarkdownResult {
   uint8_t *error_message;
   uintptr_t error_len;
   /**
-   * Peak memory estimate during streaming conversion (bytes).
+   * Peak working-set memory estimate during streaming conversion (bytes).
+   *
+   * This value is derived from converter-owned resident state and is
+   * not a process RSS/high-water-mark measurement.
    *
    * Populated by `markdown_streaming_finalize()` from
    * `StreamingStats.peak_memory_estimate`. Valid only when

--- a/components/rust-converter/src/ffi/abi.rs
+++ b/components/rust-converter/src/ffi/abi.rs
@@ -56,8 +56,12 @@ pub struct MarkdownResult {
     pub error_code: u32,
     pub error_message: *mut u8,
     pub error_len: usize,
-    /// Peak memory estimate during streaming conversion (bytes).
-    /// Populated by `markdown_streaming_finalize` from `StreamingStats.peak_memory_estimate`.
+    /// Peak working-set memory estimate during streaming conversion (bytes).
+    ///
+    /// This is derived from converter-owned resident state and is not
+    /// a process RSS/high-water-mark measurement.
+    /// Populated by `markdown_streaming_finalize` from
+    /// `StreamingStats.peak_memory_estimate`.
     pub peak_memory_estimate: usize,
 }
 

--- a/components/rust-converter/src/streaming/converter.rs
+++ b/components/rust-converter/src/streaming/converter.rs
@@ -1031,7 +1031,15 @@ fn split_utf8_tail(bytes: &[u8]) -> (&[u8], &[u8]) {
                 // The incomplete part must be after this sequence
                 break;
             }
-            // Invalid sequence — treat as split point
+            // Invalid complete sequence. If it starts at offset 0, it cannot
+            // be repaired by appending future bytes; keep it in `valid` so the
+            // caller can recover via lossy conversion now instead of carrying
+            // an ever-growing deferred tail across chunks.
+            if i == 0 {
+                return (bytes, &[]);
+            }
+            // Otherwise split before the invalid region so the valid prefix can
+            // still be emitted immediately.
             return (&bytes[..i], &bytes[i..]);
         }
     }
@@ -2167,5 +2175,36 @@ mod tests {
         let (valid2, tail2) = split_utf8_tail(&continuation_only);
         assert_eq!(valid2, &continuation_only);
         assert!(tail2.is_empty());
+    }
+
+    #[test]
+    fn test_split_utf8_tail_invalid_complete_sequence_at_start() {
+        let bytes = [0xC2, 0x41];
+        let (valid, tail) = split_utf8_tail(&bytes);
+
+        assert_eq!(valid, &bytes);
+        assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn test_split_utf8_tail_incomplete_then_invalid_followup_recovers() {
+        let first_chunk = [0x41, 0xC2];
+        let (valid1, tail1) = split_utf8_tail(&first_chunk);
+        assert_eq!(valid1, b"A");
+        assert_eq!(tail1, &[0xC2]);
+
+        let second_chunk = [tail1[0], 0x41];
+        let (valid2, tail2) = split_utf8_tail(&second_chunk);
+        assert_eq!(valid2, &second_chunk);
+        assert!(tail2.is_empty());
+    }
+
+    #[test]
+    fn test_split_utf8_tail_invalid_four_byte_start_not_deferred() {
+        let bytes = [0xF0, 0x28, 0x8C, 0xBC];
+        let (valid, tail) = split_utf8_tail(&bytes);
+
+        assert_eq!(valid, &bytes);
+        assert!(tail.is_empty());
     }
 }

--- a/components/rust-converter/src/streaming/emitter.rs
+++ b/components/rust-converter/src/streaming/emitter.rs
@@ -689,8 +689,9 @@ impl IncrementalEmitter {
             if self.max_buffer_size > 0 {
                 let marker_room = self.max_buffer_size.min(LINK_TRUNCATION_MARKER.len());
                 let keep = self.max_buffer_size.saturating_sub(marker_room);
-                if self.link_text.len() > keep {
-                    self.link_text.truncate(keep);
+                let safe_keep = self.link_text.floor_char_boundary(keep);
+                if self.link_text.len() > safe_keep {
+                    self.link_text.truncate(safe_keep);
                 }
                 self.link_text
                     .push_str(&LINK_TRUNCATION_MARKER[..marker_room]);
@@ -1335,6 +1336,23 @@ mod tests {
 
         assert!(emitter.link_text_overflow, "overflow flag should be set");
         assert_eq!(emitter.link_text, "this text is...");
+    }
+
+    #[test]
+    fn test_link_text_overflow_multibyte_chars() {
+        let budget = MemoryBudget {
+            total: 1024,
+            state_stack: 256,
+            output_buffer: 12,
+            charset_sniff: 16,
+            lookahead: 64,
+        };
+        let mut emitter = IncrementalEmitter::new(&budget);
+
+        emitter.append_link_text("こんにちは世界");
+        assert!(emitter.link_text_overflow, "overflow flag should be set");
+        assert!(std::str::from_utf8(emitter.link_text.as_bytes()).is_ok(), "link_text should be valid UTF-8 after truncation");
+        assert!(emitter.link_text.ends_with("..."), "link_text should end with truncation marker");
     }
 
     // ── Image tests ─────────────────────────────────────────────────

--- a/components/rust-converter/src/streaming/emitter.rs
+++ b/components/rust-converter/src/streaming/emitter.rs
@@ -676,14 +676,25 @@ impl IncrementalEmitter {
     /// Append text to `link_text`, respecting the output buffer budget.
     ///
     /// When the accumulated link text would exceed `max_buffer_size`,
-    /// the overflow flag is set and further appends are silently dropped.
-    /// The link is still closed properly on `Exit(Link)` — the text is
-    /// simply truncated.
+    /// the overflow flag is set and further appends are dropped.
+    /// A truncation marker is appended when possible so output drift is
+    /// operator-visible. The link is still closed on `Exit(Link)`.
     fn append_link_text(&mut self, s: &str) {
+        const LINK_TRUNCATION_MARKER: &str = "...";
+
         if self.link_text_overflow {
             return;
         }
         if self.link_text.len().saturating_add(s.len()) > self.max_buffer_size {
+            if self.max_buffer_size > 0 {
+                let marker_room = self.max_buffer_size.min(LINK_TRUNCATION_MARKER.len());
+                let keep = self.max_buffer_size.saturating_sub(marker_room);
+                if self.link_text.len() > keep {
+                    self.link_text.truncate(keep);
+                }
+                self.link_text
+                    .push_str(&LINK_TRUNCATION_MARKER[..marker_room]);
+            }
             self.link_text_overflow = true;
             return;
         }
@@ -1306,6 +1317,24 @@ mod tests {
             "got: {}",
             output
         );
+    }
+
+    #[test]
+    fn test_link_text_overflow_appends_marker() {
+        let budget = MemoryBudget {
+            total: 1024,
+            state_stack: 256,
+            output_buffer: 16,
+            charset_sniff: 16,
+            lookahead: 64,
+        };
+        let mut emitter = IncrementalEmitter::new(&budget);
+
+        emitter.append_link_text("this text is");
+        emitter.append_link_text(" intentionally very long");
+
+        assert!(emitter.link_text_overflow, "overflow flag should be set");
+        assert_eq!(emitter.link_text, "this text is...");
     }
 
     // ── Image tests ─────────────────────────────────────────────────

--- a/components/rust-converter/src/streaming/sanitizer.rs
+++ b/components/rust-converter/src/streaming/sanitizer.rs
@@ -39,6 +39,9 @@ const DANGEROUS_VOID_ELEMENTS: &[&str] = &["link", "base"];
 /// Embedded content elements: tags stripped, src/data URL extracted.
 const EMBEDDED_CONTENT_ELEMENTS: &[&str] = &["iframe", "object", "embed"];
 
+/// Media content elements: tags stripped, URL extracted from src/href.
+const MEDIA_CONTENT_ELEMENTS: &[&str] = &["video", "audio", "source", "track", "area"];
+
 /// Form elements: tags stripped, child text preserved.
 const FORM_ELEMENTS: &[&str] = &[
     "form", "button", "select", "textarea", "fieldset", "legend", "label", "option", "optgroup",
@@ -236,6 +239,32 @@ impl StreamingSanitizer {
                     return SanitizeDecision::Skip;
                 }
 
+                // Media content elements: strip tag, extract src/href URL.
+                if MEDIA_CONTENT_ELEMENTS.contains(&tag) {
+                    if !effectively_self_closing {
+                        self.strip_stack.push(tag.to_string());
+                    }
+                    let url = attrs
+                        .iter()
+                        .find(|(k, _)| {
+                            if tag == "area" {
+                                k == "href" || k == "src"
+                            } else {
+                                k == "src"
+                            }
+                        })
+                        .map(|(_, v)| v.clone());
+                    if let Some(url_val) = url
+                        && !is_dangerous_url(&url_val)
+                    {
+                        return SanitizeDecision::PassModified(StreamEvent::Text(format!(
+                            "[{}]({})",
+                            tag, url_val
+                        )));
+                    }
+                    return SanitizeDecision::Skip;
+                }
+
                 // Form elements: strip tag, keep content
                 if FORM_ELEMENTS.contains(&tag) || VOID_FORM_CONTROLS.contains(&tag) {
                     if !effectively_self_closing && !VOID_FORM_CONTROLS.contains(&tag) {
@@ -292,7 +321,10 @@ impl StreamingSanitizer {
                 // Strip stack tracking for embedded/form elements.
                 // Only pop if the end tag matches the most recent strip entry,
                 // preventing mismatched tags from corrupting the strip state.
-                if EMBEDDED_CONTENT_ELEMENTS.contains(&tag) || FORM_ELEMENTS.contains(&tag) {
+                if EMBEDDED_CONTENT_ELEMENTS.contains(&tag)
+                    || MEDIA_CONTENT_ELEMENTS.contains(&tag)
+                    || FORM_ELEMENTS.contains(&tag)
+                {
                     if self.strip_stack.last().is_some_and(|t| t == tag) {
                         self.strip_stack.pop();
                     }
@@ -625,6 +657,59 @@ mod tests {
             }
             _ => panic!("Expected PassModified with URL, got {:?}", decision),
         }
+    }
+
+    #[test]
+    fn test_video_src_url_extracted() {
+        let mut san = StreamingSanitizer::new();
+        let decision = san.process_event(start_tag(
+            "video",
+            vec![("src", "https://example.com/v.mp4")],
+        ));
+        match decision {
+            SanitizeDecision::PassModified(StreamEvent::Text(t)) => {
+                assert_eq!(t, "[video](https://example.com/v.mp4)");
+            }
+            _ => panic!("Expected PassModified with URL, got {:?}", decision),
+        }
+        let child = san.process_event(text("fallback text"));
+        assert!(matches!(child, SanitizeDecision::Pass(_)));
+        assert_eq!(san.process_event(end_tag("video")), SanitizeDecision::Skip);
+    }
+
+    #[test]
+    fn test_source_src_url_extracted() {
+        let mut san = StreamingSanitizer::new();
+        let decision = san.process_event(start_tag(
+            "source",
+            vec![("src", "https://example.com/a.mp3")],
+        ));
+        match decision {
+            SanitizeDecision::PassModified(StreamEvent::Text(t)) => {
+                assert_eq!(t, "[source](https://example.com/a.mp3)");
+            }
+            _ => panic!("Expected PassModified with URL, got {:?}", decision),
+        }
+    }
+
+    #[test]
+    fn test_area_href_url_extracted() {
+        let mut san = StreamingSanitizer::new();
+        let decision =
+            san.process_event(start_tag("area", vec![("href", "https://example.com/map")]));
+        match decision {
+            SanitizeDecision::PassModified(StreamEvent::Text(t)) => {
+                assert_eq!(t, "[area](https://example.com/map)");
+            }
+            _ => panic!("Expected PassModified with URL, got {:?}", decision),
+        }
+    }
+
+    #[test]
+    fn test_media_dangerous_url_blocked() {
+        let mut san = StreamingSanitizer::new();
+        let decision = san.process_event(start_tag("audio", vec![("src", "javascript:alert(1)")]));
+        assert_eq!(decision, SanitizeDecision::Skip);
     }
 
     // --- Form elements ---

--- a/components/rust-converter/src/streaming/sanitizer.rs
+++ b/components/rust-converter/src/streaming/sanitizer.rs
@@ -244,16 +244,18 @@ impl StreamingSanitizer {
                     if !effectively_self_closing {
                         self.strip_stack.push(tag.to_string());
                     }
-                    let url = attrs
-                        .iter()
-                        .find(|(k, _)| {
-                            if tag == "area" {
-                                k == "href" || k == "src"
-                            } else {
-                                k == "src"
-                            }
-                        })
-                        .map(|(_, v)| v.clone());
+                    let url = if tag == "area" {
+                        attrs
+                            .iter()
+                            .find(|(k, _)| k == "href")
+                            .or_else(|| attrs.iter().find(|(k, _)| k == "src"))
+                            .map(|(_, v)| v.clone())
+                    } else {
+                        attrs
+                            .iter()
+                            .find(|(k, _)| k == "src")
+                            .map(|(_, v)| v.clone())
+                    };
                     if let Some(url_val) = url
                         && !is_dangerous_url(&url_val)
                     {
@@ -700,6 +702,21 @@ mod tests {
         match decision {
             SanitizeDecision::PassModified(StreamEvent::Text(t)) => {
                 assert_eq!(t, "[area](https://example.com/map)");
+            }
+            _ => panic!("Expected PassModified with URL, got {:?}", decision),
+        }
+    }
+
+    #[test]
+    fn test_track_src_url_extracted() {
+        let mut san = StreamingSanitizer::new();
+        let decision = san.process_event(start_tag(
+            "track",
+            vec![("src", "https://example.com/captions.vtt")],
+        ));
+        match decision {
+            SanitizeDecision::PassModified(StreamEvent::Text(t)) => {
+                assert_eq!(t, "[track](https://example.com/captions.vtt)");
             }
             _ => panic!("Expected PassModified with URL, got {:?}", decision),
         }

--- a/components/rust-converter/src/streaming/types.rs
+++ b/components/rust-converter/src/streaming/types.rs
@@ -95,7 +95,10 @@ pub struct StreamingStats {
     pub tokens_processed: u64,
     /// Total number of flush points emitted.
     pub flush_count: u32,
-    /// Peak estimated memory usage in bytes.
+    /// Peak estimated working-set memory usage in bytes.
+    ///
+    /// This is a heuristic estimate from resident converter state
+    /// (for example buffers and stacks), not a process RSS measurement.
     pub peak_memory_estimate: usize,
     /// Number of input chunks processed.
     pub chunks_processed: u32,


### PR DESCRIPTION
## Summary by Sourcery

Extend streaming markdown conversion to better handle media elements, UTF-8 chunk boundaries, and link text overflow while clarifying peak memory reporting semantics across Rust and Nginx interfaces.

New Features:
- Extract URLs from media elements such as video, audio, source, track, and area during streaming sanitization and emit them as Markdown-style links while stripping the original tags.

Bug Fixes:
- Adjust UTF-8 chunk splitting logic so invalid complete sequences at the start of a chunk are not deferred, preventing unbounded tail growth and improving recovery across chunks.
- Ensure media element URLs with dangerous schemes are blocked during sanitization instead of being emitted.

Enhancements:
- Add a truncation marker to link text when the emitter hits its buffer budget so link truncation is visible in the markdown output.
- Clarify peak memory estimate semantics in Rust structs, C headers, Nginx metrics, and filter state comments, emphasizing working-set estimates rather than process RSS and noting transient double-buffering in the Nginx output path.

Tests:
- Add sanitizer tests covering media URL extraction, handling of area href/src, and blocking of dangerous media URLs.
- Add converter tests to validate UTF-8 tail splitting behavior for invalid and incomplete sequences across chunk boundaries.
- Add emitter test ensuring link text overflow appends a truncation marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 sequence handling to properly distinguish invalid complete sequences from incomplete tails.
  * Added truncation marker when link text exceeds buffer limits.

* **New Features**
  * Added media-specific sanitization for video, audio, source, track, and area tags, converting them to inline text with URL references.

* **Documentation**
  * Clarified memory metrics documentation to indicate working-set estimates rather than process RSS measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->