### PR TITLE
chore: update nginx release matrix (add 1.29.8; remove 1.29.7)

### DIFF
--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -575,10 +575,10 @@ If your NGINX version is >= 1.24.0 but not listed in the matrix below, use the [
 | 1.28.3 | glibc | x86_64 | Full |
 | 1.28.3 | musl | aarch64 | Full |
 | 1.28.3 | musl | x86_64 | Full |
-| 1.29.7 | glibc | aarch64 | Full |
-| 1.29.7 | glibc | x86_64 | Full |
-| 1.29.7 | musl | aarch64 | Full |
-| 1.29.7 | musl | x86_64 | Full |
+| 1.29.8 | glibc | aarch64 | Full |
+| 1.29.8 | glibc | x86_64 | Full |
+| 1.29.8 | musl | aarch64 | Full |
+| 1.29.8 | musl | x86_64 | Full |
 <!-- END AUTO-GENERATED MATRIX -->
 
 ---

--- a/tools/release-matrix.json
+++ b/tools/release-matrix.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "updated_at": "2026-03-31T03:29:47Z",
+  "updated_at": "2026-04-13T07:58:40Z",
   "support_tiers": {
     "full": "Prebuilt binary + install script + CI verification",
     "source_only": "Build from source required"
@@ -79,25 +79,25 @@
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.7",
+      "nginx": "1.29.8",
       "os_type": "glibc",
       "arch": "aarch64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.7",
+      "nginx": "1.29.8",
       "os_type": "glibc",
       "arch": "x86_64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.7",
+      "nginx": "1.29.8",
       "os_type": "musl",
       "arch": "aarch64",
       "support_tier": "full"
     },
     {
-      "nginx": "1.29.7",
+      "nginx": "1.29.8",
       "os_type": "musl",
       "arch": "x86_64",
       "support_tier": "full"


### PR DESCRIPTION
## Summary by Sourcery

Update supported NGINX 1.29.x release across docs and tooling to the latest patch version.

Build:
- Align release-matrix tooling configuration with the NGINX 1.29.8 release.

Documentation:
- Refresh installation guide release matrix to list NGINX 1.29.8 instead of 1.29.7.