### PR TITLE
feat(harness): add repo-owned workflow and checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main, master]
     paths:
+      - "AGENTS.md"
       - "components/**"
       - "tools/**"
       - "tests/**"
@@ -18,6 +19,7 @@ on:
   push:
     branches: [main, master]
     paths:
+      - "AGENTS.md"
       - "components/**"
       - "tools/**"
       - "tests/**"
@@ -59,6 +61,7 @@ jobs:
         with:
           filters: |
             docs:
+              - 'AGENTS.md'
               - 'docs/**'
               - 'README.md'
               - 'README_zh-CN.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
               - 'README.md'
               - 'README_zh-CN.md'
               - 'tools/docs/**'
+              - 'tools/harness/**'
               - 'tools/release-matrix.json'
               - 'examples/nginx-configs/**'
             rust:
@@ -107,11 +108,7 @@ jobs:
           python-version: '3.14.3'
 
       - name: Validate docs
-        run: |
-          python3 tools/docs/check_duplicate_docs.py
-          python3 tools/docs/check_docs.py
-          python3 tools/docs/check_packaging_docs.py
-          python3 tools/docs/check_packaging_consistency.py
+        run: make docs-check
 
   rust-quality:
     name: Rust Quality Gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,13 +18,21 @@ If two rules conflict, follow the higher-priority source.
 
 ## Harness Map
 - `AGENTS.md` remains the Codex-first contract and engineering rule map.
+- `AGENTS.md` and `docs/harness/` are the owning harness truth surfaces for
+  tracked repository behavior; Make/CI/checkers must consume these, not local
+  adapter-only summaries.
 - `docs/harness/README.md` is the repo-owned harness entrypoint.
 - `docs/harness/core.md` defines the execution loop, conflict protocol, and
   status semantics.
 - `docs/harness/routing-manifest.json` is the canonical structured routing
   source; `docs/harness/routing-manifest.md` is the readable overlay.
+- `.kiro/specs/` is read-only optional input for local spec-oriented work. Do
+  not write harness caches, annotations, or durable repo truth into `.kiro/`.
 - `.kiro/steering/` is an optional local adapter surface only. It should point
   back to `docs/harness/` and must not define stronger semantics than this file.
+- Outside voice and the user-local harness state carrier are advisory execution
+  tools. They may challenge or inform the current path, but they do not weaken
+  the repo-owned correctness and safety contract.
 
 ## Non-Negotiable NGINX Baseline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,16 @@ Goal: prevent repeated classes of mistakes that previously caused regressions.
 
 If two rules conflict, follow the higher-priority source.
 
+## Harness Map
+- `AGENTS.md` remains the Codex-first contract and engineering rule map.
+- `docs/harness/README.md` is the repo-owned harness entrypoint.
+- `docs/harness/core.md` defines the execution loop, conflict protocol, and
+  status semantics.
+- `docs/harness/routing-manifest.json` is the canonical structured routing
+  source; `docs/harness/routing-manifest.md` is the readable overlay.
+- `.kiro/steering/` is an optional local adapter surface only. It should point
+  back to `docs/harness/` and must not define stronger semantics than this file.
+
 ## Non-Negotiable NGINX Baseline
 
 ### API and lifecycle correctness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,13 @@ Required:
 - In-link formatting markers (bold/italic/inline-code) must be accumulated in link text, not flushed outside link context.
 - Code-block output must preserve raw content (blank lines/trailing spaces) and bypass generic normalization.
 - Blockquote markers must be emitted consistently on entry and after newline boundaries.
+- URL extraction parity must include media-bearing elements, not only `img`
+  (at minimum `video`, `audio`, `source`, `track`, and `area` where
+  applicable), with regression tests that cover missing-attribute and
+  attribute-present branches.
+- Human-readable fallback/detail strings that are carried in enums or result
+  types (for example `UnsupportedStructure(...)`) must use stable internal
+  identifiers, not user-influenced payloads.
 
 ### 7. Eligibility/reason-code drift and status handling bugs
 Historical issues: `d2d836f`, `5288c1b`, `19c896c`, `bc35a1f`.
@@ -346,6 +353,10 @@ Required:
   `tests/corpus/**/.meta.json -> streaming_notes.known_diff_ids` synchronized
   with `tests/streaming/known-differences.toml` IDs to avoid silent metadata
   drift.
+- Known-difference registries must carry structured drift classification
+  metadata (for example `drift_type` and `severity`) in addition to binary
+  accept/reject flags. Parsers must degrade safely for missing/unknown values
+  and tests must cover classification parsing defaults.
 - Any new `tests/corpus/**/*.html` fixture must include a same-basename
   `.meta.json` sidecar in the same change set, with all required fields:
   `fixture-id`, `page-type`, `expected-conversion-result`, `input-size-bytes`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Repo-owned harness documentation under `docs/harness/`, including a central overview, core execution loop, canonical routing manifest, and initial risk-pack overlays for runtime streaming, FFI boundary work, observability, and docs/tooling drift
+- Durable open-source documentation for the harness design and maintenance model:
+  - `docs/architecture/HARNESS_ARCHITECTURE.md`
+  - `docs/architecture/ADR/0005-repo-owned-harness.md`
+  - `docs/guides/HARNESS_MAINTENANCE.md`
+- Executable harness tooling:
+  - `tools/harness/check_harness_sync.py`
+  - `tools/harness/resolve_spec.py`
+  - `tools/harness/state_store.py`
+- Harness regression coverage for sync checks, spec resolution, and local state-carrier behavior
+- Local maintenance skills for ongoing harness upkeep:
+  - `sync-harness-rules`
+  - `evolve-harness-rules`
+
+### Changed
+- `AGENTS.md` now points explicitly at the repo-owned harness entrypoints instead of leaving agent workflow guidance scattered across local-only steering docs
+- `.kiro/steering/product.md`, `structure.md`, and `tech.md` were reduced to thin local adapter summaries that point back to `docs/harness/`
+- `Makefile` now exposes `make harness-check` and `make harness-check-full`
+- CI path filters now include `AGENTS.md` so harness contract changes trigger validation
+- `tools/docs/check_docs.py` now scans maintained canonical markdown truth surfaces instead of also treating root-level scratch notes as release-facing docs
+- Release-gates compatibility-matrix validation now supports both the legacy three-state-column table format and the current canonical single `Classification` column format
+- `README.md`, `docs/README.md`, `docs/architecture/README.md`, and `docs/testing/README.md` now point contributors at the harness workflow and commands
+
+### Fixed
+- Restored green `make harness-check-full` validation by aligning release-gate compatibility-matrix parsing with the current 0.5.0 canonical document structure
+- Prevented local scratch markdown files from causing false failures in canonical docs validation
+
 ## [0.4.1] - 2026-04-12
 
 This patch release focuses on dependency security hygiene and release metadata alignment.

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ NGINX_HEADER := $(NGINX_MODULE_DIR)/src/markdown_converter.h
         test test-rust test-rust-doc test-nginx-unit test-nginx-unit-streaming test-nginx-unit-clang-smoke test-nginx-unit-sanitize-smoke \
         test-nginx-integration test-e2e test-all test-rust-fuzz-smoke sonar-compile-db \
         test-benchmark test-benchmark-compare test-benchmark-summary \
+        harness-check harness-check-full \
         docs-check license-check release-gates-check release-gates-check-legacy release-gates-check-strict \
         verify-large-e2e verify-huge-native-e2e verify-huge-allowed-native-e2e \
         verify-chunked-native-e2e verify-chunked-native-e2e-smoke verify-chunked-native-e2e-stress \
@@ -165,6 +166,15 @@ docs-check:
 	python3 tools/docs/check_docs.py
 	python3 tools/docs/check_packaging_docs.py
 	python3 tools/docs/check_packaging_consistency.py
+	python3 tools/harness/check_harness_sync.py
+
+harness-check:
+	python3 tools/harness/check_harness_sync.py
+
+harness-check-full:
+	python3 tools/harness/check_harness_sync.py --full
+	$(MAKE) docs-check
+	$(MAKE) release-gates-check
 
 license-check:
 	python3 tools/ci/check_c_licenses.py
@@ -234,6 +244,8 @@ help:
 	@echo "  test-benchmark           - Run corpus benchmark and produce Unified Report"
 	@echo "  test-benchmark-compare   - Compare corpus reports (baseline vs current)"
 	@echo "  test-benchmark-summary   - Generate PR benchmark summary from latest report"
+	@echo "  harness-check            - Validate harness truth surfaces and optional local adapters"
+	@echo "  harness-check-full       - Run full harness validation plus docs/release checks"
 	@echo "  docs-check               - Validate documentation links/style"
 	@echo "  license-check            - Verify license policy and THIRD-PARTY-NOTICES coverage"
 	@echo "  release-gates-check      - Validate 0.5.0 release gate framework (spec #12 deliverables)"

--- a/Makefile
+++ b/Makefile
@@ -162,18 +162,20 @@ test-benchmark-summary:
 	python3 tools/perf/format_pr_summary.py \
 		--report $(CORPUS_REPORT)
 
-docs-check:
+docs-check-base:
 	python3 tools/docs/check_docs.py
 	python3 tools/docs/check_packaging_docs.py
 	python3 tools/docs/check_packaging_consistency.py
+
+docs-check: docs-check-base
 	python3 tools/harness/check_harness_sync.py
 
 harness-check:
 	python3 tools/harness/check_harness_sync.py
 
 harness-check-full:
+	$(MAKE) docs-check-base
 	python3 tools/harness/check_harness_sync.py --full
-	$(MAKE) docs-check
 	$(MAKE) release-gates-check
 
 license-check:

--- a/README.md
+++ b/README.md
@@ -273,6 +273,24 @@ make test-rust-fuzz-smoke
 
 See [docs/testing/README.md](docs/testing/README.md) for integration, E2E, and performance-oriented test references.
 
+If you are changing repo contracts, docs validators, or agent workflow rules,
+run the harness checks as well:
+
+```bash
+# Cheap blocker for repo-owned harness truth
+make harness-check
+
+# Full harness validation, including docs and release-gate checks
+make harness-check-full
+```
+
+For local spec-oriented work, the harness can also resolve the most likely spec
+from your hints or an optional local pointer file:
+
+```bash
+python3 tools/harness/resolve_spec.py --hint "continue streaming parity diff work"
+```
+
 ## Documentation Map
 
 | Goal | Document |
@@ -284,6 +302,7 @@ See [docs/testing/README.md](docs/testing/README.md) for integration, E2E, and p
 | Operate and troubleshoot | [docs/guides/OPERATIONS.md](docs/guides/OPERATIONS.md) |
 | Report a vulnerability or review security support | [SECURITY.md](SECURITY.md) |
 | Understand architecture and design choices | [docs/architecture/README.md](docs/architecture/README.md) |
+| Understand spec routing, risk packs, and harness checks | [docs/harness/README.md](docs/harness/README.md) |
 | Map directives to runtime behavior | [docs/architecture/CONFIG_BEHAVIOR_MAP.md](docs/architecture/CONFIG_BEHAVIOR_MAP.md) |
 | Explore implementation details | [docs/features/README.md](docs/features/README.md) |
 | Review testing references | [docs/testing/README.md](docs/testing/README.md) |
@@ -298,6 +317,7 @@ See [docs/testing/README.md](docs/testing/README.md) for integration, E2E, and p
 - Operating in production: use [docs/guides/OPERATIONS.md](docs/guides/OPERATIONS.md)
 - Reporting a vulnerability: use [SECURITY.md](SECURITY.md)
 - Understanding system design: use [docs/architecture/README.md](docs/architecture/README.md)
+- Understanding repo-owned agent workflow and spec routing: use [docs/harness/README.md](docs/harness/README.md)
 - Understanding what directives change in the runtime path: use [docs/architecture/CONFIG_BEHAVIOR_MAP.md](docs/architecture/CONFIG_BEHAVIOR_MAP.md)
 - Reading implementation details: use [docs/features/README.md](docs/features/README.md)
 - Validating changes: use [docs/testing/README.md](docs/testing/README.md)
@@ -312,6 +332,7 @@ docs/                  User, operator, testing, and architecture docs
   architecture/        System design, ADRs, and config behavior maps
   features/            Implementation details for specific features
   guides/              Installation, configuration, deployment, and operations
+  harness/             Repo-owned spec routing, risk packs, and harness checks
   project/             Project status and roadmap
   testing/             Testing strategy and references
 examples/
@@ -327,6 +348,23 @@ tools/                 Installers, CI scripts, and developer tooling
 .github/workflows/     CI/CD pipeline definitions
 Makefile               Top-level build and test entrypoints
 ```
+
+## Contributor Workflow
+
+If you are changing runtime behavior, use the existing test commands.
+
+If you are changing repo contracts, validation tooling, or agent-facing docs,
+add the harness workflow to your default path:
+
+1. Resolve the current spec when the task is ambiguous:
+   `python3 tools/harness/resolve_spec.py --hint "..."`
+2. Update repo-owned truth first:
+   `AGENTS.md`, `docs/harness/`, `tools/harness/`, `Makefile`, CI wiring
+3. Run `make harness-check`
+4. Run `make harness-check-full` before closing broader docs or release-gate work
+
+Optional local `.kiro/` files can refine spec resolution and adapter checks, but
+public clones must still pass without them.
 
 ## Roadmap
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -292,6 +292,22 @@ make test-rust-fuzz-smoke
 
 更完整的集成测试、E2E 与性能基线说明见 [docs/testing/README.md](docs/testing/README.md)。
 
+如果你修改的是仓库 contract、文档校验器或 agent 工作流规则，还需要运行 harness 检查：
+
+```bash
+# 仓库级 harness 真相面的廉价阻断检查
+make harness-check
+
+# 包含文档与 release-gate 的完整 harness 校验
+make harness-check-full
+```
+
+对于本地 spec 导向的工作，harness 也可以根据提示词或可选的本地指针文件解析最可能的 spec：
+
+```bash
+python3 tools/harness/resolve_spec.py --hint "continue streaming parity diff work"
+```
+
 ## 文档导航
 
 | 目标 | 文档 |
@@ -303,6 +319,9 @@ make test-rust-fuzz-smoke
 | 运维与排障 | [docs/guides/OPERATIONS.md](docs/guides/OPERATIONS.md) |
 | 报告漏洞或查看安全支持范围 | [SECURITY.md](SECURITY.md) |
 | 了解架构与设计取舍 | [docs/architecture/README.md](docs/architecture/README.md) |
+| 了解 harness 的架构设计 | [docs/architecture/HARNESS_ARCHITECTURE.md](docs/architecture/HARNESS_ARCHITECTURE.md) |
+| 理解 spec 路由、risk pack 与 harness 检查 | [docs/harness/README.md](docs/harness/README.md) |
+| 维护 repo-owned harness 规则与本地适配流程 | [docs/guides/HARNESS_MAINTENANCE.md](docs/guides/HARNESS_MAINTENANCE.md) |
 | 理解配置如何映射到运行时行为 | [docs/architecture/CONFIG_BEHAVIOR_MAP.md](docs/architecture/CONFIG_BEHAVIOR_MAP.md) |
 | 深入实现细节 | [docs/features/README.md](docs/features/README.md) |
 | 查看测试说明 | [docs/testing/README.md](docs/testing/README.md) |
@@ -317,6 +336,9 @@ make test-rust-fuzz-smoke
 - 准备上线运维：看 [docs/guides/OPERATIONS.md](docs/guides/OPERATIONS.md)
 - 报告漏洞：看 [SECURITY.md](SECURITY.md)
 - 想理解系统结构和技术选型：看 [docs/architecture/README.md](docs/architecture/README.md)
+- 想理解 harness 为什么是仓库级资产以及它如何工作：看 [docs/architecture/HARNESS_ARCHITECTURE.md](docs/architecture/HARNESS_ARCHITECTURE.md)
+- 想理解 repo-owned agent 工作流与 spec 路由：看 [docs/harness/README.md](docs/harness/README.md)
+- 想维护 harness 规则、risk pack 与本地适配层：看 [docs/guides/HARNESS_MAINTENANCE.md](docs/guides/HARNESS_MAINTENANCE.md)
 - 想理解 directive 会改动哪段运行时路径：看 [docs/architecture/CONFIG_BEHAVIOR_MAP.md](docs/architecture/CONFIG_BEHAVIOR_MAP.md)
 - 想深入实现：看 [docs/features/README.md](docs/features/README.md)
 - 想了解验证方式：看 [docs/testing/README.md](docs/testing/README.md)
@@ -331,6 +353,7 @@ docs/                  用户、运维、测试与架构文档
   architecture/        系统设计、ADR 与配置行为映射
   features/            具体功能的实现细节
   guides/              安装、配置、部署与运维指南
+  harness/             repo-owned spec 路由、risk pack 与 harness 检查
   project/             项目状态与路线图
   testing/             测试策略与参考文档
 examples/
@@ -346,6 +369,21 @@ tools/                 安装脚本、CI 脚本与开发工具
 .github/workflows/     CI/CD 流水线定义
 Makefile               顶层构建与测试入口
 ```
+
+## 贡献者工作流
+
+如果你改的是运行时行为，请继续使用现有测试入口。
+
+如果你改的是仓库 contract、验证工具或 agent-facing 文档，请把 harness 工作流纳入默认路径：
+
+1. 当任务存在歧义时，先解析当前 spec：  
+   `python3 tools/harness/resolve_spec.py --hint "..."`
+2. 优先更新 repo-owned truth：  
+   `AGENTS.md`、`docs/harness/`、`tools/harness/`、`Makefile`、CI wiring
+3. 运行 `make harness-check`
+4. 在结束更广义的文档或 release-gate 改动前，运行 `make harness-check-full`
+
+可选的本地 `.kiro/` 文件可以增强 spec 解析和适配层检查，但公开 clone 的仓库在没有这些文件时也必须通过。
 
 ## 路线方向
 

--- a/components/rust-converter/src/streaming/converter.rs
+++ b/components/rust-converter/src/streaming/converter.rs
@@ -465,6 +465,9 @@ impl StreamingConverter {
     /// ```
     fn process_single_event(&mut self, event: StreamEvent) -> Result<(), ConversionError> {
         self.stats.tokens_processed = self.stats.tokens_processed.saturating_add(1);
+        if matches!(event, StreamEvent::ParseError(_)) {
+            self.stats.parse_errors = self.stats.parse_errors.saturating_add(1);
+        }
 
         // Front matter extraction: collect metadata from <head> region,
         // but only when metadata extraction is enabled (Requirement 10.1).
@@ -727,12 +730,33 @@ impl StreamingConverter {
                 if self.collecting_title && !text.is_empty() {
                     // Collect raw text into the separate buffer.
                     // The final trim happens at </title> above.
-                    self.html_title_buf.push_str(text);
+                    self.append_title_text_bounded(text);
                 }
             }
             _ => {}
         }
         false // within budget
+    }
+
+    /// Append title text while preserving the configured lookahead bound.
+    ///
+    /// We intentionally cap the dedicated title collector by the same
+    /// configured lookahead budget used for `<head>` processing so
+    /// collector growth remains explicitly bounded.
+    fn append_title_text_bounded(&mut self, text: &str) {
+        let limit = self.budget.lookahead;
+        if limit == 0 || self.html_title_buf.len() >= limit {
+            return;
+        }
+
+        let remaining = limit.saturating_sub(self.html_title_buf.len());
+        if text.len() <= remaining {
+            self.html_title_buf.push_str(text);
+            return;
+        }
+
+        let keep = text.floor_char_boundary(remaining);
+        self.html_title_buf.push_str(&text[..keep]);
     }
 
     /// Update page metadata from a `<meta>` tag's attributes.
@@ -1409,6 +1433,28 @@ mod tests {
 
         assert!(result.stats.tokens_processed > 0);
         assert!(result.stats.chunks_processed >= 1);
+        assert_eq!(result.stats.parse_errors, 0);
+    }
+
+    #[test]
+    fn test_parse_error_counter_increments() {
+        let mut conv = make_converter();
+        conv.process_single_event(StreamEvent::ParseError("broken tag".to_string()))
+            .unwrap();
+
+        assert_eq!(conv.stats.parse_errors, 1);
+        assert_eq!(conv.stats.tokens_processed, 1);
+    }
+
+    #[test]
+    fn test_title_collector_respects_lookahead_limit() {
+        let mut conv = make_converter_with_metadata();
+        conv.budget.lookahead = 8;
+
+        conv.append_title_text_bounded("abcdef");
+        conv.append_title_text_bounded("ghijkl");
+
+        assert_eq!(conv.html_title_buf, "abcdefgh");
     }
 
     /// Regression: peak_memory_estimate must reflect the working set

--- a/components/rust-converter/src/streaming/state_machine.rs
+++ b/components/rust-converter/src/streaming/state_machine.rs
@@ -255,6 +255,38 @@ impl StructuralStateMachine {
                 // but <img> never has a matching end tag either way.
                 return Ok(StateMachineAction::Enter(ctx));
             }
+            "video" | "audio" => {
+                if let Some(src) = attrs
+                    .iter()
+                    .find(|(k, _)| k == "src")
+                    .map(|(_, v)| v.clone())
+                {
+                    // Media elements with inline src are emitted as URL-bearing
+                    // artifacts for parity with full-buffer URL extraction.
+                    let ctx = StructuralContext::Image {
+                        src,
+                        alt: name.to_string(),
+                    };
+                    return Ok(StateMachineAction::Enter(ctx));
+                }
+                // No inline src (for example <video><source ...>): child tags
+                // may still carry extractable URLs.
+                return Ok(StateMachineAction::None);
+            }
+            "source" | "track" | "area" => {
+                if let Some(src) = attrs
+                    .iter()
+                    .find(|(k, _)| *k == "src" || *k == "href")
+                    .map(|(_, v)| v.clone())
+                {
+                    let ctx = StructuralContext::Image {
+                        src,
+                        alt: name.to_string(),
+                    };
+                    return Ok(StateMachineAction::Enter(ctx));
+                }
+                return Ok(StateMachineAction::None);
+            }
             "strong" | "b" => StructuralContext::Bold,
             "em" | "i" => StructuralContext::Italic,
             "table" | "thead" | "tbody" | "tr" | "th" | "td" => {
@@ -830,6 +862,81 @@ mod tests {
         let mut sm = default_sm();
         let action = sm.process_event(&start_tag("table")).unwrap();
         assert_eq!(action, StateMachineAction::FallbackRequired);
+    }
+
+    #[test]
+    fn test_video_and_audio_with_src_emit_image_context() {
+        let mut sm = default_sm();
+
+        let video = sm
+            .process_event(&start_tag_with_attrs(
+                "video",
+                vec![("src", "https://example.com/video.mp4")],
+            ))
+            .unwrap();
+        assert_eq!(
+            video,
+            StateMachineAction::Enter(StructuralContext::Image {
+                src: "https://example.com/video.mp4".to_string(),
+                alt: "video".to_string(),
+            })
+        );
+
+        let audio = sm
+            .process_event(&start_tag_with_attrs(
+                "audio",
+                vec![("src", "https://example.com/audio.mp3")],
+            ))
+            .unwrap();
+        assert_eq!(
+            audio,
+            StateMachineAction::Enter(StructuralContext::Image {
+                src: "https://example.com/audio.mp3".to_string(),
+                alt: "audio".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_media_void_tags_extract_src_or_href() {
+        let mut sm = default_sm();
+
+        let source = sm
+            .process_event(&start_tag_with_attrs(
+                "source",
+                vec![("src", "https://example.com/v.webm")],
+            ))
+            .unwrap();
+        assert_eq!(
+            source,
+            StateMachineAction::Enter(StructuralContext::Image {
+                src: "https://example.com/v.webm".to_string(),
+                alt: "source".to_string(),
+            })
+        );
+
+        let area = sm
+            .process_event(&start_tag_with_attrs(
+                "area",
+                vec![("href", "https://example.com/map")],
+            ))
+            .unwrap();
+        assert_eq!(
+            area,
+            StateMachineAction::Enter(StructuralContext::Image {
+                src: "https://example.com/map".to_string(),
+                alt: "area".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_video_without_inline_src_is_noop() {
+        let mut sm = default_sm();
+        let action = sm
+            .process_event(&start_tag_with_attrs("video", vec![("controls", "true")]))
+            .unwrap();
+        assert_eq!(action, StateMachineAction::None);
     }
 
     #[test]

--- a/components/rust-converter/src/streaming/types.rs
+++ b/components/rust-converter/src/streaming/types.rs
@@ -40,6 +40,10 @@ pub enum FallbackReason {
     /// Front matter extraction requires data beyond the lookahead budget.
     FrontMatterOverflow,
     /// An unsupported HTML structure/capability was encountered.
+    ///
+    /// The embedded string must be a stable internal identifier
+    /// (for example `"table"` or `"prune_noise_regions"`), not
+    /// user-controlled content.
     UnsupportedStructure(String),
 }
 
@@ -93,6 +97,8 @@ pub struct StreamingResult {
 pub struct StreamingStats {
     /// Total number of HTML tokens processed.
     pub tokens_processed: u64,
+    /// Total number of tokenizer parse-error events observed.
+    pub parse_errors: u64,
     /// Total number of flush points emitted.
     pub flush_count: u32,
     /// Peak estimated working-set memory usage in bytes.

--- a/components/rust-converter/tests/known_differences.rs
+++ b/components/rust-converter/tests/known_differences.rs
@@ -14,12 +14,43 @@ pub struct KnownDifference {
     pub description: String,
     pub trigger: String,
     pub reason: String,
+    pub drift_type: DriftType,
+    pub severity: DriftSeverity,
     pub acceptable: bool,
     pub fix_version: String,
     pub fixture_contains: Option<String>,
     pub full_buffer_snippet: Option<String>,
     pub streaming_snippet: Option<String>,
     pub diff_contains: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftType {
+    WhitespaceOnly,
+    OrderedListNumbering,
+    EntityEncoding,
+    Structural,
+    Semantic,
+    Unknown,
+}
+
+impl Default for DriftType {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftSeverity {
+    Benign,
+    AcceptableDivergence,
+    NeedsInvestigation,
+}
+
+impl Default for DriftSeverity {
+    fn default() -> Self {
+        Self::AcceptableDivergence
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -55,6 +86,12 @@ impl KnownDifferences {
                         description: string_field(table, "description"),
                         trigger: string_field(table, "trigger"),
                         reason: string_field(table, "reason"),
+                        drift_type: parse_drift_type(
+                            table.get("drift_type").and_then(toml::Value::as_str),
+                        ),
+                        severity: parse_drift_severity(
+                            table.get("severity").and_then(toml::Value::as_str),
+                        ),
                         acceptable: table
                             .get("acceptable")
                             .and_then(toml::Value::as_bool)
@@ -138,6 +175,25 @@ fn optional_string_field(table: &toml::map::Map<String, toml::Value>, key: &str)
         .map(ToOwned::to_owned)
 }
 
+fn parse_drift_type(raw: Option<&str>) -> DriftType {
+    match raw.unwrap_or_default() {
+        "whitespace_only" => DriftType::WhitespaceOnly,
+        "ordered_list_numbering" => DriftType::OrderedListNumbering,
+        "entity_encoding" => DriftType::EntityEncoding,
+        "structural" => DriftType::Structural,
+        "semantic" => DriftType::Semantic,
+        _ => DriftType::Unknown,
+    }
+}
+
+fn parse_drift_severity(raw: Option<&str>) -> DriftSeverity {
+    match raw.unwrap_or_default() {
+        "benign" => DriftSeverity::Benign,
+        "needs_investigation" => DriftSeverity::NeedsInvestigation,
+        _ => DriftSeverity::AcceptableDivergence,
+    }
+}
+
 #[test]
 fn known_differences_matches_by_fixture_and_snippet() {
     let known = KnownDifferences {
@@ -146,6 +202,8 @@ fn known_differences_matches_by_fixture_and_snippet() {
             description: "test".to_string(),
             trigger: "collapse".to_string(),
             reason: "reason".to_string(),
+            drift_type: DriftType::WhitespaceOnly,
+            severity: DriftSeverity::Benign,
             acceptable: true,
             fix_version: "0.6.0".to_string(),
             fixture_contains: Some("streaming".to_string()),
@@ -163,4 +221,26 @@ fn known_differences_matches_by_fixture_and_snippet() {
 
     assert!(known.matches("streaming/example.html", &out).is_some());
     assert!(known.matches("simple/example.html", &out).is_none());
+}
+
+#[test]
+fn known_differences_parse_structured_fields() {
+    assert_eq!(
+        parse_drift_type(Some("ordered_list_numbering")),
+        DriftType::OrderedListNumbering
+    );
+    assert_eq!(
+        parse_drift_type(Some("unknown_new_value")),
+        DriftType::Unknown
+    );
+
+    assert_eq!(parse_drift_severity(Some("benign")), DriftSeverity::Benign);
+    assert_eq!(
+        parse_drift_severity(Some("needs_investigation")),
+        DriftSeverity::NeedsInvestigation
+    );
+    assert_eq!(
+        parse_drift_severity(Some("unexpected")),
+        DriftSeverity::AcceptableDivergence
+    );
 }

--- a/components/rust-converter/tests/streaming_properties.rs
+++ b/components/rust-converter/tests/streaming_properties.rs
@@ -242,6 +242,8 @@ proptest! {
                 // Note: streaming and full-buffer may differ in exact whitespace
                 // due to DOM tree builder vs raw tokenizer differences.
                 // We verify semantic equivalence: same non-empty lines present.
+                // Byte-level parity is covered by corpus parity tests in
+                // `tests/streaming_parity.rs` with known-difference controls.
                 let streaming_lines: Vec<&str> = streaming_str
                     .lines()
                     .map(|l| l.trim())

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Think of this directory as the maintained map behind that landing page: guides f
 | Understand implementation details | [features/README.md](features/README.md) |
 | Review tests and validation references | [testing/README.md](testing/README.md) |
 | Check current status and maintenance notes | [project/README.md](project/README.md) |
+| Understand why the repo-owned harness was added and what it intentionally does not do | [project/HARNESS_HISTORY.md](project/HARNESS_HISTORY.md) |
 
 ## Documentation Sections
 
@@ -82,6 +83,10 @@ Index: [testing/README.md](testing/README.md)
 ### `project/`
 
 Project-level status and maintenance-oriented references.
+
+- current project status
+- version planning
+- harness rationale, boundaries, and historical context
 
 Index: [project/README.md](project/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Think of this directory as the maintained map behind that landing page: guides f
 | Configure directives and behavior | [guides/CONFIGURATION.md](guides/CONFIGURATION.md) |
 | Operate and troubleshoot a deployment | [guides/OPERATIONS.md](guides/OPERATIONS.md) |
 | Understand the architecture and design rationale | [architecture/README.md](architecture/README.md) |
+| Understand agent routing, risk packs, and harness checks | [harness/README.md](harness/README.md) |
+| Maintain repo-owned harness rules and local adapter workflow | [guides/HARNESS_MAINTENANCE.md](guides/HARNESS_MAINTENANCE.md) |
 | Understand implementation details | [features/README.md](features/README.md) |
 | Review tests and validation references | [testing/README.md](testing/README.md) |
 | Check current status and maintenance notes | [project/README.md](project/README.md) |
@@ -29,6 +31,7 @@ Canonical user and operator documentation:
 - source builds and local verification
 - directive reference
 - deployment examples and runbooks
+- harness maintenance and contributor workflow for repo-owned agent rules
 
 Index: [guides/README.md](guides/README.md)
 
@@ -50,9 +53,20 @@ System structure, component boundaries, and decision rationale:
 - runtime architecture overview
 - configuration-to-behavior mapping
 - repository structure
+- harness architecture and design rationale
 - ADRs for major technical choices
 
 Index: [architecture/README.md](architecture/README.md)
+
+### `harness/`
+
+Repo-owned harness overlays for agent execution:
+
+- spec resolver and conflict policy
+- routing manifest and verification families
+- risk-pack index and high-risk overlays
+
+Index: [harness/README.md](harness/README.md)
 
 ### `testing/`
 

--- a/docs/architecture/ADR/0005-repo-owned-harness.md
+++ b/docs/architecture/ADR/0005-repo-owned-harness.md
@@ -1,0 +1,98 @@
+# ADR-0005: Repo-Owned Harness for Agent Workflow and Spec Routing
+
+## Status
+
+Accepted
+
+## Context
+
+The project already had strong runtime documentation and a growing body of
+agent-facing rules in `AGENTS.md`, but the execution workflow around spec
+resolution, risk routing, validation, and maintenance was still fragmented.
+
+Important behavior lived in several places:
+
+- `AGENTS.md`
+- local `.kiro/steering/` files
+- local `.kiro/specs/`
+- CI and Make targets
+- maintainer habit and review history
+
+This caused three structural problems:
+
+1. public readers could not see the full workflow contract in tracked files
+2. local-only steering risked drifting away from repo-owned rules
+3. validation behavior was partly implicit instead of executable
+
+At the same time, the project needed to remain open-source friendly. Private
+`.kiro/` assets are useful for local work, but the repository must not require
+them in order to validate or understand the public contract.
+
+## Decision
+
+Adopt a repo-owned harness with the following structure:
+
+- `AGENTS.md` remains the top-level contract and map
+- `docs/harness/` becomes the canonical repo-owned harness surface
+- `docs/harness/routing-manifest.json` is the canonical structured routing
+  source
+- `docs/harness/routing-manifest.md` is the human-readable summary of that same
+  source
+- risk packs are organized by technical hazard, not by task label
+- `.kiro/specs/` remains read-only input
+- `.kiro/steering/` becomes an optional thin adapter layer, not a second source
+  of truth
+- short-lived execution memory moves to a user-local state carrier rather than
+  tracked docs
+- cheap and full harness validation are exposed through Make targets and Python
+  helpers
+
+## Consequences
+
+### Positive Consequences
+
+- Open-source readers can understand the harness from tracked repository files.
+- Codex-first repository rules become durable and reviewable.
+- Public validation does not depend on private `.kiro/` contents.
+- Human-readable and machine-readable routing stay aligned around one canonical
+  structured source.
+- Repeated failures can drive measured harness evolution instead of relying only
+  on oral history.
+
+### Negative Consequences
+
+- The repository gains another maintained documentation and tooling surface.
+- Maintainers must keep harness docs, tools, Make targets, and CI wiring in
+  sync.
+- Local adapter files still need occasional updates, even though they are no
+  longer authoritative.
+
+## Alternatives Considered
+
+### 1. Keep workflow logic in `AGENTS.md` and local steering only
+
+Rejected because it keeps too much important behavior outside the tracked
+repository or compresses too much into one file.
+
+### 2. Make `.kiro/` the primary harness source
+
+Rejected because `.kiro/` is intentionally private and optional. The public
+repository cannot depend on it.
+
+### 3. Use prose-only harness docs with no canonical structured manifest
+
+Rejected because routing and verification relationships need an executable
+source of truth, not only narrative explanation.
+
+### 4. Build a larger agent platform first
+
+Rejected because the project needed a boring, reviewable repository contract
+before expanding into broader automation.
+
+## References
+
+- [../HARNESS_ARCHITECTURE.md](../HARNESS_ARCHITECTURE.md)
+- [../../harness/README.md](../../harness/README.md)
+- [../../harness/core.md](../../harness/core.md)
+- [../../harness/routing-manifest.json](../../harness/routing-manifest.json)
+- [../../guides/HARNESS_MAINTENANCE.md](../../guides/HARNESS_MAINTENANCE.md)

--- a/docs/architecture/ADR/README.md
+++ b/docs/architecture/ADR/README.md
@@ -58,6 +58,7 @@ What other options were considered and why were they not chosen?
 | [0002](0002-full-buffering-approach.md) | Full Buffering Approach for v1 | Accepted | 2026-02-27 |
 | [0003](0003-inline-origin-near-conversion.md) | Inline Origin-Near Conversion | Accepted | 2026-03-18 |
 | [0004](0004-streaming-bounded-memory-conversion.md) | Streaming Conversion with Bounded Memory and Controlled Fallback | Proposed | 2026-03-23 |
+| [0005](0005-repo-owned-harness.md) | Repo-Owned Harness for Agent Workflow and Spec Routing | Accepted | 2026-04-13 |
 
 ## Creating a New ADR
 

--- a/docs/architecture/HARNESS_ARCHITECTURE.md
+++ b/docs/architecture/HARNESS_ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# Harness Architecture
+
+This document explains the repo-owned harness that coordinates agent-facing
+workflow rules in `nginx-markdown-for-agents`.
+
+Use it when you need to understand:
+
+- why the harness exists as a repository asset instead of a local-only prompt
+- which files own durable harness truth
+- how spec resolution, routing, verification, and maintenance fit together
+- how the harness stays compatible with optional local `.kiro/` data without
+  making the public repository depend on it
+
+## Problem Statement
+
+The repository already had strong runtime architecture docs and a large body of
+historical fixes captured in `AGENTS.md`, but agent workflow behavior was still
+spread across:
+
+- `AGENTS.md`
+- local `.kiro/steering/` files
+- local `.kiro/specs/`
+- CI and Make targets
+- reviewer and maintainer habits
+
+That layout worked for one local setup, but it was not a stable open-source
+contract. The project needed a repo-owned harness that could:
+
+- keep Codex-first rules visible in public history
+- consume optional local spec context without requiring private files
+- expose executable checks instead of only prose guidance
+- preserve human-readable documentation and machine-readable routing from one
+  canonical source
+
+## Design Goals
+
+- Keep repo-owned truth in tracked files.
+- Keep local adaptation optional.
+- Make cheap validation easy to run and full validation explicit.
+- Separate durable rules from short-lived execution memory.
+- Preserve correctness and safety boundaries even when specs or local tools
+  suggest a more aggressive path.
+
+## Non-Goals
+
+- Re-explaining runtime HTML conversion, NGINX filter flow, or FFI semantics.
+- Storing private spec contents or replay annotations in tracked files.
+- Turning the repository into a full agent platform or orchestration service.
+- Replacing contributor judgment with automatic routing in ambiguous cases.
+
+## System Model
+
+```mermaid
+flowchart TD
+    U["User task or bound spec"] --> R["Spec resolver"]
+    R --> C["Short risk card"]
+    C --> M["Routing manifest"]
+    M --> P["Primary pack + supporting packs"]
+    P --> V["Verification matrix"]
+    V --> X["Execute"]
+    X --> D{"Drift or repeated failure?"}
+    D -- "no" --> E["Finish with evidence"]
+    D -- "yes" --> S["Shrink diff and recompute"]
+    S --> O{"Converges?"}
+    O -- "yes" --> X
+    O -- "no" --> Q["Escalate or ask for outside voice"]
+```
+
+## Truth Surfaces
+
+The harness has one public contract surface and two supporting layers.
+
+### 1. Map and contract
+
+- `AGENTS.md`
+
+`AGENTS.md` remains the top-level contract for repository-specific engineering
+rules. It points to the harness, but it does not duplicate the full harness
+implementation.
+
+### 2. Repo-owned harness truth
+
+- `docs/harness/README.md`
+- `docs/harness/core.md`
+- `docs/harness/routing-manifest.json`
+- `docs/harness/routing-manifest.md`
+- `docs/harness/risk-packs/*.md`
+- `tools/harness/*.py`
+
+This is the canonical tracked harness surface. It is designed to be readable by
+humans and consumable by tools.
+
+### 3. Optional local inputs and adapters
+
+- `.kiro/specs/`
+- `.kiro/active-spec.json`
+- `.kiro/active-spec.txt`
+- `.kiro/steering/*.md`
+
+These files are optional. Public clones must still pass repo validation without
+them. When present, they refine local resolution and adapter behavior, but they
+do not replace repo-owned truth.
+
+## Core Components
+
+### Spec resolver
+
+The resolver binds a task to a concrete spec when enough evidence exists.
+
+Resolution order:
+
+1. explicit user-provided spec
+2. optional local active-spec pointer
+3. explainable hint-based matching
+
+If confidence remains low, the resolver must degrade explicitly instead of
+guessing silently.
+
+### Routing manifest
+
+`docs/harness/routing-manifest.json` is the canonical structured source for:
+
+- truth surfaces
+- verification families
+- risk pack metadata
+- pack-to-check relationships
+
+`docs/harness/routing-manifest.md` is the readable summary of that same model.
+The markdown view must not introduce hidden semantics.
+
+### Risk packs
+
+Risk packs are organized by technical hazard, not by task label. The current
+tracked set covers:
+
+- runtime streaming behavior
+- FFI boundary synchronization
+- observability and metrics correctness
+- docs and tooling drift
+
+Each task may activate one primary pack plus zero or more supporting packs.
+
+### Verification matrix
+
+The verification matrix is phased:
+
+1. cheap blockers
+2. focused semantic checks
+3. broader umbrella or release-level checks
+
+Verification may raise the effective risk above the initial route. The first
+guess never outranks later evidence.
+
+### State carrier
+
+The harness keeps short-lived execution memory in a user-local state carrier,
+not in repo docs. The state carrier is used for:
+
+- retry counts
+- drift evidence
+- bounded reflection notes
+- promotion evidence for future rule updates
+
+This avoids polluting tracked documentation with ephemeral task history while
+still giving maintenance flows a durable signal source.
+
+## Public vs Local Execution
+
+The harness supports one public behavior model with adaptive checks.
+
+- Public repo truth is always checked.
+- Optional local `.kiro/` inputs add stricter checks when present.
+- Missing local files become `SKIP_NOT_PRESENT`, not repository failures.
+
+This keeps the project open-source friendly while still supporting richer local
+author workflows.
+
+## Maintenance Loop
+
+The harness is not intended to freeze after initial rollout.
+
+Two maintenance paths are expected:
+
+- sync maintenance: keep repo truth, adapters, Make targets, and CI aligned
+- rule evolution: update packs or routing when repeated fixes, replay evidence,
+  or historical commit patterns justify a stronger rule
+
+The maintenance loop is supported by:
+
+- `make harness-check`
+- `make harness-check-full`
+- `tools/harness/check_harness_sync.py`
+- `tools/harness/state_store.py`
+- local maintenance skills outside the repository
+
+## Failure Boundaries
+
+The harness is designed to fail explicitly in four common situations:
+
+- no confident spec binding
+- route confidence too low to pick a single safe path
+- repeated drift after one recompute attempt
+- a spec or user request appears to violate repository correctness or safety
+  boundaries
+
+In those cases the harness should either:
+
+- downgrade to core plus candidate packs
+- request explicit human confirmation
+- or ask for outside voice from a different model family
+
+## Relationship to Other Docs
+
+- Runtime system architecture: [SYSTEM_ARCHITECTURE.md](SYSTEM_ARCHITECTURE.md)
+- Request lifecycle: [REQUEST_LIFECYCLE.md](REQUEST_LIFECYCLE.md)
+- Repository layout: [REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md)
+- Harness entrypoint: [../harness/README.md](../harness/README.md)
+- Harness maintenance procedures: [../guides/HARNESS_MAINTENANCE.md](../guides/HARNESS_MAINTENANCE.md)
+- Decision record for this design: [ADR/0005-repo-owned-harness.md](ADR/0005-repo-owned-harness.md)

--- a/docs/architecture/HARNESS_ARCHITECTURE.md
+++ b/docs/architecture/HARNESS_ARCHITECTURE.md
@@ -151,6 +151,9 @@ The verification matrix is phased:
 Verification may raise the effective risk above the initial route. The first
 guess never outranks later evidence.
 
+This design intentionally favors a cheap fast path. Broader scans, replay, and
+history-heavy analysis are escalation tools, not default taxes on every task.
+
 ### State carrier
 
 The harness keeps short-lived execution memory in a user-local state carrier,
@@ -185,6 +188,9 @@ Two maintenance paths are expected:
 - rule evolution: update packs or routing when repeated fixes, replay evidence,
   or historical commit patterns justify a stronger rule
 
+The sync gate exists to keep those truth surfaces from drifting apart. The
+maintenance loop is not only social process; it is backed by executable checks.
+
 The maintenance loop is supported by:
 
 - `make harness-check`
@@ -208,6 +214,17 @@ In those cases the harness should either:
 - downgrade to core plus candidate packs
 - request explicit human confirmation
 - or ask for outside voice from a different model family
+
+## Validation Sequencing
+
+The harness design reviews settled on a dual proving-ground strategy:
+
+1. runtime-risk first
+2. static-quality second
+
+This sequencing is deliberate. It proves the harness against the most expensive
+correctness and safety surfaces before widening to style, lint, or broader
+quality-discipline scenarios.
 
 ## Relationship to Other Docs
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,9 +12,12 @@ Use it when you need more than deployment guidance but less than source-level im
 | The request flow through header/body filters and failure paths | [REQUEST_LIFECYCLE.md](REQUEST_LIFECYCLE.md) |
 | How directives map to runtime branches and implementation areas | [CONFIG_BEHAVIOR_MAP.md](CONFIG_BEHAVIOR_MAP.md) |
 | The repository layout and where code lives | [REPOSITORY_STRUCTURE.md](REPOSITORY_STRUCTURE.md) |
+| How the repo-owned harness is structured and why it exists | [HARNESS_ARCHITECTURE.md](HARNESS_ARCHITECTURE.md) |
+| How repo-owned agent routing and risk overlays are organized | [../harness/README.md](../harness/README.md) |
 | Why conversion lives in Rust | [ADR/0001-use-rust-for-conversion.md](ADR/0001-use-rust-for-conversion.md) |
 | Why v1 uses full buffering | [ADR/0002-full-buffering-approach.md](ADR/0002-full-buffering-approach.md) |
 | Why conversion runs at the origin-near layer | [ADR/0003-inline-origin-near-conversion.md](ADR/0003-inline-origin-near-conversion.md) |
+| Why the harness became a repo-owned system | [ADR/0005-repo-owned-harness.md](ADR/0005-repo-owned-harness.md) |
 | The full ADR index | [ADR/README.md](ADR/README.md) |
 
 ## Scope
@@ -23,4 +26,8 @@ Use it when you need more than deployment guidance but less than source-level im
 - `REQUEST_LIFECYCLE.md` explains the dynamic request path and control flow.
 - `CONFIG_BEHAVIOR_MAP.md` maps public directives to runtime behavior.
 - `REPOSITORY_STRUCTURE.md` explains how the repository is organized.
+- `HARNESS_ARCHITECTURE.md` explains the repo-owned harness, its truth surfaces,
+  and its relationship to local-only inputs.
+- `docs/harness/` describes task-routing overlays and check orchestration without
+  duplicating runtime semantics.
 - `ADR/` records specific architectural decisions and their consequences.

--- a/docs/guides/HARNESS_MAINTENANCE.md
+++ b/docs/guides/HARNESS_MAINTENANCE.md
@@ -62,6 +62,10 @@ make harness-check-full
 6. If optional local `.kiro/` adapters exist, keep them aligned after the
    tracked change is correct.
 
+The cheap path is intentional. Do not automatically widen every maintenance
+change into replay scans, history analysis, or release-level checks unless the
+change actually touches those surfaces.
+
 ## Adding or Changing a Risk Pack
 
 Create or update a risk pack only when the surface is distinct and durable.
@@ -104,6 +108,10 @@ Before promoting a rule, ask:
 - does it cross tasks or specs
 - would a stronger rule or pack actually prevent the mistake
 
+Use bounded scans for this work. Start with the highest-signal history and the
+most relevant spec subset instead of scanning every commit and every replay
+artifact by default.
+
 ## Optional Local Inputs
 
 The project deliberately allows richer local workflows without making them a
@@ -122,6 +130,9 @@ Rules for optional inputs:
 - presence may enable stricter local checks
 - repo-owned truth still wins if there is disagreement
 - `.kiro/specs/` is read-only input, not a cache or annotation store
+- malformed local pointer files, malformed local spec metadata, and damaged
+  user-local state files should degrade explicitly rather than crash the tool
+  with a raw traceback
 
 ## Outside Voice
 
@@ -134,6 +145,10 @@ Use outside voice when the harness stops converging cleanly:
 
 Prefer a different model family than the current driver so the second opinion
 is more likely to challenge the current assumptions.
+
+Outside voice is most valuable after repeated drift, ambiguous routing, or
+warning triage that does not converge. Use it as a challenge mechanism, not as
+the first step for routine maintenance.
 
 ## Open-Source Documentation Expectations
 
@@ -157,6 +172,10 @@ Before closing substantial harness work:
 - make sure new docs are linked from the relevant index pages
 - make sure the readable summary matches the structured manifest
 - make sure local-only helpers are still optional rather than required
+- add regression coverage for malformed optional inputs and degraded-state paths
+  when you touch harness parsing or validation logic
+- keep the sync gate healthy: tracked truth, Make targets, CI wiring, and local
+  adapters should all reflect the same public contract
 
 ## References
 

--- a/docs/guides/HARNESS_MAINTENANCE.md
+++ b/docs/guides/HARNESS_MAINTENANCE.md
@@ -1,0 +1,166 @@
+# Harness Maintenance Guide
+
+This guide explains how to maintain the repo-owned harness without turning it
+into a second product or a local-only workflow.
+
+Use it when you need to:
+
+- update agent-facing repository rules
+- add or refine a risk pack
+- wire new validation paths into the harness
+- reconcile public repo truth with optional local `.kiro/` helpers
+
+## What the Harness Owns
+
+The harness owns repository-level execution guidance for spec-driven work:
+
+- spec resolution policy
+- routing and pack selection
+- verification family wiring
+- conflict and escalation policy
+- cheap and full validation entrypoints
+
+It does **not** own:
+
+- runtime NGINX semantics already documented elsewhere
+- private spec details that live only in `.kiro/specs/`
+- ephemeral task logs that belong in local state, not tracked docs
+
+## Public Source of Truth
+
+When you change harness behavior, update repo-owned truth first:
+
+- `AGENTS.md`
+- `docs/harness/`
+- `tools/harness/`
+- `Makefile`
+- `.github/workflows/ci.yml`
+
+Optional local files may summarize or refine behavior, but they must follow the
+tracked contract instead of inventing one.
+
+## Normal Maintenance Workflow
+
+1. Bind the change to a concrete task or spec when possible.
+2. Decide whether the change is:
+   - sync work
+   - rule evolution
+   - or a new risk surface
+3. Update tracked harness truth first.
+4. Run cheap validation:
+
+```bash
+make harness-check
+```
+
+5. If docs, release-gate wiring, or broader validation changed, run:
+
+```bash
+make harness-check-full
+```
+
+6. If optional local `.kiro/` adapters exist, keep them aligned after the
+   tracked change is correct.
+
+## Adding or Changing a Risk Pack
+
+Create or update a risk pack only when the surface is distinct and durable.
+
+Good reasons:
+
+- repeated historical failures in the same technical area
+- a new cross-boundary hazard that needs explicit checks
+- an existing pack becoming too broad to reason about safely
+
+Poor reasons:
+
+- renaming a pack without changing behavior
+- copying runtime docs into harness docs
+- adding a pack only because a single task felt inconvenient
+
+When updating a pack:
+
+1. keep the pack focused on task overlays and verification, not domain restatement
+2. update the canonical routing manifest
+3. update the readable manifest summary if needed
+4. add or update targeted regression tests
+5. run `make harness-check`
+
+## Evolving Rules from Evidence
+
+The harness should learn from repeated mistakes, but it should not promote
+every noisy warning into a permanent rule.
+
+Preferred evidence sources:
+
+1. repeated fixes in git history, especially against `main...HEAD`
+2. cross-spec replay recurrences
+3. explicit user policy decisions
+4. repeated drift or warning patterns captured in local state
+
+Before promoting a rule, ask:
+
+- is the pattern repeated rather than isolated
+- does it cross tasks or specs
+- would a stronger rule or pack actually prevent the mistake
+
+## Optional Local Inputs
+
+The project deliberately allows richer local workflows without making them a
+public requirement.
+
+Supported optional inputs include:
+
+- `.kiro/specs/`
+- `.kiro/active-spec.json`
+- `.kiro/active-spec.txt`
+- `.kiro/steering/*.md`
+
+Rules for optional inputs:
+
+- absence is reported as `SKIP_NOT_PRESENT`, not failure
+- presence may enable stricter local checks
+- repo-owned truth still wins if there is disagreement
+- `.kiro/specs/` is read-only input, not a cache or annotation store
+
+## Outside Voice
+
+Use outside voice when the harness stops converging cleanly:
+
+- the route keeps flipping
+- warnings recur without narrowing
+- drift fires more than once
+- a safe path exists, but the harness cannot choose confidently
+
+Prefer a different model family than the current driver so the second opinion
+is more likely to challenge the current assumptions.
+
+## Open-Source Documentation Expectations
+
+When you add harness behavior, document it in the right layer:
+
+- `docs/architecture/` for system design and decision rationale
+- `docs/guides/` for maintenance and contributor procedure
+- `docs/harness/` for the canonical execution overlays themselves
+- `docs/project/` for current status if the change materially alters repository
+  posture
+
+Do not leave important design rationale only in ephemeral review threads or
+private local notes.
+
+## Verification Checklist
+
+Before closing substantial harness work:
+
+- run `make harness-check`
+- run `make harness-check-full` when broader docs or release wiring changed
+- make sure new docs are linked from the relevant index pages
+- make sure the readable summary matches the structured manifest
+- make sure local-only helpers are still optional rather than required
+
+## References
+
+- [../harness/README.md](../harness/README.md)
+- [../harness/core.md](../harness/core.md)
+- [../architecture/HARNESS_ARCHITECTURE.md](../architecture/HARNESS_ARCHITECTURE.md)
+- [../architecture/ADR/0005-repo-owned-harness.md](../architecture/ADR/0005-repo-owned-harness.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,6 +11,7 @@ Use these documents when you need decisions and procedures you can act on direct
 3. [CONFIGURATION.md](CONFIGURATION.md) if you need the full directive reference and tuning details.
 4. [OPERATIONS.md](OPERATIONS.md) if you are preparing for production monitoring and troubleshooting.
 5. [BUILD_INSTRUCTIONS.md](BUILD_INSTRUCTIONS.md) if you are building from source or working locally.
+6. [HARNESS_MAINTENANCE.md](HARNESS_MAINTENANCE.md) if you are maintaining repo-owned agent workflow rules and validation.
 
 ## Guide Index
 
@@ -21,6 +22,7 @@ Use these documents when you need decisions and procedures you can act on direct
 | [CONFIGURATION.md](CONFIGURATION.md) | Directive reference, defaults, and configuration behavior |
 | [OPERATIONS.md](OPERATIONS.md) | Monitoring, troubleshooting, and operational runbooks |
 | [BUILD_INSTRUCTIONS.md](BUILD_INSTRUCTIONS.md) | Source builds, development workflows, and local verification |
+| [HARNESS_MAINTENANCE.md](HARNESS_MAINTENANCE.md) | Maintaining repo-owned harness rules, checks, and local adapters |
 
 ## Scope
 
@@ -32,3 +34,5 @@ In short:
 - `DEPLOYMENT_EXAMPLES.md` gets you to a working rollout pattern faster
 - `CONFIGURATION.md` defines the knobs and policies
 - `OPERATIONS.md` covers monitoring, troubleshooting, and runtime practice
+- `HARNESS_MAINTENANCE.md` explains how to evolve the repo-owned harness without
+  moving public rules into local-only files

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -1,0 +1,69 @@
+# Harness Overview
+
+This directory is the repo-owned entrypoint for the spec-native harness.
+
+Use it when you need to answer one of these questions quickly:
+
+- what is the harness flow for a new task
+- which risk pack owns the current change surface
+- which checks are cheap blockers vs deeper validation
+- where Kiro adapters should point instead of inventing local truth
+
+Start here, then branch out:
+
+| Need | Read |
+|------|------|
+| Overall workflow, conflict policy, and escalation rules | [core.md](core.md) |
+| Canonical machine-readable routing source | [routing-manifest.json](routing-manifest.json) |
+| Human-readable routing summary | [routing-manifest.md](routing-manifest.md) |
+| Risk-pack index | [risk-packs/README.md](risk-packs/README.md) |
+| System design and rationale for the harness itself | [../architecture/HARNESS_ARCHITECTURE.md](../architecture/HARNESS_ARCHITECTURE.md) |
+| Contributor maintenance workflow for evolving harness rules | [../guides/HARNESS_MAINTENANCE.md](../guides/HARNESS_MAINTENANCE.md) |
+
+## Harness Flow
+
+```mermaid
+flowchart TD
+    A["Task or spec"] --> B["Spec resolver"]
+    B --> C["Short risk card"]
+    C --> D["Routing manifest"]
+    D --> E["Primary pack + supporting packs"]
+    E --> F["Verification matrix"]
+    F --> G["Execute"]
+    G --> H{"Loop or drift?"}
+    H -- "no" --> I["Finish with evidence"]
+    H -- "yes" --> J["Shrink diff + recompute route/verify"]
+    J --> K{"Converges?"}
+    K -- "yes" --> G
+    K -- "no" --> L["Escalate or outside voice"]
+```
+
+## Truth Surfaces
+
+```mermaid
+flowchart LR
+    A["AGENTS.md<br/>map + contract"] --> B["docs/harness/<br/>core + manifest + packs"]
+    B --> C["Make / CI / checkers"]
+    B --> D["Optional .kiro/steering adapters"]
+    B --> E["Rule-maintenance skills"]
+    F[".kiro/specs (read-only input)"] --> B
+    G["User-local state carrier"] --> E
+    E --> B
+```
+
+## Guardrails
+
+- `AGENTS.md` remains the Codex-first contract.
+- `docs/harness/` owns reusable harness truth, not domain semantics already documented elsewhere.
+- `.kiro/specs/` is read-only input, not a place for harness caches or annotations.
+- `.kiro/steering/` is an adapter layer. It can summarize and link, but it does not get its own rules.
+- Outside voice is advisory. A different model family can challenge the current path, but it does not overrule the user.
+
+## Canonical References
+
+- [../architecture/HARNESS_ARCHITECTURE.md](../architecture/HARNESS_ARCHITECTURE.md)
+- [../guides/HARNESS_MAINTENANCE.md](../guides/HARNESS_MAINTENANCE.md)
+- [../architecture/ADR/0005-repo-owned-harness.md](../architecture/ADR/0005-repo-owned-harness.md)
+- [../architecture/README.md](../architecture/README.md)
+- [../testing/README.md](../testing/README.md)
+- [../DOCUMENTATION_DUPLICATION_POLICY.md](../DOCUMENTATION_DUPLICATION_POLICY.md)

--- a/docs/harness/core.md
+++ b/docs/harness/core.md
@@ -1,0 +1,121 @@
+# Harness Core
+
+This document describes how the repo-native harness should behave during
+spec-driven work. It does not restate HTML conversion, NGINX lifecycle, or FFI
+semantics. Those stay in canonical docs and in `AGENTS.md`.
+
+## Core Loop
+
+1. Bind the current task to a concrete spec when possible.
+2. Emit a short risk card before editing.
+3. Route through the canonical manifest.
+4. Pick one primary risk pack and any supporting packs.
+5. Build a phased verification matrix before broad edits.
+6. Execute, retry once on drift, then escalate or ask for outside voice if the
+   work does not converge.
+7. Record bounded reflection and promotion evidence in the user-local state
+   carrier, not in repo truth files.
+
+## Spec Resolver Contract
+
+- Start from the current user task.
+- If an active spec pointer exists, use it to refine the target.
+- If multiple specs are in motion, explain why the current task binds to the
+  chosen spec.
+- If no spec can be bound confidently, degrade explicitly. Do not guess.
+
+Use the repo helper when you want a concrete resolution pass:
+
+```bash
+python3 tools/harness/resolve_spec.py --hint "continue streaming parity work"
+```
+
+Optional local pointer files:
+
+- `.kiro/active-spec.json` with `{"spec": "<dir-name-or-specId>"}`
+- `.kiro/active-spec.txt` with one dir name or specId
+
+## Preflight Risk Card
+
+The default card stays short:
+
+- touched area
+- likely primary pack
+- supporting packs, if any
+- minimum cheap blockers
+- one-sentence risk note
+
+Expand to a detailed card only when:
+
+- routing confidence is low
+- multiple high-risk surfaces overlap
+- warnings keep repeating
+- the diff starts to widen instead of converge
+
+## Verification Matrix
+
+Run checks in phases:
+
+1. Cheap blockers
+   - `make harness-check`
+   - other low-cost docs or config checks for the touched area
+2. Focused semantic checks
+   - one or more pack-specific commands from the routing manifest
+3. Broader umbrella checks
+   - runtime smoke, replay-driven comparisons, or release-level checks
+
+Verification may raise the effective risk level above the initial route. If it
+does, the route changes. The initial guess does not get special authority.
+
+## Status Semantics
+
+- `PASS`: the check ran and matched the contract
+- `FAIL`: the contract is broken and the task is blocked
+- `SKIP_NOT_PRESENT`: optional local-only input was not present
+- `WARN_NEEDS_AUTHOR_REVIEW`: the harness found a likely drift that should be
+  reviewed by the author, but it is not a public-repo failure by itself
+
+## Conflict Protocol
+
+- The user task and bound spec set the goal.
+- `AGENTS.md` and harness rules set correctness, safety, and engineering
+  boundaries.
+- If the goal appears to violate the contract, stop and explain the mismatch.
+- Require human confirmation before proceeding with a contract-breaking path.
+
+## Loop and Drift Rescue
+
+On the first drift trigger:
+
+1. shrink the diff
+2. recompute route and verification
+3. retry once
+
+If the same pattern repeats, escalate or ask for outside voice. The harness
+must not burn tokens pretending every retry is fresh work.
+
+## Outside Voice
+
+Use CLI-based outside voice when:
+
+- the route keeps flipping
+- warnings recur without narrowing
+- loop/drift triggers more than once
+- the harness cannot decide between safety-preserving options
+
+Prefer a different model family than the current driver:
+
+- Codex driver -> `qwen` or Claude Code
+- Qwen driver -> Codex or Claude Code
+- Claude Code driver -> Codex or `qwen`
+
+## State Carrier
+
+Keep short-lived state outside repo truth files. The user-local state carrier is
+for:
+
+- retry and drift counts
+- bounded reflection summaries
+- evidence that a small mistake has repeated enough to justify a rule upgrade
+
+Repo-owned docs keep durable truth. The state carrier keeps execution memory.

--- a/docs/harness/core.md
+++ b/docs/harness/core.md
@@ -67,6 +67,14 @@ Run checks in phases:
 Verification may raise the effective risk level above the initial route. If it
 does, the route changes. The initial guess does not get special authority.
 
+The default path should stay cheap. Prefer a fast blocker-first flow and widen
+only when the touched surface, warnings, or drift signals justify more cost.
+Do not spend replay or history-scan budget on every task by default.
+
+Warnings are not cleanup theater. Do not silence a warning by weakening checks,
+shrinking coverage, or deleting behavior unless the warning itself proves the
+behavior is invalid. Fix the underlying problem or escalate it explicitly.
+
 ## Status Semantics
 
 - `PASS`: the check ran and matched the contract
@@ -74,6 +82,11 @@ does, the route changes. The initial guess does not get special authority.
 - `SKIP_NOT_PRESENT`: optional local-only input was not present
 - `WARN_NEEDS_AUTHOR_REVIEW`: the harness found a likely drift that should be
   reviewed by the author, but it is not a public-repo failure by itself
+
+Harness tools must map malformed or unreadable inputs into these explicit
+statuses whenever possible. Public manifests should fail clearly. Optional local
+inputs and user-local state should degrade explicitly instead of crashing with a
+raw traceback.
 
 ## Conflict Protocol
 
@@ -93,6 +106,13 @@ On the first drift trigger:
 
 If the same pattern repeats, escalate or ask for outside voice. The harness
 must not burn tokens pretending every retry is fresh work.
+
+## Proving Grounds
+
+When validating harness evolution across broad scenarios, keep the first proving
+ground on runtime-risk surfaces and add static-quality proving grounds second.
+This preserves the priority order from the design reviews: correctness and
+safety on the real request path first, quality-discipline expansion second.
 
 ## Outside Voice
 

--- a/docs/harness/risk-packs/README.md
+++ b/docs/harness/risk-packs/README.md
@@ -1,0 +1,18 @@
+# Risk Packs
+
+Risk packs are thin overlays for high-risk change surfaces. They do not restate
+runtime semantics from canonical docs. They answer four practical questions:
+
+- when should this pack become primary
+- what supporting packs usually co-occur
+- which sync points are easy to miss
+- which focused verification commands should run before broader checks
+
+## Initial Packs
+
+| Pack | Use when | Canonical docs |
+|------|----------|----------------|
+| [runtime-streaming.md](runtime-streaming.md) | streaming, fail-open, deferred output, pending chains | `AGENTS.md`, `docs/architecture/REQUEST_LIFECYCLE.md` |
+| [ffi-boundary.md](ffi-boundary.md) | Rust/C headers, ABI, FFI error codes, option structs | `AGENTS.md`, `docs/architecture/REPOSITORY_STRUCTURE.md` |
+| [observability-metrics.md](observability-metrics.md) | metrics, reason codes, release visibility, dashboards | `AGENTS.md`, `docs/guides/prometheus-metrics.md` |
+| [docs-tooling-drift.md](docs-tooling-drift.md) | docs, validators, release-gate commands, CI path filters | `AGENTS.md`, `docs/DOCUMENTATION_DUPLICATION_POLICY.md` |

--- a/docs/harness/risk-packs/docs-tooling-drift.md
+++ b/docs/harness/risk-packs/docs-tooling-drift.md
@@ -1,0 +1,35 @@
+# Docs Tooling Drift Pack
+
+Use this as the primary pack when docs, validators, CI filters, or contract
+summaries change together.
+
+## Triggers
+
+- touched files under `docs/**`, `tools/docs/**`, `tools/release/**`
+- touched `AGENTS.md`, `Makefile`, or `.github/workflows/**`
+- keywords like `validator`, `path filter`, `installation`, `release gate`
+
+## Common Supporting Packs
+
+- `observability-metrics` when docs or validators mention operator-facing metrics
+
+## Sync Points
+
+- `AGENTS.md` vs `docs/harness/` map and contract references
+- docs vs validator scope and naming
+- CI path filters vs new truth surfaces
+- operator commands vs actual output format requirements
+
+## Minimum Verification
+
+```bash
+make harness-check
+make docs-check
+make harness-check-full
+```
+
+## Canonical References
+
+- [../../DOCUMENTATION_DUPLICATION_POLICY.md](../../DOCUMENTATION_DUPLICATION_POLICY.md)
+- [../../README.md](../../README.md)
+- [../../../AGENTS.md](../../../AGENTS.md)

--- a/docs/harness/risk-packs/ffi-boundary.md
+++ b/docs/harness/risk-packs/ffi-boundary.md
@@ -27,6 +27,7 @@ plumbing, or error-code classification change.
 make harness-check
 make build
 make test-rust
+make test-nginx-unit
 ```
 
 ## Canonical References

--- a/docs/harness/risk-packs/ffi-boundary.md
+++ b/docs/harness/risk-packs/ffi-boundary.md
@@ -1,0 +1,36 @@
+# FFI Boundary Pack
+
+Use this as the primary pack when Rust/C structs, headers, defaults, option
+plumbing, or error-code classification change.
+
+## Triggers
+
+- touched files under `components/rust-converter/src/ffi*`
+- touched files under `components/rust-converter/include/**`
+- touched files under `components/nginx-module/src/markdown_converter.h`
+- keywords like `repr(C)`, `markdown_converter.h`, `error code`, `struct field`
+
+## Common Supporting Packs
+
+- `observability-metrics` when a new field or error path becomes operator-visible
+
+## Sync Points
+
+- Rust struct field changes vs generated/public header copies
+- FFI option defaults vs NGINX call sites
+- test helper constructors vs new struct fields
+- operator docs vs changed enum or error naming
+
+## Minimum Verification
+
+```bash
+make harness-check
+make build
+make test-rust
+```
+
+## Canonical References
+
+- [../../architecture/REPOSITORY_STRUCTURE.md](../../architecture/REPOSITORY_STRUCTURE.md)
+- [../../testing/README.md](../../testing/README.md)
+- [../../../AGENTS.md](../../../AGENTS.md)

--- a/docs/harness/risk-packs/observability-metrics.md
+++ b/docs/harness/risk-packs/observability-metrics.md
@@ -1,0 +1,36 @@
+# Observability Metrics Pack
+
+Use this as the primary pack when metrics, reason-code visibility, text/JSON or
+Prometheus output, or release-gate monitoring semantics change.
+
+## Triggers
+
+- touched files in metrics renderers or reason-code classification paths
+- touched files under `tools/release_gates/**` or `tools/release/**`
+- touched files under `docs/guides/prometheus-metrics.md`
+- keywords like `prometheus`, `reason code`, `ttfb`, `snapshot`, `metrics`
+
+## Common Supporting Packs
+
+- `docs-tooling-drift` when dashboards, docs, or release gates need to stay in sync
+
+## Sync Points
+
+- struct fields vs renderer output vs docs
+- metric name semantics vs actual measurement point
+- reason-code additions vs log emission and severity classification
+- release-gate docs vs validator key paths
+
+## Minimum Verification
+
+```bash
+make harness-check
+make docs-check
+make release-gates-check
+```
+
+## Canonical References
+
+- [../../guides/prometheus-metrics.md](../../guides/prometheus-metrics.md)
+- [../../project/release-gates/README.md](../../project/release-gates/README.md)
+- [../../../AGENTS.md](../../../AGENTS.md)

--- a/docs/harness/risk-packs/runtime-streaming.md
+++ b/docs/harness/risk-packs/runtime-streaming.md
@@ -5,7 +5,12 @@ chains, fail-open flow, or deferred output ordering.
 
 ## Triggers
 
+- primary surface identifiers: `streaming`, `pending-chain`, `fail-open`
 - touched files under `components/nginx-module/**`
+- touched files under
+  `components/rust-converter/src/incremental.rs`
+- touched files under
+  `components/rust-converter/src/charset.rs`
 - touched files under `tools/e2e/**`
 - keywords like `NGX_AGAIN`, `last_buf`, `pending chain`, `streaming`
 
@@ -19,7 +24,11 @@ chains, fail-open flow, or deferred output ordering.
 - pending chain persistence vs terminal buffer emission
 - header-forwarded state vs fail-open branches
 - UTF-8 tail handling vs chunk boundaries
+- media URL extraction parity (`img`/`video`/`audio`/`source`/`track`/`area`)
+  vs full-buffer behavior
 - replay/runtime fixtures vs new failure paths
+- known-difference registry schema drift (`drift_type`/`severity`) vs parity
+  suppressor semantics
 
 ## Minimum Verification
 

--- a/docs/harness/risk-packs/runtime-streaming.md
+++ b/docs/harness/risk-packs/runtime-streaming.md
@@ -1,0 +1,37 @@
+# Runtime Streaming Pack
+
+Use this as the primary pack when the change touches request streaming, pending
+chains, fail-open flow, or deferred output ordering.
+
+## Triggers
+
+- touched files under `components/nginx-module/**`
+- touched files under `tools/e2e/**`
+- keywords like `NGX_AGAIN`, `last_buf`, `pending chain`, `streaming`
+
+## Common Supporting Packs
+
+- `observability-metrics` when a streaming outcome changes logs, counters, or
+  operator-visible behavior
+
+## Sync Points
+
+- pending chain persistence vs terminal buffer emission
+- header-forwarded state vs fail-open branches
+- UTF-8 tail handling vs chunk boundaries
+- replay/runtime fixtures vs new failure paths
+
+## Minimum Verification
+
+```bash
+make harness-check
+make test-rust-streaming
+make test-nginx-unit-streaming
+make verify-chunked-native-e2e-smoke
+```
+
+## Canonical References
+
+- [../../architecture/REQUEST_LIFECYCLE.md](../../architecture/REQUEST_LIFECYCLE.md)
+- [../../testing/README.md](../../testing/README.md)
+- [../../../AGENTS.md](../../../AGENTS.md)

--- a/docs/harness/routing-manifest.json
+++ b/docs/harness/routing-manifest.json
@@ -87,7 +87,7 @@
       "phase": "umbrella",
       "commands": [
         "make verify-chunked-native-e2e-smoke",
-        "make verify-streaming-failure-cache-e2e-plan"
+        "make verify-streaming-failure-cache-e2e"
       ]
     },
     "release-quality": {

--- a/docs/harness/routing-manifest.json
+++ b/docs/harness/routing-manifest.json
@@ -1,0 +1,245 @@
+{
+  "version": 1,
+  "codex_first": true,
+  "truth_surfaces": {
+    "contract": [
+      "AGENTS.md"
+    ],
+    "harness": [
+      "docs/harness/README.md",
+      "docs/harness/core.md",
+      "docs/harness/routing-manifest.md",
+      "docs/harness/routing-manifest.json",
+      "docs/harness/risk-packs/README.md"
+    ],
+    "canonical_docs": [
+      "docs/architecture/README.md",
+      "docs/testing/README.md",
+      "docs/DOCUMENTATION_DUPLICATION_POLICY.md"
+    ],
+    "optional_adapters": [
+      ".kiro/steering/product.md",
+      ".kiro/steering/structure.md",
+      ".kiro/steering/tech.md"
+    ]
+  },
+  "status_semantics": [
+    "PASS",
+    "FAIL",
+    "SKIP_NOT_PRESENT",
+    "WARN_NEEDS_AUTHOR_REVIEW"
+  ],
+  "spec_resolver": {
+    "priority": [
+      "user-task",
+      "active-spec-pointer",
+      "agents-contract",
+      "harness-core",
+      "replay-calibration"
+    ],
+    "pointer_candidates": [
+      ".kiro/active-spec.json",
+      ".kiro/active-spec.txt"
+    ],
+    "multiple_spec_policy": "explain-current-choice",
+    "conflict_policy": "stop-and-confirm"
+  },
+  "verification_families": {
+    "harness-sync": {
+      "phase": "cheap-blocker",
+      "commands": [
+        "make harness-check"
+      ]
+    },
+    "docs-tooling": {
+      "phase": "cheap-blocker",
+      "commands": [
+        "make docs-check"
+      ]
+    },
+    "rust-streaming": {
+      "phase": "focused-semantic",
+      "commands": [
+        "make test-rust-streaming"
+      ]
+    },
+    "nginx-streaming": {
+      "phase": "focused-semantic",
+      "commands": [
+        "make test-nginx-unit-streaming"
+      ]
+    },
+    "ffi-boundary": {
+      "phase": "focused-semantic",
+      "commands": [
+        "make build",
+        "make test-rust"
+      ]
+    },
+    "observability-metrics": {
+      "phase": "focused-semantic",
+      "commands": [
+        "make docs-check",
+        "make release-gates-check"
+      ]
+    },
+    "runtime-e2e": {
+      "phase": "umbrella",
+      "commands": [
+        "make verify-chunked-native-e2e-smoke",
+        "make verify-streaming-failure-cache-e2e-plan"
+      ]
+    },
+    "release-quality": {
+      "phase": "umbrella",
+      "commands": [
+        "make harness-check-full"
+      ]
+    }
+  },
+  "risk_packs": [
+    {
+      "id": "runtime-streaming",
+      "doc": "docs/harness/risk-packs/runtime-streaming.md",
+      "primary_surfaces": [
+        "streaming",
+        "pending-chain",
+        "fail-open"
+      ],
+      "supporting_surfaces": [
+        "observability"
+      ],
+      "paths": [
+        "components/nginx-module/**",
+        "components/rust-converter/src/incremental.rs",
+        "components/rust-converter/src/charset.rs",
+        "tools/e2e/**"
+      ],
+      "keywords": [
+        "streaming",
+        "chunk",
+        "NGX_AGAIN",
+        "pending chain",
+        "last_buf"
+      ],
+      "verification_families": [
+        "harness-sync",
+        "rust-streaming",
+        "nginx-streaming",
+        "runtime-e2e"
+      ]
+    },
+    {
+      "id": "ffi-boundary",
+      "doc": "docs/harness/risk-packs/ffi-boundary.md",
+      "primary_surfaces": [
+        "ffi",
+        "header-sync",
+        "abi"
+      ],
+      "supporting_surfaces": [
+        "observability"
+      ],
+      "paths": [
+        "components/rust-converter/include/**",
+        "components/rust-converter/src/ffi.rs",
+        "components/rust-converter/src/ffi/**",
+        "components/nginx-module/src/markdown_converter.h",
+        "components/nginx-module/src/**"
+      ],
+      "keywords": [
+        "ffi",
+        "markdown_converter.h",
+        "repr(C)",
+        "error code",
+        "struct field"
+      ],
+      "verification_families": [
+        "harness-sync",
+        "ffi-boundary",
+        "release-quality"
+      ]
+    },
+    {
+      "id": "observability-metrics",
+      "doc": "docs/harness/risk-packs/observability-metrics.md",
+      "primary_surfaces": [
+        "metrics",
+        "reason-codes",
+        "operator-contract"
+      ],
+      "supporting_surfaces": [
+        "docs-tooling"
+      ],
+      "paths": [
+        "components/nginx-module/src/**",
+        "docs/guides/prometheus-metrics.md",
+        "docs/project/release-gates/**",
+        "tools/release_gates/**",
+        "tools/release/**"
+      ],
+      "keywords": [
+        "metrics",
+        "prometheus",
+        "reason code",
+        "snapshot",
+        "ttfb"
+      ],
+      "verification_families": [
+        "harness-sync",
+        "observability-metrics",
+        "release-quality"
+      ]
+    },
+    {
+      "id": "docs-tooling-drift",
+      "doc": "docs/harness/risk-packs/docs-tooling-drift.md",
+      "primary_surfaces": [
+        "docs",
+        "validators",
+        "ci-gating"
+      ],
+      "supporting_surfaces": [
+        "observability"
+      ],
+      "paths": [
+        "AGENTS.md",
+        "docs/**",
+        "tools/docs/**",
+        "tools/release/**",
+        ".github/workflows/**",
+        "Makefile"
+      ],
+      "keywords": [
+        "docs",
+        "validator",
+        "release gate",
+        "path filter",
+        "installation"
+      ],
+      "verification_families": [
+        "harness-sync",
+        "docs-tooling",
+        "release-quality"
+      ]
+    }
+  ],
+  "task_entrypoints": [
+    {
+      "id": "implement-spec",
+      "default_route": "manifest-driven"
+    },
+    {
+      "id": "fix-regression",
+      "default_route": "historical-traps-first"
+    },
+    {
+      "id": "fix-static-quality",
+      "default_route": "correctness-over-green"
+    },
+    {
+      "id": "sync-docs-or-contract",
+      "default_route": "cheap-blockers-first"
+    }
+  ]
+}

--- a/docs/harness/routing-manifest.md
+++ b/docs/harness/routing-manifest.md
@@ -1,0 +1,44 @@
+# Routing Manifest Summary
+
+The canonical routing source is [routing-manifest.json](routing-manifest.json).
+This page is the readable overlay, not the machine-owned truth.
+
+## Verification Families
+
+| Family | Phase | Main commands |
+|--------|-------|---------------|
+| `harness-sync` | cheap blocker | `make harness-check` |
+| `docs-tooling` | cheap blocker | `make docs-check` |
+| `rust-streaming` | focused semantic | `make test-rust-streaming` |
+| `nginx-streaming` | focused semantic | `make test-nginx-unit-streaming` |
+| `ffi-boundary` | focused semantic | `make build`, `make test-rust` |
+| `observability-metrics` | focused semantic | `make docs-check`, `make release-gates-check` |
+| `runtime-e2e` | umbrella | `make verify-chunked-native-e2e-smoke`, `make verify-streaming-failure-cache-e2e-plan` |
+| `release-quality` | umbrella | `make harness-check-full` |
+
+## Risk Packs
+
+| Pack | Primary surfaces | Supporting surfaces | Doc |
+|------|------------------|---------------------|-----|
+| `runtime-streaming` | request/response streaming, pending chains, fail-open behavior | observability | [risk-packs/runtime-streaming.md](risk-packs/runtime-streaming.md) |
+| `ffi-boundary` | Rust/C ABI, header sync, option and error-code drift | observability | [risk-packs/ffi-boundary.md](risk-packs/ffi-boundary.md) |
+| `observability-metrics` | metrics schema, output semantics, release visibility | docs-tooling | [risk-packs/observability-metrics.md](risk-packs/observability-metrics.md) |
+| `docs-tooling-drift` | docs, validators, CI path filters, operator commands | observability | [risk-packs/docs-tooling-drift.md](risk-packs/docs-tooling-drift.md) |
+
+## Task Entry Points
+
+| Entry point | Default behavior |
+|-------------|------------------|
+| `implement-spec` | bind spec, emit short card, route by touched area |
+| `fix-regression` | bias toward historical traps and targeted regression tests |
+| `fix-static-quality` | keep correctness/safety bar above green checks |
+| `sync-docs-or-contract` | run cheap blockers first, then release-quality if risk rises |
+
+## Adaptive Checks
+
+- Public truth surfaces always check.
+- Optional local `.kiro/` adapters check only when present.
+- Missing `.kiro/` should produce `SKIP_NOT_PRESENT`, not failure.
+- Optional local active-spec pointers may refine spec resolution:
+  - `.kiro/active-spec.json`
+  - `.kiro/active-spec.txt`

--- a/docs/harness/routing-manifest.md
+++ b/docs/harness/routing-manifest.md
@@ -13,8 +13,11 @@ This page is the readable overlay, not the machine-owned truth.
 | `nginx-streaming` | focused semantic | `make test-nginx-unit-streaming` |
 | `ffi-boundary` | focused semantic | `make build`, `make test-rust` |
 | `observability-metrics` | focused semantic | `make docs-check`, `make release-gates-check` |
-| `runtime-e2e` | umbrella | `make verify-chunked-native-e2e-smoke`, `make verify-streaming-failure-cache-e2e-plan` |
+| `runtime-e2e` | umbrella | `make verify-chunked-native-e2e-smoke`, `make verify-streaming-failure-cache-e2e` |
 | `release-quality` | umbrella | `make harness-check-full` |
+
+`runtime-e2e` requires at least one executing runtime target each session.
+Plan-only targets (for example `*-plan`) are documentation aids, not evidence.
 
 ## Risk Packs
 

--- a/docs/project/HARNESS_HISTORY.md
+++ b/docs/project/HARNESS_HISTORY.md
@@ -65,14 +65,15 @@ discipline instead of forcing contributors to rediscover them manually.
 
 The harness is deliberately scoped.
 
-- It does not replace runtime architecture docs.
-- It does not store private spec content in tracked repository files.
-- It does not turn the repository into a full agent platform or orchestration
-  service.
-- It does not allow local adapters or outside voice tools to overrule the
-  repository contract.
-- It does not treat warnings as cosmetic cleanup work; warnings still require
-  real triage and, when necessary, real fixes.
+- Runtime architecture docs remain separate; the harness complements them
+  rather than replacing them.
+- Private spec content stays out of tracked repository files.
+- The repository is not an agent platform or orchestration service — the
+  harness governs workflow, not infrastructure.
+- Local adapters and outside voice tools cannot overrule the repository
+  contract.
+- Warnings require real triage and, when necessary, real fixes — they are
+  never treated as cosmetic cleanup.
 
 ## Durable Design Outcomes
 

--- a/docs/project/HARNESS_HISTORY.md
+++ b/docs/project/HARNESS_HISTORY.md
@@ -1,0 +1,100 @@
+# Harness History and Scope
+
+This note records why the repo-owned harness exists, which mistakes it was
+created to prevent, and what it intentionally does not try to become.
+
+Use it when you want the project-level rationale behind the harness, not the
+day-to-day execution contract. For execution rules, see
+[../harness/core.md](../harness/core.md). For the architectural model, see
+[../architecture/HARNESS_ARCHITECTURE.md](../architecture/HARNESS_ARCHITECTURE.md).
+
+## Why the Harness Exists
+
+The repository already had strong runtime documentation and a large set of
+historical engineering rules in `AGENTS.md`, but the practical workflow for AI
+assistance was still fragmented across:
+
+- public tracked docs
+- local `.kiro/steering/` files
+- local `.kiro/specs/`
+- review habits
+- ad hoc execution memory inside individual sessions
+
+That setup worked for one local environment, but it was not a stable open-source
+contract. The harness was introduced to turn those scattered habits into a
+tracked, reviewable, and executable repository asset.
+
+## Problems It Was Created to Prevent
+
+The harness exists to reduce a specific class of repeated engineering failures.
+
+### 1. Hidden or drifting workflow rules
+
+Important task-routing and validation behavior should not live only in private
+steering files or in the memory of whichever agent or reviewer happens to be
+running the task.
+
+### 2. Silent misrouting on spec-driven work
+
+Tasks that touch multiple high-risk surfaces can look similar while requiring
+different validation depth. The harness introduces explicit spec resolution,
+risk routing, and verification families so the repository does not rely on
+guesswork.
+
+### 3. Green checks without correctness or safety
+
+The project had already learned the hard way that passing checks is not the same
+as being correct or safe. The harness makes correctness and safety the
+completion bar, with static checks treated as supporting evidence rather than
+the final definition of success.
+
+### 4. Local-only tooling becoming the real contract
+
+The project still supports richer local workflows, especially through optional
+`.kiro/` inputs, but those local files must remain adapters. Public repository
+truth lives in tracked docs, checkers, and Make/CI entrypoints.
+
+### 5. Repeating the same classes of fixes
+
+This repository has accumulated many historical fixes in streaming, FFI,
+observability, docs drift, and related operational surfaces. The harness turns
+those recurring lessons into reusable routing, risk-pack, and maintenance
+discipline instead of forcing contributors to rediscover them manually.
+
+## What the Harness Intentionally Does Not Do
+
+The harness is deliberately scoped.
+
+- It does not replace runtime architecture docs.
+- It does not store private spec content in tracked repository files.
+- It does not turn the repository into a full agent platform or orchestration
+  service.
+- It does not allow local adapters or outside voice tools to overrule the
+  repository contract.
+- It does not treat warnings as cosmetic cleanup work; warnings still require
+  real triage and, when necessary, real fixes.
+
+## Durable Design Outcomes
+
+The design and review process for the harness produced a few durable rules that
+are worth preserving at the project level:
+
+- repo-owned truth must stay in tracked files
+- optional local inputs must degrade explicitly rather than crash or silently
+  override tracked behavior
+- cheap validation should be the default path, with broader scans used as
+  escalation tools
+- sync checks must be executable, not only documented
+- repeated fixes and repeated mistakes should feed back into rule evolution
+
+Those outcomes now live in the harness docs and tooling, but this page explains
+why they exist in the first place.
+
+## What Stays Outside Public Docs
+
+The repository keeps the durable outcomes, not every intermediate conversation.
+
+Interactive review logs, branching A/B/C plan alternatives, raw review JSONL,
+and timeline telemetry remain planning history rather than public contract.
+They are useful during design and maintenance, but they would add noise and
+duplicate transient reasoning if copied into the tracked docs.

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -11,7 +11,7 @@ steering files.
 
 ## Current Assessment
 
-As of **version 0.4.1**, the project includes Prometheus-compatible metrics, unified decision reason codes, rollout and rollback operational guides, a benchmark corpus with evidence-based regression detection, restructured installation and first-run documentation, parser path optimizations, and a repo-owned harness for agent workflow governance. Core features are implemented and tested. The codebase includes unit, integration, E2E, fuzz-oriented validation entrypoints, and harness-specific validation entrypoints, along with documentation covering installation, configuration, operations, architecture, and contributor-facing harness maintenance.
+As of the **current development line (Unreleased / upcoming 0.5.0)**, the project includes Prometheus-compatible metrics, unified decision reason codes, rollout and rollback operational guides, a benchmark corpus with evidence-based regression detection, restructured installation and first-run documentation, parser path optimizations, and a repo-owned harness for agent workflow governance. Core features are implemented and tested. The codebase includes unit, integration, E2E, fuzz-oriented validation entrypoints, and harness-specific validation entrypoints, along with documentation covering installation, configuration, operations, architecture, and contributor-facing harness maintenance.
 
 ### Repository Harness Updates
 

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -4,9 +4,26 @@
 
 This project is a production-oriented NGINX filter module backed by a Rust HTML-to-Markdown converter (via FFI). It performs HTTP content negotiation and returns Markdown when clients request `Accept: text/markdown`.
 
+The repository also includes a repo-owned harness for spec resolution, agent
+routing, risk overlays, and harness-specific validation. That harness is
+tracked in public docs and tools rather than living only in private local
+steering files.
+
 ## Current Assessment
 
-As of **version 0.4.1**, the project includes Prometheus-compatible metrics, unified decision reason codes, rollout and rollback operational guides, a benchmark corpus with evidence-based regression detection, restructured installation and first-run documentation, and parser path optimizations. Core features are implemented and tested. The codebase includes unit, integration, E2E, and fuzz-oriented validation entrypoints, along with documentation covering installation, configuration, operations, and architecture.
+As of **version 0.4.1**, the project includes Prometheus-compatible metrics, unified decision reason codes, rollout and rollback operational guides, a benchmark corpus with evidence-based regression detection, restructured installation and first-run documentation, parser path optimizations, and a repo-owned harness for agent workflow governance. Core features are implemented and tested. The codebase includes unit, integration, E2E, fuzz-oriented validation entrypoints, and harness-specific validation entrypoints, along with documentation covering installation, configuration, operations, architecture, and contributor-facing harness maintenance.
+
+### Repository Harness Updates
+
+- `docs/harness/` is the public entrypoint for spec routing, risk packs, and
+  harness checks.
+- `tools/harness/check_harness_sync.py` and Make targets
+  `make harness-check` / `make harness-check-full` provide executable
+  validation instead of prose-only workflow rules.
+- Optional local `.kiro/` adapters remain supported, but public repository
+  validation no longer depends on private spec assets being present.
+- The harness now records short-lived execution memory in a user-local state
+  carrier instead of tracked repository docs.
 
 ### Release 0.4.1 Patch Updates
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -5,10 +5,12 @@ This directory contains project-level status and maintenance-oriented documentat
 ## Contents
 
 - [PROJECT_STATUS.md](PROJECT_STATUS.md) - current implementation and validation status (aligned to code and recent verification)
+- [HARNESS_HISTORY.md](HARNESS_HISTORY.md) - why the repo-owned harness exists, which failures it is meant to prevent, and what remains intentionally out of scope
 - [VERSION_PLANNING.md](VERSION_PLANNING.md) - recommended release framing and version cut lines for `0.4.0` through `0.6.x+`
 
 Harness-related repository posture is summarized in `PROJECT_STATUS.md` and
-detailed in `docs/harness/`, `docs/architecture/HARNESS_ARCHITECTURE.md`, and
+detailed in `HARNESS_HISTORY.md`, `docs/harness/`,
+`docs/architecture/HARNESS_ARCHITECTURE.md`, and
 `docs/guides/HARNESS_MAINTENANCE.md`.
 
 Use this section for repository-wide status, maintenance posture, and other project-level notes that should stay aligned with the current tracked codebase.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -7,4 +7,8 @@ This directory contains project-level status and maintenance-oriented documentat
 - [PROJECT_STATUS.md](PROJECT_STATUS.md) - current implementation and validation status (aligned to code and recent verification)
 - [VERSION_PLANNING.md](VERSION_PLANNING.md) - recommended release framing and version cut lines for `0.4.0` through `0.6.x+`
 
+Harness-related repository posture is summarized in `PROJECT_STATUS.md` and
+detailed in `docs/harness/`, `docs/architecture/HARNESS_ARCHITECTURE.md`, and
+`docs/guides/HARNESS_MAINTENANCE.md`.
+
 Use this section for repository-wide status, maintenance posture, and other project-level notes that should stay aligned with the current tracked codebase.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -13,6 +13,7 @@ make test
 make test-rust
 make test-nginx-unit
 make test-nginx-integration
+make harness-check
 ```
 
 Use the documents in this directory when you need to understand what is covered, what requires a real `nginx` runtime, and where performance expectations are documented.
@@ -26,6 +27,9 @@ Use the documents in this directory when you need to understand what is covered,
 | [INTEGRATION_TESTS.md](INTEGRATION_TESTS.md) | Integration scenarios and expected behavior |
 | [E2E_TESTS.md](E2E_TESTS.md) | End-to-end workflows with real NGINX and backend services |
 | [PERFORMANCE_BASELINES.md](PERFORMANCE_BASELINES.md) | Performance expectations and comparison guidance |
+
+For repo-owned harness validation and adaptive local `.kiro` checks, use
+[../harness/README.md](../harness/README.md) plus `make harness-check`.
 
 ## Common Commands
 

--- a/tools/docs/check_docs.py
+++ b/tools/docs/check_docs.py
@@ -21,8 +21,16 @@ from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parents[2]
 ARCHIVE_SEGMENT = "docs/archive/"
+MAINTAINED_ROOT_DOCS = {"AGENTS.md", "README.md", "README_zh-CN.md"}
 LINK_RE = re.compile(r"(!?\[[^\]]+\]\(([^)]+)\))")
 HAN_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
+
+
+def is_maintained_markdown(rel_path: str) -> bool:
+    """Return whether a markdown path belongs to maintained repo truth surfaces."""
+    if rel_path in MAINTAINED_ROOT_DOCS:
+        return True
+    return rel_path.startswith("docs/") and not rel_path.startswith(ARCHIVE_SEGMENT)
 
 
 def iter_markdown_files() -> list[Path]:
@@ -45,7 +53,9 @@ def iter_markdown_files() -> list[Path]:
         candidates = set(ROOT.rglob("*.md"))
 
     return sorted(
-        p for p in candidates if ARCHIVE_SEGMENT not in p.relative_to(ROOT).as_posix()
+        p
+        for p in candidates
+        if is_maintained_markdown(p.relative_to(ROOT).as_posix())
     )
 
 

--- a/tools/docs/tests/test_check_docs.py
+++ b/tools/docs/tests/test_check_docs.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow imports from tools/docs/
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from check_docs import is_maintained_markdown
+
+
+def test_root_truth_surfaces_are_included():
+    assert is_maintained_markdown("AGENTS.md") is True
+    assert is_maintained_markdown("README.md") is True
+    assert is_maintained_markdown("README_zh-CN.md") is True
+
+
+def test_docs_tree_is_included_but_archive_is_not():
+    assert is_maintained_markdown("docs/harness/README.md") is True
+    assert is_maintained_markdown("docs/archive/old-note.md") is False
+
+
+def test_local_scratch_markdown_is_excluded():
+    assert is_maintained_markdown("review-findings.md") is False

--- a/tools/harness/__init__.py
+++ b/tools/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Harness tooling package."""

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -33,6 +33,13 @@ class CheckResult:
     detail: str
 
 
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def _load_manifest(path: Path | None = None) -> dict:
     path = path or MANIFEST_PATH
     try:
@@ -42,12 +49,18 @@ def _load_manifest(path: Path | None = None) -> dict:
 
 
 def _required_text(path: Path, needles: list[str]) -> list[str]:
-    text = path.read_text(encoding="utf-8")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [f"{_display_path(path)} unreadable"]
     return [needle for needle in needles if needle not in text]
 
 
 def _required_patterns(path: Path, patterns: dict[str, str]) -> list[str]:
-    text = path.read_text(encoding="utf-8")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [f"{_display_path(path)} unreadable"]
     missing: list[str] = []
     for label, pattern in patterns.items():
         if not re.search(pattern, text, flags=re.MULTILINE):

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Validate repo-owned harness truth surfaces and optional local adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PASS = "PASS"
+FAIL = "FAIL"
+SKIP_NOT_PRESENT = "SKIP_NOT_PRESENT"
+WARN_NEEDS_AUTHOR_REVIEW = "WARN_NEEDS_AUTHOR_REVIEW"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "docs" / "harness" / "routing-manifest.json"
+README_PATH = REPO_ROOT / "docs" / "harness" / "README.md"
+CORE_PATH = REPO_ROOT / "docs" / "harness" / "core.md"
+SUMMARY_PATH = REPO_ROOT / "docs" / "harness" / "routing-manifest.md"
+PACK_INDEX_PATH = REPO_ROOT / "docs" / "harness" / "risk-packs" / "README.md"
+AGENTS_PATH = REPO_ROOT / "AGENTS.md"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+
+
+def _load_manifest(path: Path = MANIFEST_PATH) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _required_text(path: Path, needles: list[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    return [needle for needle in needles if needle not in text]
+
+
+def _result(name: str, status: str, detail: str) -> CheckResult:
+    return CheckResult(name=name, status=status, detail=detail)
+
+
+def _check_manifest_structure(manifest: dict) -> CheckResult:
+    required_keys = {
+        "version",
+        "truth_surfaces",
+        "status_semantics",
+        "spec_resolver",
+        "verification_families",
+        "risk_packs",
+        "task_entrypoints",
+    }
+    missing = sorted(required_keys - set(manifest))
+    if missing:
+        return _result(
+            "manifest-structure",
+            FAIL,
+            f"missing top-level keys: {', '.join(missing)}",
+        )
+
+    if manifest["status_semantics"] != [
+        PASS,
+        FAIL,
+        SKIP_NOT_PRESENT,
+        WARN_NEEDS_AUTHOR_REVIEW,
+    ]:
+        return _result(
+            "manifest-status-semantics",
+            FAIL,
+            "status semantics do not match the canonical four-state contract",
+        )
+
+    spec_resolver = manifest["spec_resolver"]
+    required_resolver_keys = {
+        "priority",
+        "pointer_candidates",
+        "multiple_spec_policy",
+        "conflict_policy",
+    }
+    missing_resolver = sorted(required_resolver_keys - set(spec_resolver))
+    if missing_resolver:
+        return _result(
+            "manifest-spec-resolver",
+            FAIL,
+            f"missing spec resolver keys: {', '.join(missing_resolver)}",
+        )
+
+    return _result("manifest-structure", PASS, "manifest schema looks complete")
+
+
+def _check_truth_surfaces(manifest: dict) -> CheckResult:
+    missing: list[str] = []
+    for category in ("contract", "harness", "canonical_docs"):
+        for rel in manifest["truth_surfaces"][category]:
+            if not (REPO_ROOT / rel).exists():
+                missing.append(rel)
+    if missing:
+        return _result(
+            "truth-surfaces",
+            FAIL,
+            f"missing truth surface files: {', '.join(missing)}",
+        )
+    return _result("truth-surfaces", PASS, "repo-owned truth surfaces exist")
+
+
+def _check_risk_pack_docs(manifest: dict) -> CheckResult:
+    missing_docs: list[str] = []
+    missing_families: list[str] = []
+    families = set(manifest["verification_families"])
+    for pack in manifest["risk_packs"]:
+        doc_path = REPO_ROOT / pack["doc"]
+        if not doc_path.exists():
+            missing_docs.append(pack["doc"])
+        for family in pack["verification_families"]:
+            if family not in families:
+                missing_families.append(f"{pack['id']}->{family}")
+    if missing_docs or missing_families:
+        parts = []
+        if missing_docs:
+            parts.append(f"missing docs: {', '.join(missing_docs)}")
+        if missing_families:
+            parts.append(f"unknown verification families: {', '.join(missing_families)}")
+        return _result("risk-pack-contract", FAIL, "; ".join(parts))
+    return _result("risk-pack-contract", PASS, "risk packs and verification families line up")
+
+
+def _check_harness_docs(manifest: dict) -> CheckResult:
+    missing: list[str] = []
+    missing.extend(
+        _required_text(
+            README_PATH,
+            [
+                "core.md",
+                "routing-manifest.json",
+                "routing-manifest.md",
+                "risk-packs/README.md",
+            ],
+        )
+    )
+    pack_ids = [pack["id"] for pack in manifest["risk_packs"]]
+    missing.extend(_required_text(SUMMARY_PATH, pack_ids))
+    missing.extend(
+        _required_text(
+            CORE_PATH,
+            [
+                PASS,
+                FAIL,
+                SKIP_NOT_PRESENT,
+                WARN_NEEDS_AUTHOR_REVIEW,
+                "outside voice",
+                "state carrier",
+                "stop and explain the mismatch",
+                "tools/harness/resolve_spec.py",
+            ],
+        )
+    )
+    if missing:
+        unique_missing = ", ".join(sorted(set(missing)))
+        return _result(
+            "harness-docs",
+            FAIL,
+            f"harness docs are missing required references or phrases: {unique_missing}",
+        )
+    return _result("harness-docs", PASS, "README, core, and summary expose the manifest contract")
+
+
+def _check_agents_map() -> CheckResult:
+    missing = _required_text(
+        AGENTS_PATH,
+        [
+            "docs/harness/README.md",
+            "docs/harness/core.md",
+            "docs/harness/routing-manifest.json",
+            "Codex-first",
+        ],
+    )
+    if missing:
+        return _result(
+            "agents-map",
+            FAIL,
+            f"AGENTS.md is missing harness map references: {', '.join(missing)}",
+        )
+    return _result("agents-map", PASS, "AGENTS.md points at the harness entrypoints")
+
+
+def _check_optional_kiro(manifest: dict, full: bool) -> CheckResult:
+    adapters = manifest["truth_surfaces"]["optional_adapters"]
+    present = [REPO_ROOT / rel for rel in adapters if (REPO_ROOT / rel).exists()]
+    if not present:
+        return _result(
+            "kiro-adapters",
+            SKIP_NOT_PRESENT,
+            ".kiro/steering is absent, skipping optional adapter checks",
+        )
+
+    missing_links: list[str] = []
+    for path in present:
+        missing_links.extend(
+            f"{path.relative_to(REPO_ROOT)}::{needle}"
+            for needle in _required_text(
+                path,
+                [
+                    "docs/harness/README.md",
+                    "docs/harness/core.md",
+                ],
+            )
+        )
+    if missing_links:
+        status = FAIL if full else WARN_NEEDS_AUTHOR_REVIEW
+        return _result(
+            "kiro-adapters",
+            status,
+            f"local adapter docs need refresh: {', '.join(missing_links)}",
+        )
+    return _result("kiro-adapters", PASS, "optional local Kiro adapters point at harness truth")
+
+
+def collect_results(full: bool = False) -> list[CheckResult]:
+    manifest = _load_manifest()
+    return [
+        _check_manifest_structure(manifest),
+        _check_truth_surfaces(manifest),
+        _check_risk_pack_docs(manifest),
+        _check_harness_docs(manifest),
+        _check_agents_map(),
+        _check_optional_kiro(manifest, full=full),
+    ]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="treat optional local adapter drift as blocking",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    results = collect_results(full=args.full)
+    failing_statuses = {FAIL}
+    if args.full:
+        failing_statuses.add(WARN_NEEDS_AUTHOR_REVIEW)
+
+    for result in results:
+        print(f"{result.status:<24} {result.name:<20} {result.detail}")
+
+    return 1 if any(result.status in failing_statuses for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -11,18 +11,27 @@ from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    from tools.harness.constants import (
+        FAIL,
+        PASS,
+        SKIP_NOT_PRESENT,
+        WARN_NEEDS_AUTHOR_REVIEW,
+    )
+except ModuleNotFoundError:
+    from constants import (  # type: ignore[no-redef]
+        FAIL,
+        PASS,
+        SKIP_NOT_PRESENT,
+        WARN_NEEDS_AUTHOR_REVIEW,
+    )
 
-PASS = "PASS"
-FAIL = "FAIL"
-SKIP_NOT_PRESENT = "SKIP_NOT_PRESENT"
-WARN_NEEDS_AUTHOR_REVIEW = "WARN_NEEDS_AUTHOR_REVIEW"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = REPO_ROOT / "docs" / "harness" / "routing-manifest.json"
 README_PATH = REPO_ROOT / "docs" / "harness" / "README.md"
 CORE_PATH = REPO_ROOT / "docs" / "harness" / "core.md"
 SUMMARY_PATH = REPO_ROOT / "docs" / "harness" / "routing-manifest.md"
-PACK_INDEX_PATH = REPO_ROOT / "docs" / "harness" / "risk-packs" / "README.md"
 AGENTS_PATH = REPO_ROOT / "AGENTS.md"
 
 
@@ -62,9 +71,11 @@ def _required_patterns(path: Path, patterns: dict[str, str]) -> list[str]:
     except (OSError, UnicodeDecodeError):
         return [f"{_display_path(path)} unreadable"]
     missing: list[str] = []
-    for label, pattern in patterns.items():
-        if not re.search(pattern, text, flags=re.MULTILINE):
-            missing.append(label)
+    missing.extend(
+        label
+        for label, pattern in patterns.items()
+        if not re.search(pattern, text, flags=re.MULTILINE)
+    )
     return missing
 
 
@@ -82,8 +93,7 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
         "risk_packs",
         "task_entrypoints",
     }
-    missing = sorted(required_keys - set(manifest))
-    if missing:
+    if missing := sorted(required_keys - set(manifest)):
         return _result(
             "manifest-structure",
             FAIL,
@@ -97,10 +107,9 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
         "canonical_docs",
         "optional_adapters",
     }
-    missing_truth_surface_keys = sorted(
+    if missing_truth_surface_keys := sorted(
         required_truth_surface_keys - set(truth_surfaces)
-    )
-    if missing_truth_surface_keys:
+    ):
         return _result(
             "manifest-structure",
             FAIL,
@@ -142,9 +151,11 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
 def _check_truth_surfaces(manifest: dict) -> CheckResult:
     missing: list[str] = []
     for category in ("contract", "harness", "canonical_docs"):
-        for rel in manifest["truth_surfaces"][category]:
-            if not (REPO_ROOT / rel).exists():
-                missing.append(rel)
+        missing.extend(
+            rel
+            for rel in manifest["truth_surfaces"][category]
+            if not (REPO_ROOT / rel).exists()
+        )
     if missing:
         return _result(
             "truth-surfaces",
@@ -162,9 +173,11 @@ def _check_risk_pack_docs(manifest: dict) -> CheckResult:
         doc_path = REPO_ROOT / pack["doc"]
         if not doc_path.exists():
             missing_docs.append(pack["doc"])
-        for family in pack["verification_families"]:
-            if family not in families:
-                missing_families.append(f"{pack['id']}->{family}")
+        missing_families.extend(
+            f"{pack['id']}->{family}"
+            for family in pack["verification_families"]
+            if family not in families
+        )
     if missing_docs or missing_families:
         parts = []
         if missing_docs:

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,6 +44,15 @@ def _load_manifest(path: Path | None = None) -> dict:
 def _required_text(path: Path, needles: list[str]) -> list[str]:
     text = path.read_text(encoding="utf-8")
     return [needle for needle in needles if needle not in text]
+
+
+def _required_patterns(path: Path, patterns: dict[str, str]) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    missing: list[str] = []
+    for label, pattern in patterns.items():
+        if not re.search(pattern, text, flags=re.MULTILINE):
+            missing.append(label)
+    return missing
 
 
 def _result(name: str, status: str, detail: str) -> CheckResult:
@@ -84,12 +95,13 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
             + ", ".join(missing_truth_surface_keys),
         )
 
-    if manifest["status_semantics"] != [
+    expected_statuses = [
         PASS,
         FAIL,
         SKIP_NOT_PRESENT,
         WARN_NEEDS_AUTHOR_REVIEW,
-    ]:
+    ]
+    if Counter(manifest["status_semantics"]) != Counter(expected_statuses):
         return _result(
             "manifest-status-semantics",
             FAIL,
@@ -152,32 +164,47 @@ def _check_risk_pack_docs(manifest: dict) -> CheckResult:
 
 def _check_harness_docs(manifest: dict) -> CheckResult:
     missing: list[str] = []
+    missing.extend(_required_patterns(
+        README_PATH,
+        {
+            "core.md link": r"\[[^\]]+\]\(core\.md\)",
+            "routing-manifest.json link": (
+                r"\[[^\]]+\]\(routing-manifest\.json\)"
+            ),
+            "routing-manifest.md link": r"\[[^\]]+\]\(routing-manifest\.md\)",
+            "risk-packs/README.md link": (
+                r"\[[^\]]+\]\(risk-packs/README\.md\)"
+            ),
+        },
+    ))
     missing.extend(
-        _required_text(
-            README_PATH,
-            [
-                "core.md",
-                "routing-manifest.json",
-                "routing-manifest.md",
-                "risk-packs/README.md",
-            ],
+        _required_patterns(
+            SUMMARY_PATH,
+            {
+                pack_id: rf"\b{re.escape(pack_id)}\b"
+                for pack_id in [pack["id"] for pack in manifest["risk_packs"]]
+            },
         )
     )
-    pack_ids = [pack["id"] for pack in manifest["risk_packs"]]
-    missing.extend(_required_text(SUMMARY_PATH, pack_ids))
     missing.extend(
-        _required_text(
+        _required_patterns(
             CORE_PATH,
-            [
-                PASS,
-                FAIL,
-                SKIP_NOT_PRESENT,
-                WARN_NEEDS_AUTHOR_REVIEW,
-                "outside voice",
-                "state carrier",
-                "stop and explain the mismatch",
-                "tools/harness/resolve_spec.py",
-            ],
+            {
+                PASS: rf"`{re.escape(PASS)}`",
+                FAIL: rf"`{re.escape(FAIL)}`",
+                SKIP_NOT_PRESENT: rf"`{re.escape(SKIP_NOT_PRESENT)}`",
+                WARN_NEEDS_AUTHOR_REVIEW: (
+                    rf"`{re.escape(WARN_NEEDS_AUTHOR_REVIEW)}`"
+                ),
+                "outside voice": r"\boutside voice\b",
+                "state carrier": r"\bstate carrier\b",
+                "stop and explain the mismatch": (
+                    r"\bstop and explain the mismatch\b"
+                ),
+                "tools/harness/resolve_spec.py": (
+                    r"python3\s+tools/harness/resolve_spec\.py"
+                ),
+            },
         )
     )
     if missing:
@@ -191,14 +218,16 @@ def _check_harness_docs(manifest: dict) -> CheckResult:
 
 
 def _check_agents_map() -> CheckResult:
-    missing = _required_text(
+    missing = _required_patterns(
         AGENTS_PATH,
-        [
-            "docs/harness/README.md",
-            "docs/harness/core.md",
-            "docs/harness/routing-manifest.json",
-            "Codex-first",
-        ],
+        {
+            "docs/harness/README.md": r"`docs/harness/README\.md`",
+            "docs/harness/core.md": r"`docs/harness/core\.md`",
+            "docs/harness/routing-manifest.json": (
+                r"`docs/harness/routing-manifest\.json`"
+            ),
+            "Codex-first": r"\bCodex-first\b",
+        },
     )
     if missing:
         return _result(

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import re
 import sys
-from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,7 +18,7 @@ try:
         WARN_NEEDS_AUTHOR_REVIEW,
     )
 except ModuleNotFoundError:
-    from constants import (  # type: ignore[no-redef]
+    from constants import (  # type: ignore[no-redef]  # noqa: F401
         FAIL,
         PASS,
         SKIP_NOT_PRESENT,
@@ -117,13 +116,14 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
             + ", ".join(missing_truth_surface_keys),
         )
 
-    expected_statuses = [
+    expected_statuses = {
         PASS,
         FAIL,
         SKIP_NOT_PRESENT,
         WARN_NEEDS_AUTHOR_REVIEW,
-    ]
-    if Counter(manifest["status_semantics"]) != Counter(expected_statuses):
+    }
+    actual_statuses = manifest["status_semantics"]
+    if not isinstance(actual_statuses, list) or set(actual_statuses) != expected_statuses:
         return _result(
             "manifest-status-semantics",
             FAIL,

--- a/tools/harness/check_harness_sync.py
+++ b/tools/harness/check_harness_sync.py
@@ -31,8 +31,12 @@ class CheckResult:
     detail: str
 
 
-def _load_manifest(path: Path = MANIFEST_PATH) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+def _load_manifest(path: Path | None = None) -> dict:
+    path = path or MANIFEST_PATH
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"failed to load harness manifest from {path}: {exc}") from exc
 
 
 def _required_text(path: Path, needles: list[str]) -> list[str]:
@@ -60,6 +64,24 @@ def _check_manifest_structure(manifest: dict) -> CheckResult:
             "manifest-structure",
             FAIL,
             f"missing top-level keys: {', '.join(missing)}",
+        )
+
+    truth_surfaces = manifest["truth_surfaces"]
+    required_truth_surface_keys = {
+        "contract",
+        "harness",
+        "canonical_docs",
+        "optional_adapters",
+    }
+    missing_truth_surface_keys = sorted(
+        required_truth_surface_keys - set(truth_surfaces)
+    )
+    if missing_truth_surface_keys:
+        return _result(
+            "manifest-structure",
+            FAIL,
+            "missing truth surface keys: "
+            + ", ".join(missing_truth_surface_keys),
         )
 
     if manifest["status_semantics"] != [
@@ -188,7 +210,7 @@ def _check_agents_map() -> CheckResult:
 
 
 def _check_optional_kiro(manifest: dict, full: bool) -> CheckResult:
-    adapters = manifest["truth_surfaces"]["optional_adapters"]
+    adapters = manifest.get("truth_surfaces", {}).get("optional_adapters", [])
     present = [REPO_ROOT / rel for rel in adapters if (REPO_ROOT / rel).exists()]
     if not present:
         return _result(
@@ -220,9 +242,17 @@ def _check_optional_kiro(manifest: dict, full: bool) -> CheckResult:
 
 
 def collect_results(full: bool = False) -> list[CheckResult]:
-    manifest = _load_manifest()
+    try:
+        manifest = _load_manifest()
+    except ValueError as exc:
+        return [_result("manifest-load", FAIL, str(exc))]
+
+    manifest_structure = _check_manifest_structure(manifest)
+    if manifest_structure.status == FAIL:
+        return [manifest_structure]
+
     return [
-        _check_manifest_structure(manifest),
+        manifest_structure,
         _check_truth_surfaces(manifest),
         _check_risk_pack_docs(manifest),
         _check_harness_docs(manifest),

--- a/tools/harness/constants.py
+++ b/tools/harness/constants.py
@@ -1,0 +1,6 @@
+"""Shared status constants for the harness four-state contract."""
+
+PASS = "PASS"
+FAIL = "FAIL"
+SKIP_NOT_PRESENT = "SKIP_NOT_PRESENT"
+WARN_NEEDS_AUTHOR_REVIEW = "WARN_NEEDS_AUTHOR_REVIEW"

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -177,6 +176,112 @@ def _candidate_dict(candidate: SpecCandidate, *, score: int | None = None) -> di
     return data
 
 
+def _resolve_explicit(
+    candidates: list[SpecCandidate],
+    explicit_specs: list[str],
+) -> Resolution | None:
+    """Try to resolve from explicit spec names. Return None to continue."""
+    unmatched: list[str] = []
+    for explicit in explicit_specs:
+        matches = _match_by_identity(candidates, explicit)
+        if len(matches) == 1:
+            return Resolution(
+                status=PASS,
+                reason=f"explicit spec match: {explicit}",
+                chosen=_candidate_dict(matches[0]),
+                candidates=[_candidate_dict(matches[0])],
+            )
+        if len(matches) > 1:
+            return Resolution(
+                status=WARN_NEEDS_AUTHOR_REVIEW,
+                reason=f"explicit spec is ambiguous: {explicit}",
+                chosen=None,
+                candidates=[_candidate_dict(c) for c in matches],
+            )
+        unmatched.append(explicit)
+
+    if unmatched:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason="explicit spec does not match any local spec: "
+            + ", ".join(unmatched),
+            chosen=None,
+            candidates=[_candidate_dict(c) for c in candidates],
+        )
+    return None
+
+
+def _resolve_pointer(
+    candidates: list[SpecCandidate],
+    pointer_candidates: list[Path] | None,
+) -> Resolution | None:
+    """Try to resolve from an active-spec pointer file. Return None to continue."""
+    pointer_value, pointer_path = _read_pointer(pointer_candidates)
+    if not pointer_value:
+        return None
+
+    matches = _match_by_identity(candidates, pointer_value)
+    if len(matches) == 1:
+        return Resolution(
+            status=PASS,
+            reason=f"active pointer match: {pointer_value}",
+            chosen=_candidate_dict(matches[0]),
+            candidates=[_candidate_dict(matches[0])],
+            pointer=pointer_path,
+        )
+    if len(matches) > 1:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason=f"active pointer is ambiguous: {pointer_value}",
+            chosen=None,
+            candidates=[_candidate_dict(c) for c in matches],
+            pointer=pointer_path,
+        )
+    return Resolution(
+        status=WARN_NEEDS_AUTHOR_REVIEW,
+        reason=f"active pointer does not match any local spec: {pointer_value}",
+        chosen=None,
+        candidates=[_candidate_dict(c) for c in candidates],
+        pointer=pointer_path,
+    )
+
+
+def _resolve_hints(
+    candidates: list[SpecCandidate],
+    hints: list[str],
+) -> Resolution:
+    """Resolve from hint-based token scoring (always returns a result)."""
+    scored = _score_candidates(candidates, hints)
+    if not scored:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason="no spec could be bound confidently from hints",
+            chosen=None,
+            candidates=[_candidate_dict(c) for c in candidates],
+        )
+
+    best_score, best_candidate = scored[0]
+    tied = [item for item in scored if item[0] == best_score]
+    if len(tied) > 1:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason="multiple specs match the current hints",
+            chosen=None,
+            candidates=[
+                _candidate_dict(c, score=s) for s, c in tied
+            ],
+        )
+
+    return Resolution(
+        status=PASS,
+        reason="best hint match",
+        chosen=_candidate_dict(best_candidate, score=best_score),
+        candidates=[
+            _candidate_dict(c, score=s) for s, c in scored
+        ],
+    )
+
+
 def resolve_spec(
     *,
     explicit_specs: list[str] | None = None,
@@ -195,88 +300,16 @@ def resolve_spec(
             candidates=[],
         )
 
-    unmatched_explicit: list[str] = []
-    for explicit in explicit_specs:
-        matches = _match_by_identity(candidates, explicit)
-        if len(matches) == 1:
-            return Resolution(
-                status=PASS,
-                reason=f"explicit spec match: {explicit}",
-                chosen=_candidate_dict(matches[0]),
-                candidates=[_candidate_dict(matches[0])],
-            )
-        if len(matches) > 1:
-            return Resolution(
-                status=WARN_NEEDS_AUTHOR_REVIEW,
-                reason=f"explicit spec is ambiguous: {explicit}",
-                chosen=None,
-                candidates=[_candidate_dict(candidate) for candidate in matches],
-            )
-        unmatched_explicit.append(explicit)
+    if explicit_specs:
+        result = _resolve_explicit(candidates, explicit_specs)
+        if result is not None:
+            return result
 
-    if explicit_specs and unmatched_explicit:
-        return Resolution(
-            status=WARN_NEEDS_AUTHOR_REVIEW,
-            reason=(
-                "explicit spec does not match any local spec: "
-                + ", ".join(unmatched_explicit)
-            ),
-            chosen=None,
-            candidates=[_candidate_dict(candidate) for candidate in candidates],
-        )
+    result = _resolve_pointer(candidates, pointer_candidates)
+    if result is not None:
+        return result
 
-    pointer_value, pointer_path = _read_pointer(pointer_candidates)
-    if pointer_value:
-        matches = _match_by_identity(candidates, pointer_value)
-        if len(matches) == 1:
-            return Resolution(
-                status=PASS,
-                reason=f"active pointer match: {pointer_value}",
-                chosen=_candidate_dict(matches[0]),
-                candidates=[_candidate_dict(matches[0])],
-                pointer=pointer_path,
-            )
-        if len(matches) > 1:
-            return Resolution(
-                status=WARN_NEEDS_AUTHOR_REVIEW,
-                reason=f"active pointer is ambiguous: {pointer_value}",
-                chosen=None,
-                candidates=[_candidate_dict(candidate) for candidate in matches],
-                pointer=pointer_path,
-            )
-        return Resolution(
-            status=WARN_NEEDS_AUTHOR_REVIEW,
-            reason=f"active pointer does not match any local spec: {pointer_value}",
-            chosen=None,
-            candidates=[_candidate_dict(candidate) for candidate in candidates],
-            pointer=pointer_path,
-        )
-
-    scored = _score_candidates(candidates, hints)
-    if not scored:
-        return Resolution(
-            status=WARN_NEEDS_AUTHOR_REVIEW,
-            reason="no spec could be bound confidently from hints",
-            chosen=None,
-            candidates=[_candidate_dict(candidate) for candidate in candidates],
-        )
-
-    best_score, best_candidate = scored[0]
-    tied = [item for item in scored if item[0] == best_score]
-    if len(tied) > 1:
-        return Resolution(
-            status=WARN_NEEDS_AUTHOR_REVIEW,
-            reason="multiple specs match the current hints",
-            chosen=None,
-            candidates=[_candidate_dict(candidate, score=score) for score, candidate in tied],
-        )
-
-    return Resolution(
-        status=PASS,
-        reason="best hint match",
-        chosen=_candidate_dict(best_candidate, score=best_score),
-        candidates=[_candidate_dict(candidate, score=score) for score, candidate in scored],
-    )
+    return _resolve_hints(candidates, hints)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -61,12 +61,16 @@ class Resolution:
     pointer: str | None = None
 
 
-def discover_specs(specs_root: Path = SPECS_ROOT) -> list[SpecCandidate]:
+def discover_specs(specs_root: Path | None = None) -> list[SpecCandidate]:
+    specs_root = specs_root or SPECS_ROOT
     if not specs_root.exists():
         return []
     specs: list[SpecCandidate] = []
     for config_path in sorted(specs_root.glob("*/.config.kiro")):
-        data = json.loads(config_path.read_text(encoding="utf-8"))
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
         specs.append(
             SpecCandidate(
                 dir_name=config_path.parent.name,
@@ -105,13 +109,17 @@ def _match_by_identity(candidates: list[SpecCandidate], value: str) -> list[Spec
 
 
 def _read_pointer(
-    pointer_candidates: list[Path] = POINTER_CANDIDATES,
+    pointer_candidates: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
+    pointer_candidates = pointer_candidates or POINTER_CANDIDATES
     for path in pointer_candidates:
         if not path.exists():
             continue
         if path.suffix == ".json":
-            data = json.loads(path.read_text(encoding="utf-8"))
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                continue
             try:
                 path_display = str(path.relative_to(REPO_ROOT))
             except ValueError:
@@ -120,7 +128,10 @@ def _read_pointer(
                 data.get("spec"),
                 path_display,
             )
-        value = path.read_text(encoding="utf-8").strip()
+        try:
+            value = path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            continue
         if value:
             try:
                 path_display = str(path.relative_to(REPO_ROOT))
@@ -155,8 +166,8 @@ def resolve_spec(
     *,
     explicit_specs: list[str] | None = None,
     hints: list[str] | None = None,
-    specs_root: Path = SPECS_ROOT,
-    pointer_candidates: list[Path] = POINTER_CANDIDATES,
+    specs_root: Path | None = None,
+    pointer_candidates: list[Path] | None = None,
 ) -> Resolution:
     explicit_specs = explicit_specs or []
     hints = hints or []

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -10,17 +10,28 @@ import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+try:
+    from tools.harness.constants import (
+        FAIL,
+        PASS,
+        SKIP_NOT_PRESENT,
+        WARN_NEEDS_AUTHOR_REVIEW,
+    )
+except ModuleNotFoundError:
+    from constants import (  # type: ignore[no-redef]
+        FAIL,
+        PASS,
+        SKIP_NOT_PRESENT,
+        WARN_NEEDS_AUTHOR_REVIEW,
+    )
 
-PASS = "PASS"
-FAIL = "FAIL"
-SKIP_NOT_PRESENT = "SKIP_NOT_PRESENT"
-WARN_NEEDS_AUTHOR_REVIEW = "WARN_NEEDS_AUTHOR_REVIEW"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SPECS_ROOT = REPO_ROOT / ".kiro" / "specs"
+_KIRO_DIR = ".kiro"
+SPECS_ROOT = REPO_ROOT / _KIRO_DIR / "specs"
 POINTER_CANDIDATES = [
-    REPO_ROOT / ".kiro" / "active-spec.json",
-    REPO_ROOT / ".kiro" / "active-spec.txt",
+    REPO_ROOT / _KIRO_DIR / "active-spec.json",
+    REPO_ROOT / _KIRO_DIR / "active-spec.txt",
 ]
 TOKEN_RE = re.compile(r"[a-z0-9]{3,}")
 STOP_WORDS = {
@@ -153,8 +164,7 @@ def _score_candidates(candidates: list[SpecCandidate], hints: list[str]) -> list
     scored: list[tuple[int, SpecCandidate]] = []
     for candidate in candidates:
         candidate_tokens = _tokenize(candidate.dir_name, candidate.spec_id, candidate.spec_type)
-        score = len(candidate_tokens & hint_tokens)
-        if score:
+        if score := len(candidate_tokens & hint_tokens):
             scored.append((score, candidate))
     scored.sort(key=lambda item: (-item[0], item[1].dir_name))
     return scored

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -17,7 +17,7 @@ try:
         WARN_NEEDS_AUTHOR_REVIEW,
     )
 except ModuleNotFoundError:
-    from constants import (  # type: ignore[no-redef]
+    from constants import (  # type: ignore[no-redef]  # noqa: F401
         FAIL,
         PASS,
         SKIP_NOT_PRESENT,
@@ -146,9 +146,7 @@ def _read_text_pointer(path: Path) -> tuple[str | None, str | None]:
         value = path.read_text(encoding="utf-8").strip()
     except (OSError, UnicodeDecodeError):
         return None, None
-    if not value:
-        return None, None
-    return value, _display_for(path)
+    return (value, _display_for(path)) if value else (None, None)
 
 
 def _read_pointer(

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -97,13 +97,18 @@ def _tokenize(*values: str) -> set[str]:
 
 def _match_by_identity(candidates: list[SpecCandidate], value: str) -> list[SpecCandidate]:
     needle = _normalize(value)
+    if not needle:
+        return []
     matches = []
     for candidate in candidates:
-        haystack = {
-            _normalize(candidate.dir_name),
-            _normalize(candidate.spec_id),
-        }
-        if needle in haystack or needle in _normalize(candidate.dir_name) or needle in _normalize(candidate.spec_id):
+        dir_name = _normalize(candidate.dir_name)
+        spec_id = _normalize(candidate.spec_id)
+        if (
+            needle == dir_name
+            or needle == spec_id
+            or needle in dir_name
+            or needle in spec_id
+        ):
             matches.append(candidate)
     return matches
 
@@ -180,6 +185,7 @@ def resolve_spec(
             candidates=[],
         )
 
+    unmatched_explicit: list[str] = []
     for explicit in explicit_specs:
         matches = _match_by_identity(candidates, explicit)
         if len(matches) == 1:
@@ -196,6 +202,18 @@ def resolve_spec(
                 chosen=None,
                 candidates=[_candidate_dict(candidate) for candidate in matches],
             )
+        unmatched_explicit.append(explicit)
+
+    if explicit_specs and unmatched_explicit:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason=(
+                "explicit spec does not match any local spec: "
+                + ", ".join(unmatched_explicit)
+            ),
+            chosen=None,
+            candidates=[_candidate_dict(candidate) for candidate in candidates],
+        )
 
     pointer_value, pointer_path = _read_pointer(pointer_candidates)
     if pointer_value:

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -123,6 +123,34 @@ def _match_by_identity(candidates: list[SpecCandidate], value: str) -> list[Spec
     return matches
 
 
+def _display_for(path: Path) -> str:
+    """Return a repo-relative display string for *path*, falling back to str."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _read_json_pointer(path: Path) -> tuple[str | None, str | None]:
+    """Try to read a JSON pointer file. Return (value, display) or (None, None)."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None, None
+    return data.get("spec"), _display_for(path)
+
+
+def _read_text_pointer(path: Path) -> tuple[str | None, str | None]:
+    """Try to read a plain-text pointer file. Return (value, display) or (None, None)."""
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None, None
+    if not value:
+        return None, None
+    return value, _display_for(path)
+
+
 def _read_pointer(
     pointer_candidates: list[Path] | None = None,
 ) -> tuple[str | None, str | None]:
@@ -130,29 +158,10 @@ def _read_pointer(
     for path in pointer_candidates:
         if not path.exists():
             continue
-        if path.suffix == ".json":
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-                continue
-            try:
-                path_display = str(path.relative_to(REPO_ROOT))
-            except ValueError:
-                path_display = str(path)
-            return (
-                data.get("spec"),
-                path_display,
-            )
-        try:
-            value = path.read_text(encoding="utf-8").strip()
-        except (OSError, UnicodeDecodeError):
-            continue
-        if value:
-            try:
-                path_display = str(path.relative_to(REPO_ROOT))
-            except ValueError:
-                path_display = str(path)
-            return value, path_display
+        reader = _read_json_pointer if path.suffix == ".json" else _read_text_pointer
+        value, display = reader(path)
+        if value is not None:
+            return value, display
     return None, None
 
 
@@ -289,7 +298,6 @@ def resolve_spec(
     specs_root: Path | None = None,
     pointer_candidates: list[Path] | None = None,
 ) -> Resolution:
-    explicit_specs = explicit_specs or []
     hints = hints or []
     candidates = discover_specs(specs_root)
     if not candidates:
@@ -300,16 +308,13 @@ def resolve_spec(
             candidates=[],
         )
 
-    if explicit_specs:
+    if explicit_specs := explicit_specs or []:
         result = _resolve_explicit(candidates, explicit_specs)
         if result is not None:
             return result
 
     result = _resolve_pointer(candidates, pointer_candidates)
-    if result is not None:
-        return result
-
-    return _resolve_hints(candidates, hints)
+    return result if result is not None else _resolve_hints(candidates, hints)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Resolve the current spec from explicit hints, local pointers, and task text."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+PASS = "PASS"
+FAIL = "FAIL"
+SKIP_NOT_PRESENT = "SKIP_NOT_PRESENT"
+WARN_NEEDS_AUTHOR_REVIEW = "WARN_NEEDS_AUTHOR_REVIEW"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPECS_ROOT = REPO_ROOT / ".kiro" / "specs"
+POINTER_CANDIDATES = [
+    REPO_ROOT / ".kiro" / "active-spec.json",
+    REPO_ROOT / ".kiro" / "active-spec.txt",
+]
+TOKEN_RE = re.compile(r"[a-z0-9]{3,}")
+STOP_WORDS = {
+    "spec",
+    "task",
+    "tasks",
+    "feature",
+    "features",
+    "bug",
+    "bugfix",
+    "fix",
+    "work",
+    "current",
+    "continue",
+    "next",
+    "with",
+    "from",
+    "that",
+    "this",
+    "then",
+}
+
+
+@dataclass(frozen=True)
+class SpecCandidate:
+    dir_name: str
+    spec_id: str
+    spec_type: str
+    workflow_type: str
+
+
+@dataclass(frozen=True)
+class Resolution:
+    status: str
+    reason: str
+    chosen: dict | None
+    candidates: list[dict]
+    pointer: str | None = None
+
+
+def discover_specs(specs_root: Path = SPECS_ROOT) -> list[SpecCandidate]:
+    if not specs_root.exists():
+        return []
+    specs: list[SpecCandidate] = []
+    for config_path in sorted(specs_root.glob("*/.config.kiro")):
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        specs.append(
+            SpecCandidate(
+                dir_name=config_path.parent.name,
+                spec_id=data.get("specId", ""),
+                spec_type=data.get("specType", ""),
+                workflow_type=data.get("workflowType", ""),
+            )
+        )
+    return specs
+
+
+def _normalize(text: str) -> str:
+    return text.strip().lower()
+
+
+def _tokenize(*values: str) -> set[str]:
+    tokens: set[str] = set()
+    for value in values:
+        for token in TOKEN_RE.findall(_normalize(value)):
+            if token not in STOP_WORDS and len(token) >= 3:
+                tokens.add(token)
+    return tokens
+
+
+def _match_by_identity(candidates: list[SpecCandidate], value: str) -> list[SpecCandidate]:
+    needle = _normalize(value)
+    matches = []
+    for candidate in candidates:
+        haystack = {
+            _normalize(candidate.dir_name),
+            _normalize(candidate.spec_id),
+        }
+        if needle in haystack or needle in _normalize(candidate.dir_name) or needle in _normalize(candidate.spec_id):
+            matches.append(candidate)
+    return matches
+
+
+def _read_pointer(
+    pointer_candidates: list[Path] = POINTER_CANDIDATES,
+) -> tuple[str | None, str | None]:
+    for path in pointer_candidates:
+        if not path.exists():
+            continue
+        if path.suffix == ".json":
+            data = json.loads(path.read_text(encoding="utf-8"))
+            try:
+                path_display = str(path.relative_to(REPO_ROOT))
+            except ValueError:
+                path_display = str(path)
+            return (
+                data.get("spec"),
+                path_display,
+            )
+        value = path.read_text(encoding="utf-8").strip()
+        if value:
+            try:
+                path_display = str(path.relative_to(REPO_ROOT))
+            except ValueError:
+                path_display = str(path)
+            return value, path_display
+    return None, None
+
+
+def _score_candidates(candidates: list[SpecCandidate], hints: list[str]) -> list[tuple[int, SpecCandidate]]:
+    hint_tokens = _tokenize(*hints)
+    if not hint_tokens:
+        return []
+    scored: list[tuple[int, SpecCandidate]] = []
+    for candidate in candidates:
+        candidate_tokens = _tokenize(candidate.dir_name, candidate.spec_id, candidate.spec_type)
+        score = len(candidate_tokens & hint_tokens)
+        if score:
+            scored.append((score, candidate))
+    scored.sort(key=lambda item: (-item[0], item[1].dir_name))
+    return scored
+
+
+def _candidate_dict(candidate: SpecCandidate, *, score: int | None = None) -> dict:
+    data = asdict(candidate)
+    if score is not None:
+        data["score"] = score
+    return data
+
+
+def resolve_spec(
+    *,
+    explicit_specs: list[str] | None = None,
+    hints: list[str] | None = None,
+    specs_root: Path = SPECS_ROOT,
+    pointer_candidates: list[Path] = POINTER_CANDIDATES,
+) -> Resolution:
+    explicit_specs = explicit_specs or []
+    hints = hints or []
+    candidates = discover_specs(specs_root)
+    if not candidates:
+        return Resolution(
+            status=SKIP_NOT_PRESENT,
+            reason="spec root not present",
+            chosen=None,
+            candidates=[],
+        )
+
+    for explicit in explicit_specs:
+        matches = _match_by_identity(candidates, explicit)
+        if len(matches) == 1:
+            return Resolution(
+                status=PASS,
+                reason=f"explicit spec match: {explicit}",
+                chosen=_candidate_dict(matches[0]),
+                candidates=[_candidate_dict(matches[0])],
+            )
+        if len(matches) > 1:
+            return Resolution(
+                status=WARN_NEEDS_AUTHOR_REVIEW,
+                reason=f"explicit spec is ambiguous: {explicit}",
+                chosen=None,
+                candidates=[_candidate_dict(candidate) for candidate in matches],
+            )
+
+    pointer_value, pointer_path = _read_pointer(pointer_candidates)
+    if pointer_value:
+        matches = _match_by_identity(candidates, pointer_value)
+        if len(matches) == 1:
+            return Resolution(
+                status=PASS,
+                reason=f"active pointer match: {pointer_value}",
+                chosen=_candidate_dict(matches[0]),
+                candidates=[_candidate_dict(matches[0])],
+                pointer=pointer_path,
+            )
+        if len(matches) > 1:
+            return Resolution(
+                status=WARN_NEEDS_AUTHOR_REVIEW,
+                reason=f"active pointer is ambiguous: {pointer_value}",
+                chosen=None,
+                candidates=[_candidate_dict(candidate) for candidate in matches],
+                pointer=pointer_path,
+            )
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason=f"active pointer does not match any local spec: {pointer_value}",
+            chosen=None,
+            candidates=[_candidate_dict(candidate) for candidate in candidates],
+            pointer=pointer_path,
+        )
+
+    scored = _score_candidates(candidates, hints)
+    if not scored:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason="no spec could be bound confidently from hints",
+            chosen=None,
+            candidates=[_candidate_dict(candidate) for candidate in candidates],
+        )
+
+    best_score, best_candidate = scored[0]
+    tied = [item for item in scored if item[0] == best_score]
+    if len(tied) > 1:
+        return Resolution(
+            status=WARN_NEEDS_AUTHOR_REVIEW,
+            reason="multiple specs match the current hints",
+            chosen=None,
+            candidates=[_candidate_dict(candidate, score=score) for score, candidate in tied],
+        )
+
+    return Resolution(
+        status=PASS,
+        reason="best hint match",
+        chosen=_candidate_dict(best_candidate, score=best_score),
+        candidates=[_candidate_dict(candidate, score=score) for score, candidate in scored],
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", action="append", default=[], help="explicit spec name or specId")
+    parser.add_argument(
+        "--hint",
+        action="append",
+        default=[],
+        help="task text or other hint text used for matching",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print machine-readable JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    resolution = resolve_spec(explicit_specs=args.spec, hints=args.hint)
+    payload = asdict(resolution)
+
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=True))
+    else:
+        print(f"{resolution.status}: {resolution.reason}")
+        if resolution.pointer:
+            print(f"pointer: {resolution.pointer}")
+        if resolution.chosen:
+            print(f"chosen: {resolution.chosen['dir_name']} ({resolution.chosen['spec_id']})")
+        if resolution.status != PASS:
+            print("candidates:")
+            for candidate in resolution.candidates:
+                print(f"- {candidate['dir_name']} ({candidate['spec_id']})")
+
+    return 0 if resolution.status in {PASS, SKIP_NOT_PRESENT} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harness/state_store.py
+++ b/tools/harness/state_store.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Minimal user-local state carrier for harness execution memory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FILE = "events.jsonl"
+
+
+@dataclass(frozen=True)
+class StateEvent:
+    event_type: str
+    key: str
+    source: str
+    note: str
+    ts: str
+
+
+def state_dir(repo_root: Path = REPO_ROOT) -> Path:
+    override = os.environ.get("HARNESS_STATE_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".gstack" / "projects" / repo_root.name / "harness-state"
+
+
+def state_file(repo_root: Path = REPO_ROOT) -> Path:
+    return state_dir(repo_root) / DEFAULT_FILE
+
+
+def append_event(
+    event_type: str,
+    key: str,
+    source: str,
+    note: str,
+    repo_root: Path = REPO_ROOT,
+) -> Path:
+    path = state_file(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "event_type": event_type,
+        "key": key,
+        "source": source,
+        "note": note,
+        "ts": datetime.now(UTC).isoformat(),
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
+    return path
+
+
+def load_events(repo_root: Path = REPO_ROOT) -> list[dict[str, Any]]:
+    path = state_file(repo_root)
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            events.append(json.loads(line))
+    return events
+
+
+def summarize(repo_root: Path = REPO_ROOT) -> str:
+    events = load_events(repo_root)
+    if not events:
+        return "No harness state recorded yet."
+    counts = Counter(event["event_type"] for event in events)
+    parts = [f"{key}={counts[key]}" for key in sorted(counts)]
+    return f"{len(events)} events, " + ", ".join(parts)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("path")
+    sub.add_parser("summary")
+
+    append = sub.add_parser("append")
+    append.add_argument("--event-type", required=True)
+    append.add_argument("--key", required=True)
+    append.add_argument("--source", required=True)
+    append.add_argument("--note", required=True)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "path":
+        print(state_file())
+        return 0
+    if args.command == "summary":
+        print(summarize())
+        return 0
+    if args.command == "append":
+        path = append_event(
+            event_type=args.event_type,
+            key=args.key,
+            source=args.source,
+            note=args.note,
+        )
+        print(path)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harness/state_store.py
+++ b/tools/harness/state_store.py
@@ -26,14 +26,15 @@ class StateEvent:
     ts: str
 
 
-def state_dir(repo_root: Path = REPO_ROOT) -> Path:
+def state_dir(repo_root: Path | None = None) -> Path:
+    repo_root = repo_root or REPO_ROOT
     override = os.environ.get("HARNESS_STATE_DIR")
     if override:
         return Path(override).expanduser()
     return Path.home() / ".gstack" / "projects" / repo_root.name / "harness-state"
 
 
-def state_file(repo_root: Path = REPO_ROOT) -> Path:
+def state_file(repo_root: Path | None = None) -> Path:
     return state_dir(repo_root) / DEFAULT_FILE
 
 
@@ -42,7 +43,7 @@ def append_event(
     key: str,
     source: str,
     note: str,
-    repo_root: Path = REPO_ROOT,
+    repo_root: Path | None = None,
 ) -> Path:
     path = state_file(repo_root)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -58,18 +59,25 @@ def append_event(
     return path
 
 
-def load_events(repo_root: Path = REPO_ROOT) -> list[dict[str, Any]]:
+def load_events(repo_root: Path | None = None) -> list[dict[str, Any]]:
     path = state_file(repo_root)
     if not path.exists():
         return []
     events: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    for line in lines:
         if line.strip():
-            events.append(json.loads(line))
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
     return events
 
 
-def summarize(repo_root: Path = REPO_ROOT) -> str:
+def summarize(repo_root: Path | None = None) -> str:
     events = load_events(repo_root)
     if not events:
         return "No harness state recorded yet."

--- a/tools/harness/state_store.py
+++ b/tools/harness/state_store.py
@@ -38,6 +38,15 @@ def state_file(repo_root: Path | None = None) -> Path:
     return state_dir(repo_root) / DEFAULT_FILE
 
 
+def _as_event(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    event_type = payload.get("event_type")
+    if not isinstance(event_type, str) or not event_type:
+        return None
+    return payload
+
+
 def append_event(
     event_type: str,
     key: str,
@@ -71,9 +80,12 @@ def load_events(repo_root: Path | None = None) -> list[dict[str, Any]]:
     for line in lines:
         if line.strip():
             try:
-                events.append(json.loads(line))
+                payload = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            event = _as_event(payload)
+            if event is not None:
+                events.append(event)
     return events
 
 
@@ -84,7 +96,11 @@ def summarize(repo_root: Path | None = None) -> str:
     counts = Counter(
         event_type
         for event in events
-        if (event_type := event.get("event_type")) is not None
+        if (
+            isinstance(event, dict)
+            and isinstance(event_type := event.get("event_type"), str)
+            and event_type
+        )
     )
     event_count = sum(counts.values())
     if not counts:

--- a/tools/harness/state_store.py
+++ b/tools/harness/state_store.py
@@ -81,9 +81,16 @@ def summarize(repo_root: Path | None = None) -> str:
     events = load_events(repo_root)
     if not events:
         return "No harness state recorded yet."
-    counts = Counter(event["event_type"] for event in events)
+    counts = Counter(
+        event_type
+        for event in events
+        if (event_type := event.get("event_type")) is not None
+    )
+    event_count = sum(counts.values())
+    if not counts:
+        return "No harness state recorded yet."
     parts = [f"{key}={counts[key]}" for key in sorted(counts)]
-    return f"{len(events)} events, " + ", ".join(parts)
+    return f"{event_count} events, " + ", ".join(parts)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tools/harness/tests/test_check_harness_sync.py
+++ b/tools/harness/tests/test_check_harness_sync.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT / "tools"))
-
-from harness import check_harness_sync as sync
+from tools.harness import check_harness_sync as sync
 
 
 def test_collect_results_skips_missing_kiro(tmp_path, monkeypatch):
@@ -63,6 +59,49 @@ def test_collect_results_fail_when_pack_doc_missing(tmp_path, monkeypatch):
     pack = next(item for item in results if item.name == "risk-pack-contract")
     assert pack.status == sync.FAIL
     assert "missing docs" in pack.detail
+
+
+def test_collect_results_fail_for_invalid_manifest_json(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    manifest_path = repo / "docs/harness/routing-manifest.json"
+    manifest_path.write_text("{not-json", encoding="utf-8")
+
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    assert len(results) == 1
+    assert results[0].name == "manifest-load"
+    assert results[0].status == sync.FAIL
+
+
+def test_collect_results_fail_when_optional_adapters_key_missing(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    manifest_path = repo / "docs/harness/routing-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["truth_surfaces"]["optional_adapters"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    assert len(results) == 1
+    assert results[0].name == "manifest-structure"
+    assert results[0].status == sync.FAIL
+    assert "truth surface keys" in results[0].detail
 
 
 def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = True) -> None:

--- a/tools/harness/tests/test_check_harness_sync.py
+++ b/tools/harness/tests/test_check_harness_sync.py
@@ -61,6 +61,27 @@ def test_collect_results_fail_when_pack_doc_missing(tmp_path, monkeypatch):
     assert "missing docs" in pack.detail
 
 
+def test_collect_results_handles_missing_harness_doc_without_crash(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    (repo / "docs/harness/core.md").unlink()
+
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", repo / "docs/harness/routing-manifest.json")
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    truth = next(item for item in results if item.name == "truth-surfaces")
+    docs = next(item for item in results if item.name == "harness-docs")
+    assert truth.status == sync.FAIL
+    assert docs.status == sync.FAIL
+    assert "unreadable" in docs.detail
+
+
 def test_collect_results_fail_for_invalid_manifest_json(tmp_path, monkeypatch):
     repo = tmp_path
     _write_repo_fixture(repo, with_kiro=False)

--- a/tools/harness/tests/test_check_harness_sync.py
+++ b/tools/harness/tests/test_check_harness_sync.py
@@ -104,6 +104,32 @@ def test_collect_results_fail_when_optional_adapters_key_missing(tmp_path, monke
     assert "truth surface keys" in results[0].detail
 
 
+def test_collect_results_accept_reordered_status_semantics(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    manifest_path = repo / "docs/harness/routing-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["status_semantics"] = [
+        sync.WARN_NEEDS_AUTHOR_REVIEW,
+        sync.SKIP_NOT_PRESENT,
+        sync.FAIL,
+        sync.PASS,
+    ]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    manifest_result = next(item for item in results if item.name == "manifest-structure")
+    assert manifest_result.status == sync.PASS
+
+
 def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = True) -> None:
     for rel in [
         "docs/harness/risk-packs",
@@ -141,7 +167,6 @@ def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = T
             sync.SKIP_NOT_PRESENT,
             sync.WARN_NEEDS_AUTHOR_REVIEW,
         ],
-        "spec_resolver": {},
         "spec_resolver": {
             "priority": ["user-task", "active-spec-pointer"],
             "pointer_candidates": [
@@ -167,7 +192,15 @@ def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = T
         json.dumps(manifest), encoding="utf-8"
     )
     (repo / "docs/harness/README.md").write_text(
-        "core.md\nrouting-manifest.json\nrouting-manifest.md\nrisk-packs/README.md\n",
+        "\n".join(
+            [
+                "[Workflow](core.md)",
+                "[Manifest JSON](routing-manifest.json)",
+                "[Manifest Summary](routing-manifest.md)",
+                "[Risk Packs](risk-packs/README.md)",
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
     (repo / "docs/harness/core.md").write_text(
@@ -200,7 +233,15 @@ def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = T
         "duplication\n", encoding="utf-8"
     )
     (repo / "AGENTS.md").write_text(
-        "docs/harness/README.md\ndocs/harness/core.md\ndocs/harness/routing-manifest.json\nCodex-first\n",
+        "\n".join(
+            [
+                "- `docs/harness/README.md` is the repo-owned harness entrypoint.",
+                "- `docs/harness/core.md` defines the execution loop.",
+                "- `docs/harness/routing-manifest.json` is the canonical route source.",
+                "- Codex-first semantics apply.",
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
 

--- a/tools/harness/tests/test_check_harness_sync.py
+++ b/tools/harness/tests/test_check_harness_sync.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from harness import check_harness_sync as sync
+
+
+def test_collect_results_skips_missing_kiro(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", repo / "docs/harness/routing-manifest.json")
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    adapter = next(item for item in results if item.name == "kiro-adapters")
+    assert adapter.status == sync.SKIP_NOT_PRESENT
+
+
+def test_collect_results_warns_for_local_kiro_drift(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=True, kiro_has_links=False)
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", repo / "docs/harness/routing-manifest.json")
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results(full=False)
+    adapter = next(item for item in results if item.name == "kiro-adapters")
+    assert adapter.status == sync.WARN_NEEDS_AUTHOR_REVIEW
+
+    full_results = sync.collect_results(full=True)
+    full_adapter = next(item for item in full_results if item.name == "kiro-adapters")
+    assert full_adapter.status == sync.FAIL
+
+
+def test_collect_results_fail_when_pack_doc_missing(tmp_path, monkeypatch):
+    repo = tmp_path
+    _write_repo_fixture(repo, with_kiro=False)
+    (repo / "docs/harness/risk-packs/runtime-streaming.md").unlink()
+
+    monkeypatch.setattr(sync, "REPO_ROOT", repo)
+    monkeypatch.setattr(sync, "MANIFEST_PATH", repo / "docs/harness/routing-manifest.json")
+    monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
+    monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
+    monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
+    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
+    monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
+
+    results = sync.collect_results()
+    pack = next(item for item in results if item.name == "risk-pack-contract")
+    assert pack.status == sync.FAIL
+    assert "missing docs" in pack.detail
+
+
+def _write_repo_fixture(repo: Path, *, with_kiro: bool, kiro_has_links: bool = True) -> None:
+    for rel in [
+        "docs/harness/risk-packs",
+        "docs/architecture",
+        "docs/testing",
+        "docs",
+    ]:
+        (repo / rel).mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "version": 1,
+        "truth_surfaces": {
+            "contract": ["AGENTS.md"],
+            "harness": [
+                "docs/harness/README.md",
+                "docs/harness/core.md",
+                "docs/harness/routing-manifest.md",
+                "docs/harness/routing-manifest.json",
+                "docs/harness/risk-packs/README.md",
+            ],
+            "canonical_docs": [
+                "docs/architecture/README.md",
+                "docs/testing/README.md",
+                "docs/DOCUMENTATION_DUPLICATION_POLICY.md",
+            ],
+            "optional_adapters": [
+                ".kiro/steering/product.md",
+                ".kiro/steering/structure.md",
+                ".kiro/steering/tech.md",
+            ],
+        },
+        "status_semantics": [
+            sync.PASS,
+            sync.FAIL,
+            sync.SKIP_NOT_PRESENT,
+            sync.WARN_NEEDS_AUTHOR_REVIEW,
+        ],
+        "spec_resolver": {},
+        "spec_resolver": {
+            "priority": ["user-task", "active-spec-pointer"],
+            "pointer_candidates": [
+                ".kiro/active-spec.json",
+                ".kiro/active-spec.txt",
+            ],
+            "multiple_spec_policy": "explain-current-choice",
+            "conflict_policy": "stop-and-confirm",
+        },
+        "verification_families": {
+            "harness-sync": {"phase": "cheap-blocker", "commands": ["make harness-check"]}
+        },
+        "risk_packs": [
+            {
+                "id": "runtime-streaming",
+                "doc": "docs/harness/risk-packs/runtime-streaming.md",
+                "verification_families": ["harness-sync"],
+            }
+        ],
+        "task_entrypoints": [],
+    }
+    (repo / "docs/harness/routing-manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    (repo / "docs/harness/README.md").write_text(
+        "core.md\nrouting-manifest.json\nrouting-manifest.md\nrisk-packs/README.md\n",
+        encoding="utf-8",
+    )
+    (repo / "docs/harness/core.md").write_text(
+        "\n".join(
+            [
+                sync.PASS,
+                sync.FAIL,
+                sync.SKIP_NOT_PRESENT,
+                sync.WARN_NEEDS_AUTHOR_REVIEW,
+                "outside voice",
+                "state carrier",
+                "stop and explain the mismatch",
+                "tools/harness/resolve_spec.py",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (repo / "docs/harness/routing-manifest.md").write_text(
+        "runtime-streaming\n", encoding="utf-8"
+    )
+    (repo / "docs/harness/risk-packs/README.md").write_text(
+        "runtime-streaming\n", encoding="utf-8"
+    )
+    (repo / "docs/harness/risk-packs/runtime-streaming.md").write_text(
+        "pack doc\n", encoding="utf-8"
+    )
+    (repo / "docs/architecture/README.md").write_text("arch\n", encoding="utf-8")
+    (repo / "docs/testing/README.md").write_text("testing\n", encoding="utf-8")
+    (repo / "docs/DOCUMENTATION_DUPLICATION_POLICY.md").write_text(
+        "duplication\n", encoding="utf-8"
+    )
+    (repo / "AGENTS.md").write_text(
+        "docs/harness/README.md\ndocs/harness/core.md\ndocs/harness/routing-manifest.json\nCodex-first\n",
+        encoding="utf-8",
+    )
+
+    if with_kiro:
+        (repo / ".kiro/steering").mkdir(parents=True, exist_ok=True)
+        content = "docs/harness/README.md\ndocs/harness/core.md\n" if kiro_has_links else "old doc\n"
+        for name in ("product.md", "structure.md", "tech.md"):
+            (repo / f".kiro/steering/{name}").write_text(content, encoding="utf-8")

--- a/tools/harness/tests/test_check_harness_sync.py
+++ b/tools/harness/tests/test_check_harness_sync.py
@@ -14,7 +14,6 @@ def test_collect_results_skips_missing_kiro(tmp_path, monkeypatch):
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()
@@ -30,7 +29,6 @@ def test_collect_results_warns_for_local_kiro_drift(tmp_path, monkeypatch):
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results(full=False)
@@ -52,7 +50,6 @@ def test_collect_results_fail_when_pack_doc_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()
@@ -71,7 +68,6 @@ def test_collect_results_handles_missing_harness_doc_without_crash(tmp_path, mon
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()
@@ -93,7 +89,6 @@ def test_collect_results_fail_for_invalid_manifest_json(tmp_path, monkeypatch):
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()
@@ -115,7 +110,6 @@ def test_collect_results_fail_when_optional_adapters_key_missing(tmp_path, monke
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()
@@ -143,7 +137,6 @@ def test_collect_results_accept_reordered_status_semantics(tmp_path, monkeypatch
     monkeypatch.setattr(sync, "README_PATH", repo / "docs/harness/README.md")
     monkeypatch.setattr(sync, "CORE_PATH", repo / "docs/harness/core.md")
     monkeypatch.setattr(sync, "SUMMARY_PATH", repo / "docs/harness/routing-manifest.md")
-    monkeypatch.setattr(sync, "PACK_INDEX_PATH", repo / "docs/harness/risk-packs/README.md")
     monkeypatch.setattr(sync, "AGENTS_PATH", repo / "AGENTS.md")
 
     results = sync.collect_results()

--- a/tools/harness/tests/test_resolve_spec.py
+++ b/tools/harness/tests/test_resolve_spec.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from harness import resolve_spec
+
+
+def test_resolve_returns_skip_when_specs_absent(tmp_path):
+    result = resolve_spec.resolve_spec(specs_root=tmp_path / ".kiro" / "specs")
+    assert result.status == resolve_spec.SKIP_NOT_PRESENT
+
+
+def test_resolve_explicit_spec_match(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    result = resolve_spec.resolve_spec(
+        explicit_specs=["14-nginx-streaming-runtime-and-ffi"],
+        specs_root=specs_root,
+        pointer_candidates=[],
+    )
+    assert result.status == resolve_spec.PASS
+    assert result.chosen["dir_name"] == "14-nginx-streaming-runtime-and-ffi"
+
+
+def test_resolve_uses_active_pointer(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    pointer = tmp_path / ".kiro" / "active-spec.json"
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    pointer.write_text(
+        json.dumps({"spec": "streaming-performance-evidence-and-release-001"}),
+        encoding="utf-8",
+    )
+    result = resolve_spec.resolve_spec(
+        specs_root=specs_root,
+        pointer_candidates=[pointer],
+    )
+    assert result.status == resolve_spec.PASS
+    assert result.chosen["dir_name"] == "18-streaming-performance-evidence-and-release"
+
+
+def test_resolve_best_hint_match(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    result = resolve_spec.resolve_spec(
+        hints=["work on streaming parity diff failure triage"],
+        specs_root=specs_root,
+        pointer_candidates=[],
+    )
+    assert result.status == resolve_spec.PASS
+    assert result.chosen["dir_name"] == "16-streaming-parity-diff-testing"
+
+
+def test_resolve_warns_when_hints_are_ambiguous(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    result = resolve_spec.resolve_spec(
+        hints=["continue streaming work"],
+        specs_root=specs_root,
+        pointer_candidates=[],
+    )
+    assert result.status == resolve_spec.WARN_NEEDS_AUTHOR_REVIEW
+    assert len(result.candidates) > 1
+
+
+def _write_specs(tmp_path: Path) -> Path:
+    specs_root = tmp_path / ".kiro" / "specs"
+    specs = {
+        "14-nginx-streaming-runtime-and-ffi": "nginx-streaming-runtime-and-ffi-001",
+        "16-streaming-parity-diff-testing": "streaming-parity-diff-testing-001",
+        "18-streaming-performance-evidence-and-release": "streaming-performance-evidence-and-release-001",
+    }
+    for dir_name, spec_id in specs.items():
+        spec_dir = specs_root / dir_name
+        spec_dir.mkdir(parents=True, exist_ok=True)
+        (spec_dir / ".config.kiro").write_text(
+            json.dumps(
+                {
+                    "specId": spec_id,
+                    "workflowType": "requirements-first",
+                    "specType": "feature",
+                }
+            ),
+            encoding="utf-8",
+        )
+    return specs_root

--- a/tools/harness/tests/test_resolve_spec.py
+++ b/tools/harness/tests/test_resolve_spec.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT / "tools"))
-
-from harness import resolve_spec
+from tools.harness import resolve_spec
 
 
 def test_resolve_returns_skip_when_specs_absent(tmp_path):
@@ -38,6 +34,75 @@ def test_resolve_uses_active_pointer(tmp_path):
         specs_root=specs_root,
         pointer_candidates=[pointer],
     )
+    assert result.status == resolve_spec.PASS
+    assert result.chosen["dir_name"] == "18-streaming-performance-evidence-and-release"
+
+
+def test_resolve_warns_on_pointer_mismatch(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    pointer = tmp_path / ".kiro" / "active-spec.json"
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    pointer.write_text(json.dumps({"spec": "non-existent-spec"}), encoding="utf-8")
+
+    result = resolve_spec.resolve_spec(
+        specs_root=specs_root,
+        pointer_candidates=[pointer],
+    )
+
+    assert result.status == resolve_spec.WARN_NEEDS_AUTHOR_REVIEW
+    assert result.chosen is None
+    candidate_dirs = {candidate["dir_name"] for candidate in result.candidates}
+    assert candidate_dirs == {
+        "14-nginx-streaming-runtime-and-ffi",
+        "16-streaming-parity-diff-testing",
+        "18-streaming-performance-evidence-and-release",
+    }
+
+
+def test_resolve_warns_on_explicit_spec_without_match(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    result = resolve_spec.resolve_spec(
+        explicit_specs=["non-existent-spec"],
+        specs_root=specs_root,
+        pointer_candidates=[],
+    )
+    assert result.status == resolve_spec.WARN_NEEDS_AUTHOR_REVIEW
+    assert result.chosen is None
+    assert {candidate["dir_name"] for candidate in result.candidates} == {
+        "14-nginx-streaming-runtime-and-ffi",
+        "16-streaming-parity-diff-testing",
+        "18-streaming-performance-evidence-and-release",
+    }
+
+
+def test_resolve_skips_malformed_pointer_json_and_uses_hints(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    pointer = tmp_path / ".kiro" / "active-spec.json"
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    pointer.write_text("{not-json", encoding="utf-8")
+
+    result = resolve_spec.resolve_spec(
+        hints=["streaming parity diff"],
+        specs_root=specs_root,
+        pointer_candidates=[pointer],
+    )
+
+    assert result.status == resolve_spec.PASS
+    assert result.chosen["dir_name"] == "16-streaming-parity-diff-testing"
+
+
+def test_resolve_skips_malformed_config_files(tmp_path):
+    specs_root = _write_specs(tmp_path)
+    bad_dir = specs_root / "99-bad-spec"
+    bad_dir.mkdir(parents=True, exist_ok=True)
+    (bad_dir / ".config.kiro").write_text("{bad-json", encoding="utf-8")
+
+    result = resolve_spec.resolve_spec(
+        hints=["streaming performance evidence"],
+        specs_root=specs_root,
+        pointer_candidates=[],
+    )
+
     assert result.status == resolve_spec.PASS
     assert result.chosen["dir_name"] == "18-streaming-performance-evidence-and-release"
 

--- a/tools/harness/tests/test_resolve_spec.py
+++ b/tools/harness/tests/test_resolve_spec.py
@@ -67,6 +67,8 @@ def test_resolve_warns_on_explicit_spec_without_match(tmp_path):
         pointer_candidates=[],
     )
     assert result.status == resolve_spec.WARN_NEEDS_AUTHOR_REVIEW
+    assert "explicit spec does not match any local spec" in result.reason
+    assert "non-existent-spec" in result.reason
     assert result.chosen is None
     assert {candidate["dir_name"] for candidate in result.candidates} == {
         "14-nginx-streaming-runtime-and-ffi",

--- a/tools/harness/tests/test_state_store.py
+++ b/tools/harness/tests/test_state_store.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from tools.harness import state_store
 
 
-def test_state_dir_uses_override(monkeypatch):
-    monkeypatch.setenv("HARNESS_STATE_DIR", "/tmp/harness-state-test")
-    assert state_store.state_dir() == Path("/tmp/harness-state-test")
+def test_state_dir_uses_override(tmp_path, monkeypatch):
+    expected = tmp_path / "harness-state-test"
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(expected))
+    assert state_store.state_dir() == expected
 
 
 def test_append_and_summary(tmp_path, monkeypatch):
@@ -63,3 +64,24 @@ def test_summary_skips_entries_missing_event_type(tmp_path, monkeypatch):
     )
 
     assert state_store.summarize() == "1 events, loop=1"
+
+
+def test_load_events_skips_non_dict_entries(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    path = state_store.state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                '{"event_type":"loop","key":"runtime","source":"t","note":"ok","ts":"2026-04-13T00:00:00+00:00"}',
+                '"raw-string-entry"',
+                "1",
+                "[]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    events = state_store.load_events()
+    assert len(events) == 1
+    assert events[0]["event_type"] == "loop"

--- a/tools/harness/tests/test_state_store.py
+++ b/tools/harness/tests/test_state_store.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from harness import state_store
+
+
+def test_state_dir_uses_override(monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", "/tmp/harness-state-test")
+    assert state_store.state_dir() == Path("/tmp/harness-state-test")
+
+
+def test_append_and_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    path = state_store.append_event(
+        event_type="loop",
+        key="runtime-streaming",
+        source="local-test",
+        note="first retry",
+    )
+    assert path.exists()
+    summary = state_store.summarize()
+    assert "1 events" in summary
+    assert "loop=1" in summary

--- a/tools/harness/tests/test_state_store.py
+++ b/tools/harness/tests/test_state_store.py
@@ -46,3 +46,20 @@ def test_load_events_skips_malformed_jsonl_lines(tmp_path, monkeypatch):
     events = state_store.load_events()
     assert len(events) == 1
     assert events[0]["event_type"] == "loop"
+
+
+def test_summary_skips_entries_missing_event_type(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    path = state_store.state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                '{"event_type":"loop","key":"runtime","source":"t","note":"ok","ts":"2026-04-13T00:00:00+00:00"}',
+                '{"key":"runtime","source":"t","note":"missing","ts":"2026-04-13T00:00:01+00:00"}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert state_store.summarize() == "1 events, loop=1"

--- a/tools/harness/tests/test_state_store.py
+++ b/tools/harness/tests/test_state_store.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT / "tools"))
-
-from harness import state_store
+from tools.harness import state_store
 
 
 def test_state_dir_uses_override(monkeypatch):
@@ -26,3 +22,27 @@ def test_append_and_summary(tmp_path, monkeypatch):
     summary = state_store.summarize()
     assert "1 events" in summary
     assert "loop=1" in summary
+
+
+def test_summary_reports_no_events_when_state_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    assert state_store.summarize() == "No harness state recorded yet."
+
+
+def test_load_events_skips_malformed_jsonl_lines(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARNESS_STATE_DIR", str(tmp_path))
+    path = state_store.state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                '{"event_type":"loop","key":"runtime","source":"t","note":"ok","ts":"2026-04-13T00:00:00+00:00"}',
+                "{bad-json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    events = state_store.load_events()
+    assert len(events) == 1
+    assert events[0]["event_type"] == "loop"

--- a/tools/release_gates/tests/test_compatibility_matrix_properties.py
+++ b/tools/release_gates/tests/test_compatibility_matrix_properties.py
@@ -177,9 +177,12 @@ def test_multiple_states_marked_fails():
         i for i, h in enumerate(header)
         if h.strip().lower() in {s.lower() for s in VALID_STATES}
     ]
+    capability_idx = next(
+        i for i, value in enumerate(header) if value.strip().lower() == "capability"
+    )
 
     result = ValidationResult()
-    check_compat_row_validity(result, rows[1:], state_indices)
+    check_compat_row_validity(result, rows[1:], state_indices, capability_idx)
     assert result.has_failures
     fail_detail = next(d for s, _, d in result.results if s == "FAIL")
     assert "marked 2 states" in fail_detail

--- a/tools/release_gates/tests/test_validate_release_gates_compat.py
+++ b/tools/release_gates/tests/test_validate_release_gates_compat.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from release_gates.validate_release_gates import (
+    ValidationResult,
+    check_compat_capabilities,
+    check_compat_row_validity,
+    check_compat_states,
+    extract_table_under_heading,
+)
+
+
+def test_single_classification_column_matrix_passes():
+    content = "\n".join(
+        [
+            "## Capability Classification Matrix",
+            "",
+            "| # | Capability | Classification | Notes |",
+            "|---|-----------|---------------|-------|",
+            "| 1 | automatic decompression | `streaming-supported` | note |",
+            "| 2 | charset detection / transcoding | `streaming-supported` | note |",
+            "| 3 | security sanitization | `streaming-supported` | note |",
+            "| 4 | deterministic output | `streaming-supported` | note |",
+            "| 5 | `markdown_timeout` | `streaming-supported` | note |",
+            "| 6 | `markdown_max_size` | `streaming-supported` | note |",
+            "| 7 | `markdown_token_estimate` | `streaming-supported` | note |",
+            "| 8 | `markdown_front_matter` (common head metadata within lookahead) | `streaming-supported` | note |",
+            "| 9 | `markdown_front_matter` (metadata beyond lookahead budget) | `pre-commit-fallback-only` | note |",
+            "| 10 | `markdown_etag` (response-header ETag) | `full-buffer-only` | note |",
+            "| 11 | `markdown_etag` (internal hash) | `streaming-supported` | note |",
+            "| 12 | `markdown_conditional_requests` (`if_modified_since_only`) | `streaming-supported` (conditional) | note |",
+            "| 13 | `markdown_conditional_requests` (`full_support`) | `full-buffer-only` | note |",
+            "| 14 | authenticated request policy / cache-control | `streaming-supported` (conditional) | note |",
+            "| 15 | decision logs / reason codes / metrics | `streaming-supported` | note |",
+            "| 16 | table conversion | `pre-commit-fallback-only` | note |",
+            "| 17 | `prune_noise_regions` | `pre-commit-fallback-only` | note |",
+            "| 18 | `markdown_on_wildcard` | `streaming-supported` | note |",
+        ]
+    )
+    rows = extract_table_under_heading(content, "Capability Classification Matrix")
+    result = ValidationResult()
+    check_compat_capabilities(result, rows)
+    state_indices = check_compat_states(result, rows[0])
+    check_compat_row_validity(result, rows[1:], state_indices)
+    assert not result.has_failures, [r for r in result.results if r[0] == "FAIL"]
+
+
+def test_single_classification_column_rejects_invalid_state():
+    content = "\n".join(
+        [
+            "## Capability Classification Matrix",
+            "",
+            "| # | Capability | Classification | Notes |",
+            "|---|-----------|---------------|-------|",
+            "| 1 | automatic decompression | `secretly-degraded` | note |",
+        ]
+    )
+    rows = extract_table_under_heading(content, "Capability Classification Matrix")
+    result = ValidationResult()
+    state_indices = check_compat_states(result, rows[0])
+    check_compat_row_validity(result, rows[1:], state_indices)
+    assert result.has_failures
+    fail_detail = next(d for s, _, d in result.results if s == "FAIL")
+    assert "invalid state" in fail_detail

--- a/tools/release_gates/tests/test_validate_release_gates_compat.py
+++ b/tools/release_gates/tests/test_validate_release_gates_compat.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
-
-from release_gates.validate_release_gates import (
+from tools.release_gates.validate_release_gates import (
     ValidationResult,
     check_compat_capabilities,
     check_compat_row_validity,
@@ -44,8 +39,8 @@ def test_single_classification_column_matrix_passes():
     rows = extract_table_under_heading(content, "Capability Classification Matrix")
     result = ValidationResult()
     check_compat_capabilities(result, rows)
-    state_indices = check_compat_states(result, rows[0])
-    check_compat_row_validity(result, rows[1:], state_indices)
+    state_indices, capability_idx = check_compat_states(result, rows[0])
+    check_compat_row_validity(result, rows[1:], state_indices, capability_idx)
     assert not result.has_failures, [r for r in result.results if r[0] == "FAIL"]
 
 
@@ -61,8 +56,27 @@ def test_single_classification_column_rejects_invalid_state():
     )
     rows = extract_table_under_heading(content, "Capability Classification Matrix")
     result = ValidationResult()
-    state_indices = check_compat_states(result, rows[0])
-    check_compat_row_validity(result, rows[1:], state_indices)
+    state_indices, capability_idx = check_compat_states(result, rows[0])
+    check_compat_row_validity(result, rows[1:], state_indices, capability_idx)
     assert result.has_failures
     fail_detail = next(d for s, _, d in result.results if s == "FAIL")
     assert "invalid state" in fail_detail
+
+
+def test_single_classification_column_rejects_missing_state_cell():
+    content = "\n".join(
+        [
+            "## Capability Classification Matrix",
+            "",
+            "| # | Capability | Classification | Notes |",
+            "|---|-----------|---------------|-------|",
+            "| 1 | automatic decompression |  | note |",
+        ]
+    )
+    rows = extract_table_under_heading(content, "Capability Classification Matrix")
+    result = ValidationResult()
+    state_indices, capability_idx = check_compat_states(result, rows[0])
+    check_compat_row_validity(result, rows[1:], state_indices, capability_idx)
+    assert result.has_failures
+    fail_detail = next(d for s, _, d in result.results if s == "FAIL")
+    assert "missing classification" in fail_detail

--- a/tools/release_gates/validate_release_gates.py
+++ b/tools/release_gates/validate_release_gates.py
@@ -485,6 +485,38 @@ CHECK_GATE_CHECKLIST = "gate-failures:checklist"
 _VALID_STATES_LOWER = {s.lower() for s in VALID_STATES}
 
 
+def _normalize_state_value(value: str) -> str:
+    """Normalize a state cell from either matrix format to a canonical state.
+
+    Supports:
+    - old format: state columns marked with a checkmark
+    - new format: single Classification column containing values such as
+      "`streaming-supported`" or "`streaming-supported` (conditional)"
+    """
+    normalized = value.strip().replace("`", "").lower()
+    if " " in normalized:
+        normalized = normalized.split(" ", 1)[0]
+    return normalized
+
+
+def _compat_column_indices(header: list[str]) -> tuple[int, int | None]:
+    """Return the capability column index and optional classification column index."""
+    lowered = [cell.strip().lower() for cell in header]
+    capability_idx = -1
+    for idx, value in enumerate(lowered):
+        if value == "capability":
+            capability_idx = idx
+            break
+
+    classification_idx = None
+    for idx, value in enumerate(lowered):
+        if value == "classification":
+            classification_idx = idx
+            break
+
+    return capability_idx, classification_idx
+
+
 def check_compat_capabilities(
     result: ValidationResult, rows: list[list[str]]
 ) -> None:
@@ -502,8 +534,15 @@ def check_compat_capabilities(
         result.failed(CHECK_COMPAT_CAPS, "no table rows to check")
         return
 
-    # Collect first-column values from data rows (skip header)
-    row_caps = [row[0].strip().lower() for row in rows[1:] if row]
+    capability_idx, _ = _compat_column_indices(rows[0])
+    if capability_idx == -1:
+        result.failed(CHECK_COMPAT_CAPS, "capability column not found")
+        return
+
+    row_caps = []
+    for row in rows[1:]:
+        if capability_idx < len(row):
+            row_caps.append(row[capability_idx].strip().lower())
 
     missing = []
     for cap in CANONICAL_CAPABILITIES:
@@ -535,12 +574,21 @@ def check_compat_states(result: ValidationResult, header: list[str]) -> list[int
     Returns:
         List of column indices for the state columns, or empty list on failure
     """
+    capability_idx, classification_idx = _compat_column_indices(header)
+    if capability_idx == -1:
+        result.failed(CHECK_COMPAT_STATES, "capability column not found")
+        return []
+
+    if classification_idx is not None:
+        result.passed(CHECK_COMPAT_STATES)
+        return [classification_idx]
+
     state_columns = [h for h in header if h.strip() and h.lower() in _VALID_STATES_LOWER]
     extra_columns = [
         h for h in header
         if h.strip()
         and h.lower() not in _VALID_STATES_LOWER
-        and h.lower() not in ("capability", "notes")
+        and h.lower() not in ("#", "capability", "notes")
     ]
     if len(state_columns) != len(VALID_STATES):
         result.failed(
@@ -573,14 +621,27 @@ def check_compat_row_validity(
         state_indices: List of column indices for the state columns
     """
     invalid_rows = []
+    uses_classification_column = len(state_indices) == 1
+
     for row in data_rows:
-        # Count how many states are marked in this row
-        marked = sum(
-            bool(idx < len(row) and row[idx].strip())
-            for idx in state_indices
-        )
+        cap_name = "<empty>"
+        if len(row) >= 2:
+            cap_name = row[1].strip() or cap_name
+        elif row:
+            cap_name = row[0].strip() or cap_name
+
+        if uses_classification_column:
+            idx = state_indices[0]
+            if idx >= len(row):
+                invalid_rows.append(f"{cap_name} (missing classification)")
+                continue
+            state_value = _normalize_state_value(row[idx])
+            if state_value not in _VALID_STATES_LOWER:
+                invalid_rows.append(f"{cap_name} (invalid state: {row[idx].strip()})")
+            continue
+
+        marked = sum(bool(idx < len(row) and row[idx].strip()) for idx in state_indices)
         if marked != 1:
-            cap_name = row[0].strip() if row else "<empty>"
             invalid_rows.append(f"{cap_name} (marked {marked} states)")
     if invalid_rows:
         result.failed(

--- a/tools/release_gates/validate_release_gates.py
+++ b/tools/release_gates/validate_release_gates.py
@@ -561,7 +561,9 @@ def check_compat_capabilities(
         result.passed(CHECK_COMPAT_CAPS)
 
 
-def check_compat_states(result: ValidationResult, header: list[str]) -> list[int]:
+def check_compat_states(
+    result: ValidationResult, header: list[str]
+) -> tuple[list[int], int]:
     """Sub-check: header must have exactly the valid state columns.
 
     This function verifies that the compatibility matrix header contains
@@ -577,11 +579,11 @@ def check_compat_states(result: ValidationResult, header: list[str]) -> list[int
     capability_idx, classification_idx = _compat_column_indices(header)
     if capability_idx == -1:
         result.failed(CHECK_COMPAT_STATES, "capability column not found")
-        return []
+        return [], -1
 
     if classification_idx is not None:
         result.passed(CHECK_COMPAT_STATES)
-        return [classification_idx]
+        return [classification_idx], capability_idx
 
     state_columns = [h for h in header if h.strip() and h.lower() in _VALID_STATES_LOWER]
     extra_columns = [
@@ -595,19 +597,24 @@ def check_compat_states(result: ValidationResult, header: list[str]) -> list[int
             CHECK_COMPAT_STATES,
             f"expected {len(VALID_STATES)} state columns, found {len(state_columns)}: {state_columns}",
         )
-        return []
+        return [], capability_idx
     if extra_columns:
         result.failed(
             CHECK_COMPAT_STATES,
             f"unexpected columns in matrix header: {extra_columns}",
         )
-        return []
+        return [], capability_idx
     result.passed(CHECK_COMPAT_STATES)
-    return [i for i, h in enumerate(header) if h.strip() and h.lower() in _VALID_STATES_LOWER]
+    return [
+        i for i, h in enumerate(header) if h.strip() and h.lower() in _VALID_STATES_LOWER
+    ], capability_idx
 
 
 def check_compat_row_validity(
-    result: ValidationResult, data_rows: list[list[str]], state_indices: list[int]
+    result: ValidationResult,
+    data_rows: list[list[str]],
+    state_indices: list[int],
+    capability_idx: int,
 ) -> None:
     """Sub-check: each data row must mark exactly one state.
 
@@ -625,14 +632,14 @@ def check_compat_row_validity(
 
     for row in data_rows:
         cap_name = "<empty>"
-        if len(row) >= 2:
-            cap_name = row[1].strip() or cap_name
+        if capability_idx >= 0 and capability_idx < len(row):
+            cap_name = row[capability_idx].strip() or cap_name
         elif row:
             cap_name = row[0].strip() or cap_name
 
         if uses_classification_column:
             idx = state_indices[0]
-            if idx >= len(row):
+            if idx >= len(row) or not row[idx].strip():
                 invalid_rows.append(f"{cap_name} (missing classification)")
                 continue
             state_value = _normalize_state_value(row[idx])
@@ -680,8 +687,9 @@ def check_compatibility_matrix(result: ValidationResult) -> None:
     check_compat_capabilities(result, rows)
 
     # Check that the header has the correct state columns and validate rows
-    if state_indices := check_compat_states(result, rows[0]):
-        check_compat_row_validity(result, rows[1:], state_indices)
+    state_indices, capability_idx = check_compat_states(result, rows[0])
+    if state_indices:
+        check_compat_row_validity(result, rows[1:], state_indices, capability_idx)
 
 
 _CHECKLIST_RE_PREFIX = "- ["


### PR DESCRIPTION
## Summary by Sourcery

Introduce a repo-owned harness for agent workflow, spec routing, and validation, while extending streaming conversion, release-gate compatibility checks, test metadata, and documentation to align with the new harness model.

New Features:
- Add harness tooling, manifests, and risk-pack documentation to govern agent workflow, spec routing, and validation from repo-owned truth surfaces.
- Introduce Make targets and CI wiring to run harness checks as part of documentation and release-gate validation.
- Extend streaming URL extraction to cover additional media-bearing HTML elements and emit parse-error statistics.
- Add structured drift classification fields to streaming parity known-difference metadata for finer-grained difference tracking.

Bug Fixes:
- Update release-gate compatibility-matrix validation to handle both legacy multi-column and new single-classification-column formats, restoring harness check success.
- Limit HTML title collection in the streaming converter to the configured lookahead budget to prevent unbounded buffer growth.
- Adjust docs validation to ignore non-maintained markdown files and avoid false failures from local scratch notes.

Enhancements:
- Document the harness architecture, maintenance workflow, and project-level status so contributors can understand and evolve repo-owned agent rules.
- Track tokenizer parse-error counts in streaming converter statistics for improved observability.
- Clarify AGENTS.md with harness mapping rules and additional streaming and drift-handling requirements.

Tests:
- Add harness-focused tests covering manifest validation, spec resolution behavior, state-store robustness, and release-gate compatibility matrix properties.
- Expand streaming tests to cover media URL extraction for additional HTML tags, parse-error counting, and bounded title collection behavior.
- Extend docs-check tests to distinguish maintained documentation surfaces from local or archived markdown files.
- Augment known-differences tests to verify drift classification parsing and matching semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repo-owned harness with new validation commands and CLI helpers for spec resolution, harness checks, and local harness state management

* **Documentation**
  * Comprehensive harness docs added (architecture, routing manifest, risk packs, maintenance guide, ADR, changelogs, README updates)

* **Tests**
  * New tests covering harness tools, spec resolution, state persistence, docs scanning, and compatibility-matrix parsing

* **Chores**
  * CI path filters updated to include agent contract file; docs-check now invoked via Make targets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->