### PR TITLE
test(coverage): raise streaming and c coverage with e2e hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,10 @@ Required:
   5. **Test helper constructors**: any `empty_result()`, `zeroed_result()`, or similar test helper must include the new field.
 - **Prefer helper functions over literal initialization for FFI structs**: When writing test code that needs a zeroed/empty FFI struct, **always use existing helper functions** (for example `empty_result()`, `zeroed_result()`, `ffi_test_empty_result()`) rather than writing `StructName { field: value, ... }` literals. This reduces future maintenance cost when the struct gains new fields — only the helper needs updating, not every call site. If no helper exists for a struct, create one before writing multiple literal initializations.
 - **Lifecycle ordering rule: read data from foreign-owned structs BEFORE calling their associated free/release function.** Do not access fields after `markdown_result_free()`, `markdown_converter_free()`, or similar cleanup calls — the memory may be invalidated, zeroed, or returned to the allocator. Capture values to local variables first, then free.
+- In C unit tests that stub FFI lifecycle helpers (for example
+  `markdown_result_free()`), clear **all** struct fields covered by the public
+  ABI (pointer, length, and numeric/error fields). Partial clears create false
+  confidence and can mask stale-state regressions.
 - When C code classifies FFI error codes into semantic categories, the
   classification branch must cover **all** codes defined in the FFI header
   that map to that category.  Do not assume a 1:1 mapping between C-local
@@ -414,6 +418,10 @@ Required:
 - Declare loop variables (`i`, `feed_count`, etc.) inside the `for` statement when they are not used after the loop. The test code already uses C99 features, so `for (size_t i = 0; ...)` is preferred over declaring `i` at function scope.
 - When a test assigns a variable to verify a cast or representation, ensure the variable is actually read by a `TEST_ASSERT` before the function ends.
 - Initialize variables at declaration when the compiler cannot prove they are always assigned before use (for example variables set only inside conditional branches).
+- Output variables passed by pointer to helpers (for example
+  `foo(..., &last_buf, ..., &fallback_cl)`) must be initialized before the call
+  even when the callee is expected to assign them on success; early-return
+  paths in test/prod helpers can otherwise read indeterminate storage.
 
 ### 17. Cognitive complexity in C functions
 SonarCloud rule: `c:S3776`.
@@ -452,6 +460,13 @@ Required:
   are preserved in all environments. Prefer `bash path/to/script.sh` (or ensure
   the executable bit is enforced) so coverage/release pipelines do not fail with
   `Permission denied`.
+- Under `set -e`, command substitutions that intentionally inspect failure-path
+  responses (for example truncated-stream curl probes) must not abort before
+  assertions run. Use explicit tolerance (`|| true`) and then enforce behavior
+  via subsequent checks on status/header/body artifacts.
+- For HTTP HEAD validation in curl-based harness scripts, use `curl --head`
+  (or `-I`) instead of `-X HEAD`, and create any expected empty body artifact
+  explicitly when downstream checks read a body file.
 
 ### 19. Python e2e/tooling harness guardrails
 

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -12,6 +12,9 @@
  * configuration object lifecycle and the directive registry table.
  */
 
+#include <errno.h>
+#include <stdlib.h>
+
 static ngx_int_t
 ngx_http_markdown_arg_equals(
     const ngx_str_t *arg,
@@ -29,6 +32,85 @@ ngx_http_markdown_arg_equals(
     return ngx_strncasecmp(arg->data,
                            expected,
                            expected_len) == 0;
+}
+
+/*
+ * Parse an ngx_str_t size token using the module's directive
+ * semantics.  Supports the same suffix families as NGINX's size
+ * parser (k/K, m/M, g/G) and rejects overflow or malformed input.
+ */
+static size_t
+ngx_http_markdown_parse_size(ngx_str_t *line)
+{
+    char                 buf[64];
+    char                *endptr;
+    size_t               len;
+    size_t               value;
+    size_t               scale;
+    unsigned long long   raw;
+    char                 suffix;
+
+    if (line == NULL || line->data == NULL || line->len == 0) {
+        return (size_t) NGX_ERROR;
+    }
+
+    len = line->len;
+    if (len >= sizeof(buf)) {
+        return (size_t) NGX_ERROR;
+    }
+
+    memcpy(buf, line->data, len);
+    buf[len] = '\0';
+
+    suffix = '\0';
+    if (len > 1) {
+        switch (buf[len - 1]) {
+        case 'k':
+        case 'K':
+        case 'm':
+        case 'M':
+        case 'g':
+        case 'G':
+            suffix = buf[len - 1];
+            buf[len - 1] = '\0';
+            break;
+        default:
+            break;
+        }
+    }
+
+    errno = 0;
+    raw = strtoull(buf, &endptr, 10);
+    if (errno == ERANGE || *endptr != '\0'
+        || raw > (unsigned long long) NGX_MAX_SIZE_T_VALUE)
+    {
+        return (size_t) NGX_ERROR;
+    }
+
+    value = (size_t) raw;
+
+    switch (suffix) {
+    case 'k':
+    case 'K':
+        scale = (size_t) 1024;
+        break;
+    case 'm':
+    case 'M':
+        scale = (size_t) 1024 * 1024;
+        break;
+    case 'g':
+    case 'G':
+        scale = (size_t) 1024 * 1024 * 1024;
+        break;
+    default:
+        return value;
+    }
+
+    if (value > NGX_MAX_SIZE_T_VALUE / scale) {
+        return (size_t) NGX_ERROR;
+    }
+
+    return value * scale;
 }
 
 /*
@@ -466,7 +548,7 @@ ngx_http_markdown_large_body_threshold(ngx_conf_t *cf,
         return NGX_CONF_OK;
     }
 
-    mcf->large_body_threshold = ngx_parse_size(&value[1]);
+    mcf->large_body_threshold = ngx_http_markdown_parse_size(&value[1]);
     if (mcf->large_body_threshold == (size_t) NGX_ERROR) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
             "invalid value \"%V\" in "

--- a/components/nginx-module/tests/Makefile
+++ b/components/nginx-module/tests/Makefile
@@ -27,6 +27,12 @@ SANITIZER_ENV ?= ASAN_OPTIONS=$(ASAN_OPTIONS_BASE) UBSAN_OPTIONS=print_stacktrac
 build/unit build/integration build/generated:
 	@mkdir -p $@
 
+# Unit test build rule.  The case statement selects per-target flags:
+#   streaming_impl  - full streaming pipeline; needs NGINX src headers, nginx_stubs,
+#                      Rust FFI headers, streaming enabled, and -lz for decomp.
+#   config_handlers_impl / config_core_impl - config-layer unit tests; need
+#                      nginx_stubs for NGINX API redefinitions and -ffunction-sections
+#                      for dead-code elimination of unused stubs.
 build/unit/%: unit/%_test.c include/test_common.h include/test_metrics_snapshot.h | build/unit build/generated
 	@extra_srcs=""; \
 	extra_cflags=""; \

--- a/components/nginx-module/tests/Makefile
+++ b/components/nginx-module/tests/Makefile
@@ -37,7 +37,10 @@ build/unit/%: unit/%_test.c include/test_common.h include/test_metrics_snapshot.
 	  gzip_deflate_decompression) extra_ldflags="-lz" ;; \
 	  streaming_decomp) extra_cflags="-I../src -Iinclude/nginx_stubs -DMARKDOWN_STREAMING_ENABLED"; extra_ldflags="-lz" ;; \
 	  streaming) extra_cflags="-DMARKDOWN_STREAMING_ENABLED" ;; \
+	  streaming_impl) extra_cflags="-I../src -Iinclude/nginx_stubs -I../../rust-converter/include -DMARKDOWN_STREAMING_ENABLED -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS) -lz" ;; \
 	  conversion_impl_base_url) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
+	  config_handlers_impl) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
+	  config_core_impl) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
 	  prometheus_renderer) extra_cflags="-DMARKDOWN_STREAMING_ENABLED" ;; \
 	esac; \
 	$(CC) $(CFLAGS_COMMON) $(LDFLAGS_COMMON) $$extra_cflags -o "$@" "$<" $$extra_srcs $$extra_ldflags

--- a/components/nginx-module/tests/unit/config_core_impl_test.c
+++ b/components/nginx-module/tests/unit/config_core_impl_test.c
@@ -1,0 +1,727 @@
+/*
+ * Test: config_core_impl
+ * Description: direct branch coverage for config core helpers.
+ */
+
+#include "../include/test_common.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+
+#define MARKDOWN_STREAMING_ENABLED 1
+
+#include "../../src/ngx_http_markdown_filter_module.h"
+
+#ifndef NGX_OK
+#define NGX_OK 0
+#endif
+#ifndef NGX_ERROR
+#define NGX_ERROR -1
+#endif
+#ifndef NGX_CONF_OK
+#define NGX_CONF_OK ((char *) NULL)
+#endif
+#ifndef NGX_CONF_ERROR
+#define NGX_CONF_ERROR ((char *) 1)
+#endif
+
+#ifndef NGX_CONF_UNSET
+#define NGX_CONF_UNSET (-1)
+#endif
+#ifndef NGX_CONF_UNSET_UINT
+#define NGX_CONF_UNSET_UINT ((ngx_uint_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_SIZE
+#define NGX_CONF_UNSET_SIZE ((size_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_MSEC
+#define NGX_CONF_UNSET_MSEC ((ngx_msec_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_PTR
+#define NGX_CONF_UNSET_PTR ((void *) -1)
+#endif
+
+#ifndef NGX_LOG_WARN
+#define NGX_LOG_WARN 2
+#endif
+#ifndef NGX_LOG_INFO
+#define NGX_LOG_INFO 3
+#endif
+#ifndef NGX_LOG_DEBUG
+#define NGX_LOG_DEBUG 4
+#endif
+
+typedef intptr_t ngx_err_t;
+typedef struct ngx_connection_s ngx_connection_t;
+
+struct ngx_module_s {
+    int dummy;
+};
+
+struct ngx_pool_s {
+    int dummy;
+};
+
+struct ngx_array_s {
+    ngx_uint_t nelts;
+};
+
+struct ngx_log_s {
+    int dummy;
+};
+
+struct ngx_connection_s {
+    ngx_log_t *log;
+};
+
+struct ngx_http_request_s {
+    ngx_connection_t *connection;
+};
+
+struct ngx_http_complex_value_s {
+    ngx_str_t  value;
+    ngx_int_t  eval_rc;
+};
+
+struct ngx_conf_s {
+    ngx_pool_t *pool;
+};
+
+typedef struct ngx_slab_pool_s ngx_slab_pool_t;
+
+struct ngx_slab_pool_s {
+    void *data;
+};
+
+typedef struct {
+    void      *addr;
+    ngx_flag_t exists;
+} ngx_shm_t;
+
+struct ngx_shm_zone_s {
+    ngx_shm_t  shm;
+    void      *data;
+    ngx_int_t (*init)(ngx_shm_zone_t *zone, void *data);
+};
+
+ngx_module_t ngx_http_markdown_filter_module;
+ngx_str_t ngx_http_markdown_metrics_shm_name = ngx_string("markdown_metrics");
+ngx_shm_zone_t *ngx_http_markdown_metrics_shm_zone = NULL;
+
+static size_t ngx_pagesize = 4096;
+static ngx_shm_zone_t *g_shared_zone;
+static size_t g_shared_size;
+static ngx_int_t g_slab_alloc_fail;
+
+#define ngx_conf_init_size_value(conf, default_value) \
+    if ((conf) == NGX_CONF_UNSET_SIZE) {              \
+        (conf) = (default_value);                      \
+    }
+
+#define ngx_conf_merge_size_value(conf, prev, default_value) \
+    if ((conf) == NGX_CONF_UNSET_SIZE) {                      \
+        (conf) = ((prev) == NGX_CONF_UNSET_SIZE)              \
+            ? (default_value)                                 \
+            : (prev);                                         \
+    }
+
+#define ngx_conf_merge_msec_value(conf, prev, default_value) \
+    if ((conf) == NGX_CONF_UNSET_MSEC) {                     \
+        (conf) = ((prev) == NGX_CONF_UNSET_MSEC)             \
+            ? (default_value)                                 \
+            : (prev);                                         \
+    }
+
+#define ngx_conf_merge_uint_value(conf, prev, default_value) \
+    if ((conf) == NGX_CONF_UNSET_UINT) {                     \
+        (conf) = ((prev) == NGX_CONF_UNSET_UINT)             \
+            ? (default_value)                                 \
+            : (prev);                                         \
+    }
+
+#define ngx_conf_merge_value(conf, prev, default_value) \
+    if ((conf) == NGX_CONF_UNSET) {                     \
+        (conf) = ((prev) == NGX_CONF_UNSET)             \
+            ? (default_value)                            \
+            : (prev);                                    \
+    }
+
+#define ngx_conf_merge_ptr_value(conf, prev, default_value) \
+    if ((conf) == NGX_CONF_UNSET_PTR) {                     \
+        (conf) = ((prev) == NGX_CONF_UNSET_PTR)             \
+            ? (default_value)                                 \
+            : (prev);                                         \
+    }
+
+/*
+ * Test-only NGINX stubs used by config_core_impl_test.
+ *
+ * These helpers intentionally model only the subset of behavior needed by the
+ * unit tests and differ from production NGINX in several ways:
+ * - allocator paths are deterministic (`calloc`) and always zero memory;
+ * - slab failure is synthetic (`g_slab_alloc_fail`) instead of SHM pressure;
+ * - shared-memory add path records requested size in `g_shared_size`;
+ * - complex value evaluation is short-circuited to fixed test return codes;
+ * - locking, logging internals, and runtime side effects are not simulated.
+ *
+ * Contract relied on by tests:
+ * - success returns NGINX-style success codes and expected copied values;
+ * - allocation failures return NULL from allocator stubs;
+ * - zero-initialization semantics are preserved for created buffers/structs;
+ * - invalid inputs return NGX_ERROR where the tested branch expects it.
+ *
+ * Divergence risk:
+ * If production NGINX semantics for these primitives change, dependent tests
+ * in this file must be reviewed and updated to keep branch expectations valid.
+ */
+static ngx_int_t
+ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        u_char c1;
+        u_char c2;
+
+        c1 = (u_char) tolower((unsigned char) s1[i]);
+        c2 = (u_char) tolower((unsigned char) s2[i]);
+
+        if (c1 != c2) {
+            return (ngx_int_t) c1 - (ngx_int_t) c2;
+        }
+    }
+
+    return 0;
+}
+
+static void
+ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
+    const char *fmt, ...)
+{
+    va_list ap;
+
+    UNUSED(level);
+    UNUSED(cf);
+    UNUSED(err);
+
+    va_start(ap, fmt);
+    va_end(ap);
+}
+
+static void *
+ngx_pcalloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    return calloc(1, size);
+}
+
+static void
+ngx_memzero(void *p, size_t n)
+{
+    memset(p, 0, n);
+}
+
+static void *
+ngx_slab_alloc(ngx_slab_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+
+    if (g_slab_alloc_fail) {
+        return NULL;
+    }
+
+    return calloc(1, size);
+}
+
+static ngx_shm_zone_t *
+ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
+    ngx_module_t *module)
+{
+    UNUSED(cf);
+    UNUSED(name);
+    UNUSED(module);
+
+    g_shared_size = size;
+    return g_shared_zone;
+}
+
+static ngx_int_t
+ngx_http_complex_value(ngx_http_request_t *r,
+    ngx_http_complex_value_t *val, ngx_str_t *value)
+{
+    UNUSED(r);
+
+    if (val == NULL || value == NULL) {
+        return NGX_ERROR;
+    }
+
+    *value = val->value;
+    return val->eval_rc;
+}
+
+#include "../../src/ngx_http_markdown_config_core_impl.h"
+
+static ngx_pool_t g_pool;
+static ngx_log_t g_log;
+static ngx_connection_t g_conn = { &g_log };
+
+static void
+set_str(ngx_str_t *dst, const char *src)
+{
+    dst->data = (u_char *) (uintptr_t) src;
+    dst->len = strlen(src);
+}
+
+static void
+init_complex(ngx_http_complex_value_t *cv, const char *value, ngx_int_t rc)
+{
+    set_str(&cv->value, value);
+    cv->eval_rc = rc;
+}
+
+static void
+test_metrics_zone_init(void)
+{
+    ngx_shm_zone_t zone;
+    ngx_slab_pool_t shpool;
+    ngx_http_markdown_metrics_t old_metrics;
+    ngx_http_markdown_metrics_t *new_metrics;
+    ngx_int_t rc;
+
+    TEST_SUBSECTION("metrics zone init paths");
+
+    memset(&zone, 0, sizeof(zone));
+    memset(&shpool, 0, sizeof(shpool));
+
+    rc = ngx_http_markdown_init_metrics_zone(&zone, &old_metrics);
+    TEST_ASSERT(rc == NGX_OK, "reuse path should succeed");
+    TEST_ASSERT(zone.data == &old_metrics, "reuse should keep existing data");
+
+    memset(&zone, 0, sizeof(zone));
+    zone.shm.addr = NULL;
+    rc = ngx_http_markdown_init_metrics_zone(&zone, NULL);
+    TEST_ASSERT(rc == NGX_ERROR, "NULL slab pool should fail");
+
+    memset(&zone, 0, sizeof(zone));
+    memset(&shpool, 0, sizeof(shpool));
+    zone.shm.addr = &shpool;
+    zone.shm.exists = 1;
+    shpool.data = &old_metrics;
+    rc = ngx_http_markdown_init_metrics_zone(&zone, NULL);
+    TEST_ASSERT(rc == NGX_OK, "existing shm data should attach");
+    TEST_ASSERT(zone.data == &old_metrics, "existing shm data pointer mismatch");
+
+    memset(&zone, 0, sizeof(zone));
+    memset(&shpool, 0, sizeof(shpool));
+    zone.shm.addr = &shpool;
+    zone.shm.exists = 1;
+    shpool.data = NULL;
+    rc = ngx_http_markdown_init_metrics_zone(&zone, NULL);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "existing shm without data should fail");
+
+    memset(&zone, 0, sizeof(zone));
+    memset(&shpool, 0, sizeof(shpool));
+    zone.shm.addr = &shpool;
+    zone.shm.exists = 0;
+    g_slab_alloc_fail = 0;
+    rc = ngx_http_markdown_init_metrics_zone(&zone, NULL);
+    TEST_ASSERT(rc == NGX_OK, "fresh allocation should succeed");
+    TEST_ASSERT(zone.data != NULL, "zone data should be set");
+    TEST_ASSERT(shpool.data == zone.data, "slab and zone pointers should match");
+
+    new_metrics = zone.data;
+    TEST_ASSERT(new_metrics->conversions_attempted == 0,
+        "fresh metrics should be zero-initialized");
+
+    memset(&zone, 0, sizeof(zone));
+    memset(&shpool, 0, sizeof(shpool));
+    zone.shm.addr = &shpool;
+    zone.shm.exists = 0;
+    g_slab_alloc_fail = 1;
+    rc = ngx_http_markdown_init_metrics_zone(&zone, NULL);
+    TEST_ASSERT(rc == NGX_ERROR, "allocation failure should fail init");
+    g_slab_alloc_fail = 0;
+
+    TEST_PASS("metrics zone init branches covered");
+}
+
+static void
+test_main_conf_create_and_init(void)
+{
+    ngx_conf_t cf;
+    ngx_http_markdown_main_conf_t *mcf;
+    ngx_shm_zone_t zone;
+    char *rc;
+
+    TEST_SUBSECTION("main conf create/init");
+
+    memset(&cf, 0, sizeof(cf));
+    cf.pool = &g_pool;
+
+    mcf = ngx_http_markdown_create_main_conf(&cf);
+    TEST_ASSERT(mcf != NULL, "create_main_conf should allocate");
+    TEST_ASSERT(mcf->metrics_shm_size == NGX_CONF_UNSET_SIZE,
+        "metrics_shm_size should be unset");
+    TEST_ASSERT(mcf->metrics_shm_zone == NULL,
+        "metrics_shm_zone should start NULL");
+
+    memset(&zone, 0, sizeof(zone));
+    g_shared_zone = &zone;
+    g_shared_size = 0;
+
+    rc = ngx_http_markdown_init_main_conf(&cf, mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "init_main_conf should succeed");
+    TEST_ASSERT(mcf->metrics_shm_size == 8 * ngx_pagesize,
+        "default shm size should be 8 pages");
+    TEST_ASSERT(mcf->metrics_shm_zone == &zone,
+        "main conf should store zone pointer");
+    TEST_ASSERT(ngx_http_markdown_metrics_shm_zone == &zone,
+        "global metrics shm zone should be updated");
+    TEST_ASSERT(zone.init == ngx_http_markdown_init_metrics_zone,
+        "zone init callback should be set");
+
+    g_shared_zone = NULL;
+    rc = ngx_http_markdown_init_main_conf(&cf, mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "shared memory add failure should return conf error");
+
+    TEST_PASS("main conf create/init branches covered");
+}
+
+static void
+test_create_conf_defaults(void)
+{
+    ngx_conf_t cf;
+    ngx_http_markdown_conf_t *conf;
+
+    TEST_SUBSECTION("create_conf defaults");
+
+    memset(&cf, 0, sizeof(cf));
+    cf.pool = &g_pool;
+
+    conf = ngx_http_markdown_create_conf(&cf);
+    TEST_ASSERT(conf != NULL, "create_conf should allocate");
+
+    TEST_ASSERT(conf->enabled_source == NGX_HTTP_MARKDOWN_ENABLED_UNSET,
+        "enabled source default should be unset");
+    TEST_ASSERT(conf->max_size == NGX_CONF_UNSET_SIZE,
+        "max_size should be unset");
+    TEST_ASSERT(conf->timeout == NGX_CONF_UNSET_MSEC,
+        "timeout should be unset");
+    TEST_ASSERT(conf->ops.metrics_format == NGX_CONF_UNSET_UINT,
+        "metrics format should be unset");
+    TEST_ASSERT(conf->streaming_budget == NGX_CONF_UNSET_SIZE,
+        "streaming budget should be unset");
+
+    TEST_PASS("create_conf defaults covered");
+}
+
+static void
+test_merge_conf(void)
+{
+    ngx_conf_t cf;
+    ngx_http_markdown_conf_t parent;
+    ngx_http_markdown_conf_t child;
+    ngx_http_complex_value_t cv;
+    char *rc;
+
+    TEST_SUBSECTION("merge_conf inheritance/defaults");
+
+    memset(&cf, 0, sizeof(cf));
+    cf.pool = &g_pool;
+
+    memset(&parent, 0, sizeof(parent));
+    memset(&child, 0, sizeof(child));
+
+    parent.enabled = 1;
+    parent.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_COMPLEX;
+    parent.enabled_complex = &cv;
+    parent.max_size = 2048;
+    parent.timeout = 42;
+    parent.on_error = NGX_HTTP_MARKDOWN_ON_ERROR_REJECT;
+    parent.flavor = NGX_HTTP_MARKDOWN_FLAVOR_GFM;
+    parent.token_estimate = 1;
+    parent.front_matter = 1;
+    parent.on_wildcard = 1;
+    parent.auth_policy = NGX_HTTP_MARKDOWN_AUTH_POLICY_DENY;
+    parent.generate_etag = 0;
+    parent.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_DISABLED;
+    parent.log_verbosity = NGX_HTTP_MARKDOWN_LOG_DEBUG;
+    parent.buffer_chunked = 0;
+    parent.auto_decompress = 0;
+    parent.large_body_threshold = 4096;
+    parent.ops.trust_forwarded_headers = 1;
+    parent.ops.metrics_format = NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS;
+    parent.streaming_engine = &cv;
+    parent.streaming_budget = 777;
+    parent.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_REJECT;
+    parent.streaming_shadow = 1;
+
+    child.enabled = NGX_CONF_UNSET;
+    child.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_UNSET;
+    child.max_size = NGX_CONF_UNSET_SIZE;
+    child.timeout = NGX_CONF_UNSET_MSEC;
+    child.on_error = NGX_CONF_UNSET_UINT;
+    child.flavor = NGX_CONF_UNSET_UINT;
+    child.token_estimate = NGX_CONF_UNSET;
+    child.front_matter = NGX_CONF_UNSET;
+    child.on_wildcard = NGX_CONF_UNSET;
+    child.auth_policy = NGX_CONF_UNSET_UINT;
+    child.auth_cookies = NGX_CONF_UNSET_PTR;
+    child.generate_etag = NGX_CONF_UNSET;
+    child.conditional_requests = NGX_CONF_UNSET_UINT;
+    child.log_verbosity = NGX_CONF_UNSET_UINT;
+    child.buffer_chunked = NGX_CONF_UNSET;
+    child.stream_types = NGX_CONF_UNSET_PTR;
+    child.auto_decompress = NGX_CONF_UNSET;
+    child.large_body_threshold = NGX_CONF_UNSET_SIZE;
+    child.ops.trust_forwarded_headers = NGX_CONF_UNSET;
+    child.ops.metrics_format = NGX_CONF_UNSET_UINT;
+    child.streaming_budget = NGX_CONF_UNSET_SIZE;
+    child.streaming_on_error = NGX_CONF_UNSET_UINT;
+    child.streaming_shadow = NGX_CONF_UNSET;
+
+    rc = ngx_http_markdown_merge_conf(&cf, &parent, &child);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "merge_conf should succeed");
+    TEST_ASSERT(child.enabled_source == NGX_HTTP_MARKDOWN_ENABLED_COMPLEX,
+        "child should inherit complex enabled source");
+    TEST_ASSERT(child.enabled_complex == &cv,
+        "child should inherit complex expression");
+    TEST_ASSERT(child.max_size == 2048, "child should inherit max_size");
+    TEST_ASSERT(child.timeout == 42, "child should inherit timeout");
+    TEST_ASSERT(child.streaming_engine == &cv,
+        "child should inherit streaming engine");
+    TEST_ASSERT(child.streaming_budget == 777,
+        "child should inherit streaming budget");
+    TEST_ASSERT(child.streaming_on_error
+        == NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_REJECT,
+        "child should inherit streaming on_error");
+
+    memset(&child, 0, sizeof(child));
+    child.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+    child.enabled = 0;
+    child.enabled_complex = &cv;
+    child.max_size = NGX_CONF_UNSET_SIZE;
+    child.timeout = NGX_CONF_UNSET_MSEC;
+    child.on_error = NGX_CONF_UNSET_UINT;
+    child.flavor = NGX_CONF_UNSET_UINT;
+    child.token_estimate = NGX_CONF_UNSET;
+    child.front_matter = NGX_CONF_UNSET;
+    child.on_wildcard = NGX_CONF_UNSET;
+    child.auth_policy = NGX_CONF_UNSET_UINT;
+    child.auth_cookies = NGX_CONF_UNSET_PTR;
+    child.generate_etag = NGX_CONF_UNSET;
+    child.conditional_requests = NGX_CONF_UNSET_UINT;
+    child.log_verbosity = NGX_CONF_UNSET_UINT;
+    child.buffer_chunked = NGX_CONF_UNSET;
+    child.stream_types = NGX_CONF_UNSET_PTR;
+    child.auto_decompress = NGX_CONF_UNSET;
+    child.large_body_threshold = NGX_CONF_UNSET_SIZE;
+    child.ops.trust_forwarded_headers = NGX_CONF_UNSET;
+    child.ops.metrics_format = NGX_CONF_UNSET_UINT;
+    child.streaming_budget = NGX_CONF_UNSET_SIZE;
+    child.streaming_on_error = NGX_CONF_UNSET_UINT;
+    child.streaming_shadow = NGX_CONF_UNSET;
+
+    rc = ngx_http_markdown_merge_conf(&cf, &parent, &child);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "merge with static child should succeed");
+    TEST_ASSERT(child.enabled_complex == NULL,
+        "static enabled source should clear complex pointer");
+
+    TEST_PASS("merge_conf branches covered");
+}
+
+static void
+test_name_helpers_and_levels(void)
+{
+    const ngx_str_t *name;
+
+    TEST_SUBSECTION("name helpers and verbosity level mapping");
+
+    TEST_ASSERT(ngx_http_markdown_log_verbosity_to_ngx_level(
+            NGX_HTTP_MARKDOWN_LOG_ERROR) == NGX_LOG_ERR,
+        "error verbosity should map to NGX_LOG_ERR");
+    TEST_ASSERT(ngx_http_markdown_log_verbosity_to_ngx_level(
+            NGX_HTTP_MARKDOWN_LOG_WARN) == NGX_LOG_WARN,
+        "warn verbosity should map to NGX_LOG_WARN");
+    TEST_ASSERT(ngx_http_markdown_log_verbosity_to_ngx_level(
+            NGX_HTTP_MARKDOWN_LOG_DEBUG) == NGX_LOG_DEBUG,
+        "debug verbosity should map to NGX_LOG_DEBUG");
+    TEST_ASSERT(ngx_http_markdown_log_verbosity_to_ngx_level(999) == NGX_LOG_INFO,
+        "unknown verbosity should map to NGX_LOG_INFO");
+
+    name = ngx_http_markdown_on_error_name(NGX_HTTP_MARKDOWN_ON_ERROR_PASS);
+    TEST_ASSERT(name->len == strlen("pass"), "on_error pass name");
+    name = ngx_http_markdown_on_error_name(999);
+    TEST_ASSERT(name->len == strlen("unknown"), "on_error unknown name");
+
+    name = ngx_http_markdown_flavor_name(NGX_HTTP_MARKDOWN_FLAVOR_GFM);
+    TEST_ASSERT(name->len == strlen("gfm"), "flavor gfm name");
+
+    name = ngx_http_markdown_auth_policy_name(NGX_HTTP_MARKDOWN_AUTH_POLICY_DENY);
+    TEST_ASSERT(name->len == strlen("deny"), "auth policy deny name");
+
+    name = ngx_http_markdown_conditional_requests_name(
+        NGX_HTTP_MARKDOWN_CONDITIONAL_IF_MODIFIED_SINCE);
+    TEST_ASSERT(name->len == strlen("if_modified_since_only"),
+        "conditional ims_only name");
+
+    name = ngx_http_markdown_log_verbosity_name(NGX_HTTP_MARKDOWN_LOG_DEBUG);
+    TEST_ASSERT(name->len == strlen("debug"), "verbosity debug name");
+
+    name = ngx_http_markdown_metrics_format_name(
+        NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS);
+    TEST_ASSERT(name->len == strlen("prometheus"), "metrics format name");
+
+    name = ngx_http_markdown_compression_name(NGX_HTTP_MARKDOWN_COMPRESSION_GZIP);
+    TEST_ASSERT(name->len == strlen("gzip"), "compression gzip name");
+    name = ngx_http_markdown_compression_name((ngx_http_markdown_compression_type_e) 999);
+    TEST_ASSERT(name->len == strlen("invalid"), "compression invalid name");
+
+    name = ngx_http_markdown_enabled_source_name(NGX_HTTP_MARKDOWN_ENABLED_COMPLEX);
+    TEST_ASSERT(name->len == strlen("complex"), "enabled source name");
+
+    TEST_PASS("name helper branches covered");
+}
+
+static void
+test_filter_flag_and_is_enabled(void)
+{
+    ngx_str_t value;
+    ngx_flag_t enabled;
+    ngx_http_markdown_conf_t conf;
+    ngx_http_complex_value_t cv;
+    ngx_http_request_t req;
+
+    TEST_SUBSECTION("parse_filter_flag and is_enabled");
+
+    TEST_ASSERT(ngx_http_markdown_is_ascii_space(' ') == 1,
+        "space should be recognized");
+    TEST_ASSERT(ngx_http_markdown_is_ascii_space('x') == 0,
+        "non-space should not be recognized");
+
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(NULL, &enabled) == NGX_ERROR,
+        "NULL value should fail parsing");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, NULL) == NGX_ERROR,
+        "NULL output should fail parsing");
+
+    set_str(&value, "  on\t");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, &enabled) == NGX_OK,
+        "on should parse");
+    TEST_ASSERT(enabled == 1, "on should enable");
+
+    set_str(&value, "0");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, &enabled) == NGX_OK,
+        "numeric off should parse");
+    TEST_ASSERT(enabled == 0, "0 should disable");
+
+    set_str(&value, "TRUE");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, &enabled) == NGX_OK,
+        "true should parse case-insensitively");
+    TEST_ASSERT(enabled == 1, "true should enable");
+
+    set_str(&value, "\t ");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, &enabled) == NGX_OK,
+        "empty token after trim should parse");
+    TEST_ASSERT(enabled == 0, "empty token should disable");
+
+    set_str(&value, "maybe");
+    TEST_ASSERT(ngx_http_markdown_parse_filter_flag(&value, &enabled) == NGX_ERROR,
+        "invalid token should fail");
+
+    memset(&conf, 0, sizeof(conf));
+    conf.enabled = 1;
+    conf.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 1,
+        "static enabled should bypass complex evaluation");
+
+    conf.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_COMPLEX;
+    conf.enabled_complex = &cv;
+
+    TEST_ASSERT(ngx_http_markdown_is_enabled(NULL, &conf) == 0,
+        "NULL request should disable complex mode");
+
+    init_complex(&cv, "on", NGX_ERROR);
+    req.connection = &g_conn;
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 0,
+        "complex evaluation failure should disable");
+
+    init_complex(&cv, "maybe", NGX_OK);
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 0,
+        "invalid complex token should disable");
+
+    init_complex(&cv, "off", NGX_OK);
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 0,
+        "complex off should disable");
+
+    init_complex(&cv, "yes", NGX_OK);
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 1,
+        "complex yes should enable");
+
+    TEST_ASSERT(ngx_http_markdown_is_enabled(&req, NULL) == 0,
+        "NULL conf should disable");
+
+    TEST_PASS("parse_filter_flag and is_enabled branches covered");
+}
+
+static void
+test_log_merged_conf(void)
+{
+    ngx_conf_t cf;
+    ngx_http_markdown_conf_t conf;
+    ngx_array_t auth;
+    ngx_array_t stream_types;
+
+    TEST_SUBSECTION("log_merged_conf helper");
+
+    memset(&cf, 0, sizeof(cf));
+    cf.pool = &g_pool;
+
+    memset(&conf, 0, sizeof(conf));
+    conf.log_verbosity = NGX_HTTP_MARKDOWN_LOG_INFO;
+    conf.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+    conf.on_error = NGX_HTTP_MARKDOWN_ON_ERROR_PASS;
+    conf.flavor = NGX_HTTP_MARKDOWN_FLAVOR_COMMONMARK;
+    conf.auth_policy = NGX_HTTP_MARKDOWN_AUTH_POLICY_ALLOW;
+    conf.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_FULL_SUPPORT;
+    conf.ops.metrics_format = NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO;
+
+    memset(&auth, 0, sizeof(auth));
+    auth.nelts = 2;
+    conf.auth_cookies = &auth;
+
+    memset(&stream_types, 0, sizeof(stream_types));
+    stream_types.nelts = 1;
+    conf.stream_types = &stream_types;
+
+    ngx_http_markdown_log_merged_conf(NULL, &conf);
+    ngx_http_markdown_log_merged_conf(&cf, &conf);
+
+    TEST_PASS("log_merged_conf covered");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("config_core_impl Tests\n");
+    printf("========================================\n");
+
+    test_metrics_zone_init();
+    test_main_conf_create_and_init();
+    test_create_conf_defaults();
+    test_merge_conf();
+    test_name_helpers_and_levels();
+    test_filter_flag_and_is_enabled();
+    test_log_merged_conf();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+
+    return 0;
+}

--- a/components/nginx-module/tests/unit/config_core_impl_test.c
+++ b/components/nginx-module/tests/unit/config_core_impl_test.c
@@ -742,6 +742,7 @@ test_filter_flag_and_is_enabled(void)
     memset(&conf, 0, sizeof(conf));
     conf.enabled = 1;
     conf.enabled_source = NGX_HTTP_MARKDOWN_ENABLED_STATIC;
+    memset(&req, 0, sizeof(req));
     TEST_ASSERT(ngx_http_markdown_is_enabled(&req, &conf) == 1,
         "static enabled should bypass complex evaluation");
 

--- a/components/nginx-module/tests/unit/config_core_impl_test.c
+++ b/components/nginx-module/tests/unit/config_core_impl_test.c
@@ -22,7 +22,7 @@
 #define NGX_CONF_OK ((char *) NULL)
 #endif
 #ifndef NGX_CONF_ERROR
-#define NGX_CONF_ERROR ((char *) 1)
+#define NGX_CONF_ERROR ((char *) -1)
 #endif
 
 #ifndef NGX_CONF_UNSET

--- a/components/nginx-module/tests/unit/config_core_impl_test.c
+++ b/components/nginx-module/tests/unit/config_core_impl_test.c
@@ -104,15 +104,24 @@ struct ngx_shm_zone_s {
     ngx_int_t (*init)(ngx_shm_zone_t *zone, void *data);
 };
 
+/* Global module symbol required by the config implementation header. */
 ngx_module_t ngx_http_markdown_filter_module;
 ngx_str_t ngx_http_markdown_metrics_shm_name = ngx_string("markdown_metrics");
 ngx_shm_zone_t *ngx_http_markdown_metrics_shm_zone = NULL;
 
+/* Test-controlled state for allocator and SHM stubs. */
 static size_t ngx_pagesize = 4096;
 static ngx_shm_zone_t *g_shared_zone;
 static size_t g_shared_size;
 static ngx_int_t g_slab_alloc_fail;
 
+/*
+ * NGINX configuration merge macros (test-local definitions).
+ * These replicate the standard ngx_conf_merge_* family for environments
+ * where the real NGINX headers are unavailable.  Each macro assigns
+ * default_value when conf is at its unset sentinel, inheriting from
+ * prev if prev is not also unset.
+ */
 #define ngx_conf_init_size_value(conf, default_value) \
     if ((conf) == NGX_CONF_UNSET_SIZE) {              \
         (conf) = (default_value);                      \
@@ -174,6 +183,16 @@ static ngx_int_t g_slab_alloc_fail;
  * If production NGINX semantics for these primitives change, dependent tests
  * in this file must be reviewed and updated to keep branch expectations valid.
  */
+/*
+ * Case-insensitive comparison of the first n bytes of s1 and s2.
+ *
+ * Returns 0 if equal, or the difference of the first mismatching
+ * lowercased byte (cast to ngx_int_t) otherwise.
+ *
+ * Note: this is a test-local reimplementation of the NGINX primitive
+ * because the production symbol cannot be linked in the unit harness.
+ * It mirrors the semantic contract of ngx_strncasecmp in ngx_string.h.
+ */
 static ngx_int_t
 ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
 {
@@ -194,6 +213,11 @@ ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
     return 0;
 }
 
+/*
+ * No-op stub for ngx_conf_log_error.  Consumes the variadic argument list
+ * without producing output, since the unit harness has no real NGINX log
+ * cycle.  All parameters are marked UNUSED to suppress compiler warnings.
+ */
 static void
 ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
     const char *fmt, ...)
@@ -208,6 +232,11 @@ ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
     va_end(ap);
 }
 
+/*
+ * Pool allocator stub that delegates to calloc(3).  Ignores the pool
+ * argument and always zero-initializes, matching the semantic guarantee
+ * of the production ngx_pcalloc.
+ */
 static void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
@@ -215,12 +244,21 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     return calloc(1, size);
 }
 
+/*
+ * Zero-fill wrapper delegating to memset(3).  Mirrors the production
+ * ngx_memzero macro semantics for the unit harness.
+ */
 static void
 ngx_memzero(void *p, size_t n)
 {
     memset(p, 0, n);
 }
 
+/*
+ * Slab allocator stub.  Returns NULL when g_slab_alloc_fail is set
+ * (simulating shared-memory pressure), otherwise delegates to calloc(3).
+ * The pool argument is unused in this stub.
+ */
 static void *
 ngx_slab_alloc(ngx_slab_pool_t *pool, size_t size)
 {
@@ -233,6 +271,11 @@ ngx_slab_alloc(ngx_slab_pool_t *pool, size_t size)
     return calloc(1, size);
 }
 
+/*
+ * Shared-memory zone registration stub.  Records the requested size in
+ * g_shared_size and returns the preconfigured g_shared_zone pointer.
+ * cf, name, and module are unused in this stub.
+ */
 static ngx_shm_zone_t *
 ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
     ngx_module_t *module)
@@ -245,6 +288,12 @@ ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
     return g_shared_zone;
 }
 
+/*
+ * Complex value evaluation stub.  Copies val->value to the output and
+ * returns val->eval_rc, allowing tests to control both the resolved
+ * string and the return code.  Returns NGX_ERROR if either pointer is
+ * NULL.
+ */
 static ngx_int_t
 ngx_http_complex_value(ngx_http_request_t *r,
     ngx_http_complex_value_t *val, ngx_str_t *value)
@@ -265,6 +314,11 @@ static ngx_pool_t g_pool;
 static ngx_log_t g_log;
 static ngx_connection_t g_conn = { &g_log };
 
+/*
+ * Assign a C string literal to an ngx_str_t.  Sets data to the literal
+ * pointer (cast through uintptr_t to satisfy the u_char* type) and len
+ * to the string length.  The caller must ensure src outlives dst.
+ */
 static void
 set_str(ngx_str_t *dst, const char *src)
 {
@@ -272,6 +326,11 @@ set_str(ngx_str_t *dst, const char *src)
     dst->len = strlen(src);
 }
 
+/*
+ * Initialize a complex value stub with a fixed string and return code.
+ * The test harness will return these when ngx_http_complex_value is
+ * called with this object.
+ */
 static void
 init_complex(ngx_http_complex_value_t *cv, const char *value, ngx_int_t rc)
 {
@@ -279,6 +338,15 @@ init_complex(ngx_http_complex_value_t *cv, const char *value, ngx_int_t rc)
     cv->eval_rc = rc;
 }
 
+/*
+ * Verify ngx_http_markdown_init_metrics_zone branch coverage:
+ *  - reuse path when old_metrics is provided (zone.data preserved);
+ *  - NULL slab pool detection (NGX_ERROR);
+ *  - existing SHM with valid data pointer (attach);
+ *  - existing SHM with NULL data (NGX_ERROR);
+ *  - fresh allocation on non-existing SHM (zero-initialized metrics);
+ *  - slab allocation failure (g_slab_alloc_fail simulation).
+ */
 static void
 test_metrics_zone_init(void)
 {
@@ -346,6 +414,14 @@ test_metrics_zone_init(void)
     TEST_PASS("metrics zone init branches covered");
 }
 
+/*
+ * Verify create_main_conf and init_main_conf:
+ *  - create_main_conf allocates and returns a zeroed main conf with
+ *    metrics_shm_size unset and metrics_shm_zone NULL;
+ *  - init_main_conf applies the default SHM size (8 pages), stores the
+ *    zone pointer, and sets the init callback;
+ *  - init_main_conf returns NGX_CONF_ERROR when shared_memory_add fails.
+ */
 static void
 test_main_conf_create_and_init(void)
 {
@@ -390,6 +466,11 @@ test_main_conf_create_and_init(void)
     TEST_PASS("main conf create/init branches covered");
 }
 
+/*
+ * Verify that create_conf initializes all fields to their NGINX unset
+ * sentinel values (NGX_CONF_UNSET_SIZE, NGX_CONF_UNSET_MSEC, etc.),
+ * ensuring merge_conf will later inherit from the parent.
+ */
 static void
 test_create_conf_defaults(void)
 {
@@ -418,6 +499,13 @@ test_create_conf_defaults(void)
     TEST_PASS("create_conf defaults covered");
 }
 
+/*
+ * Verify merge_conf inheritance and override semantics:
+ *  - child fields at their unset sentinels inherit from parent;
+ *  - child with a static enabled_source clears the complex pointer;
+ *  - streaming_engine, streaming_budget, and streaming_on_error are
+ *    inherited from parent when child leaves them unset.
+ */
 static void
 test_merge_conf(void)
 {
@@ -535,6 +623,13 @@ test_merge_conf(void)
     TEST_PASS("merge_conf branches covered");
 }
 
+/*
+ * Verify enum-to-name helpers and log verbosity level mapping:
+ *  - log_verbosity_to_ngx_level maps each verbosity to the correct
+ *    NGINX log level, with unknown values defaulting to NGX_LOG_INFO;
+ *  - on_error_name, flavor_name, auth_policy_name, etc. return the
+ *    expected string length for known and unknown enum values.
+ */
 static void
 test_name_helpers_and_levels(void)
 {
@@ -588,6 +683,17 @@ test_name_helpers_and_levels(void)
     TEST_PASS("name helper branches covered");
 }
 
+/*
+ * Verify parse_filter_flag and is_enabled branch coverage:
+ *  - is_ascii_space recognizes space/tab and rejects non-whitespace;
+ *  - parse_filter_flag rejects NULL inputs, trims whitespace, and
+ *    parses on/off/true/false/1/0/yes/no (case-insensitive);
+ *  - empty token after trimming defaults to disabled;
+ *  - invalid tokens return NGX_ERROR;
+ *  - is_enabled with static source bypasses complex evaluation;
+ *  - is_enabled with complex source evaluates via the stub, handling
+ *    NULL request, evaluation failure, and invalid/off/on tokens.
+ */
 static void
 test_filter_flag_and_is_enabled(void)
 {
@@ -668,6 +774,11 @@ test_filter_flag_and_is_enabled(void)
     TEST_PASS("parse_filter_flag and is_enabled branches covered");
 }
 
+/*
+ * Verify log_merged_conf does not crash with NULL or populated conf
+ * pointers.  The stub log function discards output, so this test
+ * exercises the formatting branches without verifying log text.
+ */
 static void
 test_log_merged_conf(void)
 {
@@ -704,6 +815,10 @@ test_log_merged_conf(void)
     TEST_PASS("log_merged_conf covered");
 }
 
+/*
+ * Entry point: run all config_core_impl unit tests.
+ * Returns 0 on success; aborts via TEST_ASSERT on failure.
+ */
 int
 main(void)
 {

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -19,10 +19,12 @@
 #define NGX_ERROR -1
 #endif
 #ifndef NGX_CONF_OK
-#define NGX_CONF_OK ((char *) "OK")
+static char ngx_conf_ok[] = "OK";
+#define NGX_CONF_OK ngx_conf_ok
 #endif
 #ifndef NGX_CONF_ERROR
-#define NGX_CONF_ERROR ((char *) "ERROR")
+static char ngx_conf_error[] = "ERROR";
+#define NGX_CONF_ERROR ngx_conf_error
 #endif
 
 #ifndef NGX_CONF_UNSET

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -470,72 +470,6 @@ ngx_array_push(ngx_array_t *a)
 }
 
 /*
- * Size parser stub supporting optional k/K/m/M suffixes.
- *
- * Test-local reimplementation of the NGINX primitive because the
- * production symbol cannot be linked in the unit harness.
- *
- * Divergence risk: medium — production ngx_parse_size supports
- * additional suffixes (g/G) and overflow checks; this stub
- * handles only k/K/m/M and performs no overflow detection.
- *
- * Parameters:
- *   line - ngx_str_t containing the size token to parse.
- *
- * Return: parsed size in bytes, or (size_t)NGX_ERROR on invalid
- *         input (NULL, empty, non-numeric, or overflow).
- *
- * Side effects: none.
- */
-static size_t
-ngx_parse_size(ngx_str_t *line)
-{
-    char    buf[64];
-    char   *endptr;
-    size_t  len;
-    size_t  value;
-
-    if (line == NULL || line->data == NULL || line->len == 0) {
-        return (size_t) NGX_ERROR;
-    }
-
-    len = line->len;
-    if (len >= sizeof(buf)) {
-        return (size_t) NGX_ERROR;
-    }
-
-    memcpy(buf, line->data, len);
-    buf[len] = '\0';
-
-    if (len > 1 && (buf[len - 1] == 'k' || buf[len - 1] == 'K'
-                 || buf[len - 1] == 'm' || buf[len - 1] == 'M'))
-    {
-        char suffix;
-
-        suffix = buf[len - 1];
-        buf[len - 1] = '\0';
-
-        value = (size_t) strtoull(buf, &endptr, 10);
-        if (*endptr != '\0') {
-            return (size_t) NGX_ERROR;
-        }
-
-        if (suffix == 'k' || suffix == 'K') {
-            return value * 1024;
-        }
-
-        return value * 1024 * 1024;
-    }
-
-    value = (size_t) strtoull(buf, &endptr, 10);
-    if (*endptr != '\0') {
-        return (size_t) NGX_ERROR;
-    }
-
-    return value;
-}
-
-/*
  * Complex value compilation stub.  Copies the input string to the
  * output complex_value and returns g_compile_complex_rc, allowing
  * tests to control compilation success or failure.
@@ -1084,13 +1018,13 @@ test_stream_types_handler(void)
 }
 
 /*
- * Verify large_body_threshold handler: off, size suffixes (k/m),
+ * Verify large_body_threshold handler: off, size suffixes (k/m/g),
  * invalid token, and duplicate detection.
  *
  * Semantic contract mirrored: ngx_http_markdown_large_body_threshold
- * maps "off" to 0, parses size tokens with optional k/K/m/M
- * suffixes via ngx_parse_size, rejects duplicates, and returns
- * NGX_CONF_ERROR for invalid tokens.
+ * maps "off" to 0, parses size tokens with optional k/K/m/M/g/G
+ * suffixes via the shared production parser helper, rejects
+ * duplicates, and returns NGX_CONF_ERROR for invalid tokens.
  *
  * Return: void.
  *
@@ -1131,6 +1065,28 @@ test_large_body_threshold_handler(void)
     TEST_ASSERT(rc == NGX_CONF_OK, "1m should parse");
     TEST_ASSERT(mcf.large_body_threshold == 1024 * 1024,
         "1m should map correctly");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "1g");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "1g should parse");
+    TEST_ASSERT(mcf.large_body_threshold == (size_t) 1024 * 1024 * 1024,
+        "1g should map correctly");
+
+    init_conf(&mcf);
+    {
+        char overflow_token[32];
+        size_t overflow_value;
+
+        overflow_value = (NGX_MAX_SIZE_T_VALUE
+                          / ((size_t) 1024 * 1024 * 1024)) + 1;
+        snprintf(overflow_token, sizeof(overflow_token), "%zuG",
+            overflow_value);
+        set_arg(&values[1], overflow_token);
+    }
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "overflow threshold token should fail");
 
     init_conf(&mcf);
     set_arg(&values[1], "bad");

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -99,12 +99,35 @@ typedef struct {
     ngx_int_t (*handler)(ngx_http_request_t *r);
 } ngx_http_core_loc_conf_t;
 
+/*
+ * Global module symbols required by the config implementation header.
+ * These are referenced by the production code but never dereferenced
+ * in the unit harness.
+ */
 ngx_module_t ngx_http_markdown_filter_module;
 ngx_module_t ngx_http_core_module;
 
+/*
+ * Test-controlled state for stub return values.
+ * g_clcf:          pointer returned by ngx_http_conf_get_module_loc_conf;
+ *                  tests set it to control the core location configuration.
+ * g_compile_complex_rc: return code for ngx_http_compile_complex_value;
+ *                  tests set it to simulate compilation success or failure.
+ */
 static ngx_http_core_loc_conf_t *g_clcf;
 static ngx_int_t g_compile_complex_rc;
 
+/*
+ * No-op stub for the metrics content handler.
+ *
+ * Parameters:
+ *   r  - HTTP request (unused in the unit harness).
+ *
+ * Return: NGX_OK unconditionally; the unit harness does not exercise
+ *         HTTP request processing.
+ *
+ * Side effects: none.
+ */
 static ngx_int_t
 ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
 {
@@ -112,6 +135,28 @@ ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
     return NGX_OK;
 }
 
+/*
+ * Case-insensitive comparison of the first n bytes.
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — logic is a direct transliteration of
+ * ngx_ascii_strncasecmp in src/core/ngx_string.c; any future
+ * change to the production locale handling or byte folding would
+ * require a corresponding update here.
+ *
+ * Parameters:
+ *   s1 - first byte string.
+ *   s2 - second byte string.
+ *   n  - number of leading bytes to compare.
+ *
+ * Return: 0 if all n bytes match case-insensitively; otherwise the
+ *         difference between the lowercased mismatching bytes
+ *         (s1[i] - s2[i]).
+ *
+ * Side effects: none.
+ */
 static ngx_int_t
 ngx_ascii_strncasecmp(const u_char *s1, const u_char *s2, size_t n)
 {
@@ -132,6 +177,26 @@ ngx_ascii_strncasecmp(const u_char *s1, const u_char *s2, size_t n)
     return 0;
 }
 
+/*
+ * Null-terminated case-insensitive string comparison.
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — mirrors ngx_strcasecmp in
+ * src/core/ngx_string.c; changes to the production early-exit or
+ * NULL-handling semantics would require a corresponding update.
+ *
+ * Parameters:
+ *   s1 - first null-terminated byte string.
+ *   s2 - second null-terminated byte string.
+ *
+ * Return: NGX_ERROR if either pointer is NULL; otherwise 0 on
+ *         equality, or the difference between the lowercased
+ *         mismatching bytes.
+ *
+ * Side effects: none.
+ */
 static ngx_int_t
 ngx_strcasecmp(u_char *s1, u_char *s2)
 {
@@ -157,12 +222,49 @@ ngx_strcasecmp(u_char *s1, u_char *s2)
          - (ngx_int_t) tolower((unsigned char) s2[i]);
 }
 
+/*
+ * Length-bounded case-insensitive comparison delegating to
+ * ngx_ascii_strncasecmp.
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — thin wrapper; any change to the
+ * production delegation target would require an update here.
+ *
+ * Parameters:
+ *   s1 - first byte string.
+ *   s2 - second byte string.
+ *   n  - maximum number of bytes to compare.
+ *
+ * Return: value from ngx_ascii_strncasecmp.
+ *
+ * Side effects: none.
+ */
 static ngx_int_t
 ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
 {
     return ngx_ascii_strncasecmp(s1, s2, n);
 }
 
+/*
+ * Search for byte c in the range [p, last).
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — mirrors ngx_strlchr in
+ * src/core/ngx_string.c.
+ *
+ * Parameters:
+ *   p    - start of search range (inclusive).
+ *   last - end of search range (exclusive).
+ *   c    - byte value to find.
+ *
+ * Return: pointer to the first occurrence of c, or NULL if not found.
+ *
+ * Side effects: none.
+ */
 static u_char *
 ngx_strlchr(u_char *p, u_char *last, u_char c)
 {
@@ -176,18 +278,71 @@ ngx_strlchr(u_char *p, u_char *last, u_char c)
     return NULL;
 }
 
+/*
+ * Thin wrapper around strchr(3) with u_char* return type.
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — one-line wrapper; any change to the
+ * production signature would require an update here.
+ *
+ * Parameters:
+ *   s - null-terminated byte string to search.
+ *   c - character value to find.
+ *
+ * Return: pointer to the first occurrence of c, or NULL.
+ *
+ * Side effects: none.
+ */
 static u_char *
 ngx_strchr(const u_char *s, int c)
 {
     return (u_char *) strchr((const char *) s, c);
 }
 
+/*
+ * Zero-fill wrapper delegating to memset(3).
+ *
+ * Mirrors production ngx_memzero; test-local reimplementation
+ * because the production macro cannot be linked in the unit harness.
+ *
+ * Divergence risk: low — direct transliteration of the production
+ * macro.
+ *
+ * Parameters:
+ *   p - pointer to the memory region to zero.
+ *   n - number of bytes to zero.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies the memory region pointed to by p.
+ */
 static void
 ngx_memzero(void *p, size_t n)
 {
     memset(p, 0, n);
 }
 
+/*
+ * Pool allocator stub delegating to malloc(3).
+ *
+ * Does not zero-initialize (unlike ngx_pcalloc).  The pool
+ * argument is ignored; the unit harness does not simulate pool
+ * ownership or cleanup.
+ *
+ * Divergence risk: medium — production ngx_palloc may return
+ * previously-freed pool memory or trigger pool expansion; this
+ * stub always calls malloc, so allocation patterns differ.
+ *
+ * Parameters:
+ *   pool - memory pool (unused).
+ *   size - number of bytes to allocate.
+ *
+ * Return: pointer to allocated memory, or NULL on failure.
+ *
+ * Side effects: allocates heap memory via malloc(3).
+ */
 static void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
@@ -195,6 +350,24 @@ ngx_palloc(ngx_pool_t *pool, size_t size)
     return malloc(size);
 }
 
+/*
+ * Pool allocator stub delegating to calloc(3).
+ *
+ * Always zero-initializes.  The pool argument is ignored; the unit
+ * harness does not simulate pool ownership or cleanup.
+ *
+ * Divergence risk: medium — production ngx_pcalloc may return
+ * previously-freed pool memory; this stub always calls calloc,
+ * so allocation patterns differ.
+ *
+ * Parameters:
+ *   pool - memory pool (unused).
+ *   size - number of bytes to allocate.
+ *
+ * Return: pointer to zero-initialized memory, or NULL on failure.
+ *
+ * Side effects: allocates heap memory via calloc(3).
+ */
 static void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
@@ -202,6 +375,23 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     return calloc(1, size);
 }
 
+/*
+ * Array creation stub.  Allocates the array header and element
+ * storage via calloc(3).  The pool argument is ignored.
+ *
+ * Divergence risk: medium — production ngx_array_create allocates
+ * from the pool and does not guarantee zero-initialization of
+ * elements; this stub uses calloc, so elements are always zeroed.
+ *
+ * Parameters:
+ *   pool - memory pool (unused).
+ *   n    - initial number of elements to allocate (0 is promoted to 1).
+ *   size - size of each element in bytes.
+ *
+ * Return: pointer to the new array, or NULL on allocation failure.
+ *
+ * Side effects: allocates heap memory via calloc(3).
+ */
 static ngx_array_t *
 ngx_array_create(ngx_pool_t *pool, ngx_uint_t n, size_t size)
 {
@@ -226,6 +416,25 @@ ngx_array_create(ngx_pool_t *pool, ngx_uint_t n, size_t size)
     return a;
 }
 
+/*
+ * Array push stub.  Doubles storage on overflow via realloc(3),
+ * zero-initializing new slots.  Returns NULL on NULL input or
+ * allocation failure.
+ *
+ * Divergence risk: medium — production ngx_array_push allocates
+ * from the pool and may not zero-initialize new elements; this
+ * stub uses realloc and explicit memset, so behaviour differs
+ * for uninitialized-element reads.
+ *
+ * Parameters:
+ *   a - pointer to the array to push into.
+ *
+ * Return: pointer to the newly pushed element (zero-initialized),
+ *         or NULL on NULL input or allocation failure.
+ *
+ * Side effects: may reallocate the element buffer; modifies a->nelts
+ *               and a->nalloc on growth.
+ */
 static void *
 ngx_array_push(ngx_array_t *a)
 {
@@ -260,6 +469,24 @@ ngx_array_push(ngx_array_t *a)
     return elt;
 }
 
+/*
+ * Size parser stub supporting optional k/K/m/M suffixes.
+ *
+ * Test-local reimplementation of the NGINX primitive because the
+ * production symbol cannot be linked in the unit harness.
+ *
+ * Divergence risk: medium — production ngx_parse_size supports
+ * additional suffixes (g/G) and overflow checks; this stub
+ * handles only k/K/m/M and performs no overflow detection.
+ *
+ * Parameters:
+ *   line - ngx_str_t containing the size token to parse.
+ *
+ * Return: parsed size in bytes, or (size_t)NGX_ERROR on invalid
+ *         input (NULL, empty, non-numeric, or overflow).
+ *
+ * Side effects: none.
+ */
 static size_t
 ngx_parse_size(ngx_str_t *line)
 {
@@ -308,6 +535,25 @@ ngx_parse_size(ngx_str_t *line)
     return value;
 }
 
+/*
+ * Complex value compilation stub.  Copies the input string to the
+ * output complex_value and returns g_compile_complex_rc, allowing
+ * tests to control compilation success or failure.
+ *
+ * Divergence risk: high — production ngx_http_compile_complex_value
+ * parses NGINX variable expressions and builds a bytecode program;
+ * this stub performs a shallow copy only, so variable resolution
+ * at request time is not exercised.
+ *
+ * Parameters:
+ *   ccv - compilation context containing cf, value, and
+ *         complex_value pointers.
+ *
+ * Return: g_compile_complex_rc (NGX_OK or NGX_ERROR as set by
+ *         the test), or NGX_ERROR if ccv or its members are NULL.
+ *
+ * Side effects: writes to ccv->complex_value->value on success.
+ */
 static ngx_int_t
 ngx_http_compile_complex_value(ngx_http_compile_complex_value_t *ccv)
 {
@@ -319,6 +565,22 @@ ngx_http_compile_complex_value(ngx_http_compile_complex_value_t *ccv)
     return g_compile_complex_rc;
 }
 
+/*
+ * No-op stub for ngx_conf_log_error.  Consumes variadic args
+ * without output, silencing configuration error logging in the
+ * unit harness.
+ *
+ * Parameters:
+ *   level - log level (unused).
+ *   cf    - configuration context (unused).
+ *   err   - error code (unused).
+ *   fmt   - printf-style format string (consumed but not printed).
+ *   ...   - format arguments (consumed but not printed).
+ *
+ * Return: void.
+ *
+ * Side effects: none (va_start/va_end pair consumes args only).
+ */
 static void
 ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
     const char *fmt, ...)
@@ -333,6 +595,19 @@ ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
     va_end(ap);
 }
 
+/*
+ * Returns the preconfigured g_clcf pointer, allowing tests to
+ * control the core location configuration without linking the
+ * full NGINX HTTP module infrastructure.
+ *
+ * Parameters:
+ *   cf     - configuration context (unused).
+ *   module - module identifier (unused).
+ *
+ * Return: g_clcf as set by the test.
+ *
+ * Side effects: none.
+ */
 static void *
 ngx_http_conf_get_module_loc_conf(ngx_conf_t *cf, ngx_module_t module)
 {
@@ -345,6 +620,19 @@ ngx_http_conf_get_module_loc_conf(ngx_conf_t *cf, ngx_module_t module)
 
 static ngx_pool_t g_pool;
 
+/*
+ * Assign a C string literal to an ngx_str_t.  Casts through
+ * uintptr_t for u_char* compatibility to avoid compiler warnings
+ * about discarding const from string literals.
+ *
+ * Parameters:
+ *   arg - pointer to the ngx_str_t to populate.
+ *   s   - null-terminated C string literal.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies arg->data and arg->len.
+ */
 static void
 set_arg(ngx_str_t *arg, const char *s)
 {
@@ -352,6 +640,21 @@ set_arg(ngx_str_t *arg, const char *s)
     arg->len = strlen(s);
 }
 
+/*
+ * Wire up an ngx_conf_t with a pool and an args array pointing to
+ * the given values array.  Prepares the configuration structure
+ * used by directive handler invocations in tests.
+ *
+ * Parameters:
+ *   cf    - pointer to the ngx_conf_t to initialize.
+ *   args  - pointer to the ngx_array_t to use as the args array.
+ *   values - array of ngx_str_t values to serve as array elements.
+ *   count  - number of elements in values.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies cf->pool, cf->args, and all fields of args.
+ */
 static void
 setup_cf(ngx_conf_t *cf, ngx_array_t *args, ngx_str_t *values,
     ngx_uint_t count)
@@ -366,6 +669,18 @@ setup_cf(ngx_conf_t *cf, ngx_array_t *args, ngx_str_t *values,
     cf->args = args;
 }
 
+/*
+ * Zero-initialize a location conf and set all enum/pointer fields
+ * to their NGINX unset sentinels.  Ensures each test starts from a
+ * clean, well-defined configuration state.
+ *
+ * Parameters:
+ *   mcf - pointer to the ngx_http_markdown_conf_t to initialize.
+ *
+ * Return: void.
+ *
+ * Side effects: overwrites all fields of *mcf.
+ */
 static void
 init_conf(ngx_http_markdown_conf_t *mcf)
 {
@@ -385,6 +700,18 @@ init_conf(ngx_http_markdown_conf_t *mcf)
     mcf->streaming_engine = NULL;
 }
 
+/*
+ * Verify ngx_http_markdown_arg_equals: NULL data, case-insensitive
+ * match, and length mismatch.
+ *
+ * Semantic contract mirrored: the production arg_equals helper
+ * returns 1 for an exact (case-insensitive, length-equal) match
+ * and 0 otherwise.
+ *
+ * Return: void.
+ *
+ * Side effects: none (assertions only).
+ */
 static void
 test_arg_equals(void)
 {
@@ -407,6 +734,20 @@ test_arg_equals(void)
     TEST_PASS("arg_equals branches covered");
 }
 
+/*
+ * Verify the markdown_filter directive handler: on/off, duplicate
+ * detection, variable compilation, invalid token, and compile
+ * failure.
+ *
+ * Semantic contract mirrored: ngx_http_markdown_filter sets
+ * mcf->enabled and mcf->enabled_source for static tokens, or
+ * mcf->enabled_complex for variable expressions; it rejects
+ * duplicates and invalid tokens.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies g_compile_complex_rc; asserts on mcf fields.
+ */
 static void
 test_markdown_filter_handler(void)
 {
@@ -469,6 +810,18 @@ test_markdown_filter_handler(void)
     TEST_PASS("markdown_filter branches covered");
 }
 
+/*
+ * Verify on_error, flavor, and auth_policy handlers: valid values,
+ * duplicate detection, and invalid values.
+ *
+ * Semantic contract mirrored: each handler maps a string token to
+ * the corresponding enum value in mcf, rejects duplicates, and
+ * returns NGX_CONF_ERROR for unrecognized tokens.
+ *
+ * Return: void.
+ *
+ * Side effects: asserts on mcf enum fields.
+ */
 static void
 test_simple_enum_handlers(void)
 {
@@ -534,6 +887,18 @@ test_simple_enum_handlers(void)
     TEST_PASS("simple enum handlers covered");
 }
 
+/*
+ * Verify auth_cookies handler: multiple patterns, duplicate
+ * detection, and empty pattern rejection.
+ *
+ * Semantic contract mirrored: ngx_http_markdown_auth_cookies
+ * collects one or more glob patterns into an ngx_array_t stored in
+ * mcf->auth_cookies; it rejects duplicates and empty patterns.
+ *
+ * Return: void.
+ *
+ * Side effects: asserts on mcf.auth_cookies array contents.
+ */
 static void
 test_auth_cookies_handler(void)
 {
@@ -579,6 +944,18 @@ test_auth_cookies_handler(void)
     TEST_PASS("auth_cookies branches covered");
 }
 
+/*
+ * Verify conditional_requests and log_verbosity handlers: valid
+ * and invalid enum values.
+ *
+ * Semantic contract mirrored: each handler maps a string token to
+ * the corresponding enum value, rejects duplicates, and returns
+ * NGX_CONF_ERROR for unrecognized tokens.
+ *
+ * Return: void.
+ *
+ * Side effects: asserts on mcf enum fields.
+ */
 static void
 test_conditional_and_log_verbosity_handlers(void)
 {
@@ -636,6 +1013,20 @@ test_conditional_and_log_verbosity_handlers(void)
     TEST_PASS("conditional/log_verbosity branches covered");
 }
 
+/*
+ * Verify stream_types handler: valid types, duplicate detection,
+ * and format validation (no-slash, leading-slash, trailing-slash,
+ * multiple-slashes).
+ *
+ * Semantic contract mirrored: ngx_http_markdown_stream_types
+ * collects MIME type strings of the form "type/subtype" into an
+ * ngx_array_t stored in mcf->stream_types; it rejects duplicates
+ * and malformed type strings.
+ *
+ * Return: void.
+ *
+ * Side effects: asserts on mcf.stream_types array contents.
+ */
 static void
 test_stream_types_handler(void)
 {
@@ -692,6 +1083,19 @@ test_stream_types_handler(void)
     TEST_PASS("stream_types branches covered");
 }
 
+/*
+ * Verify large_body_threshold handler: off, size suffixes (k/m),
+ * invalid token, and duplicate detection.
+ *
+ * Semantic contract mirrored: ngx_http_markdown_large_body_threshold
+ * maps "off" to 0, parses size tokens with optional k/K/m/M
+ * suffixes via ngx_parse_size, rejects duplicates, and returns
+ * NGX_CONF_ERROR for invalid tokens.
+ *
+ * Return: void.
+ *
+ * Side effects: asserts on mcf.large_body_threshold.
+ */
 static void
 test_large_body_threshold_handler(void)
 {
@@ -744,6 +1148,21 @@ test_large_body_threshold_handler(void)
     TEST_PASS("large_body_threshold branches covered");
 }
 
+/*
+ * Verify metrics_format and metrics directive handlers: valid
+ * formats, invalid format, handler installation, and duplicate
+ * content handler.
+ *
+ * Semantic contract mirrored: ngx_http_markdown_metrics_format
+ * maps format tokens to enum values; ngx_http_markdown_metrics_directive
+ * installs the metrics content handler in the core location
+ * configuration and rejects duplicates.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies g_clcf; asserts on mcf.ops.metrics_format
+ *               and clcf.handler.
+ */
 static void
 test_metrics_handlers(void)
 {
@@ -804,6 +1223,21 @@ test_metrics_handlers(void)
     TEST_PASS("metrics handler branches covered");
 }
 
+/*
+ * Verify streaming_engine handler: static values, duplicate
+ * detection, variable compilation, and compile failure.
+ *
+ * Semantic contract mirrored: ngx_http_markdown_streaming_engine
+ * accepts static tokens or NGINX variable expressions, stores the
+ * compiled complex value in mcf->streaming_engine, rejects
+ * duplicates, and returns NGX_CONF_ERROR for invalid tokens or
+ * compilation failures.
+ *
+ * Return: void.
+ *
+ * Side effects: modifies g_compile_complex_rc; asserts on
+ *               mcf.streaming_engine.
+ */
 static void
 test_streaming_engine_handler(void)
 {
@@ -856,6 +1290,13 @@ test_streaming_engine_handler(void)
     TEST_PASS("streaming_engine branches covered");
 }
 
+/*
+ * Entry point: run all config_handlers_impl unit tests.
+ *
+ * Return: 0 on success (all assertions pass).
+ *
+ * Side effects: writes test progress to stdout.
+ */
 int
 main(void)
 {

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -1,0 +1,881 @@
+/*
+ * Test: config_handlers_impl
+ * Description: direct branch coverage for config directive handlers.
+ */
+
+#include "../include/test_common.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+
+#define MARKDOWN_STREAMING_ENABLED 1
+
+#include "../../src/ngx_http_markdown_filter_module.h"
+
+#ifndef NGX_OK
+#define NGX_OK 0
+#endif
+#ifndef NGX_ERROR
+#define NGX_ERROR -1
+#endif
+#ifndef NGX_CONF_OK
+#define NGX_CONF_OK ((char *) "OK")
+#endif
+#ifndef NGX_CONF_ERROR
+#define NGX_CONF_ERROR ((char *) "ERROR")
+#endif
+
+#ifndef NGX_CONF_UNSET
+#define NGX_CONF_UNSET (-1)
+#endif
+#ifndef NGX_CONF_UNSET_UINT
+#define NGX_CONF_UNSET_UINT ((ngx_uint_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_SIZE
+#define NGX_CONF_UNSET_SIZE ((size_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_PTR
+#define NGX_CONF_UNSET_PTR ((void *) -1)
+#endif
+
+#ifndef NGX_LOG_EMERG
+#define NGX_LOG_EMERG 1
+#endif
+#ifndef NGX_LOG_DEBUG
+#define NGX_LOG_DEBUG 2
+#endif
+#ifndef NGX_LOG_INFO
+#define NGX_LOG_INFO 3
+#endif
+
+#ifndef NGX_MAX_SIZE_T_VALUE
+#define NGX_MAX_SIZE_T_VALUE ((size_t) -1)
+#endif
+
+typedef intptr_t ngx_err_t;
+
+struct ngx_pool_s {
+    int dummy;
+};
+
+struct ngx_array_s {
+    void       *elts;
+    ngx_uint_t  nelts;
+    size_t      size;
+    ngx_uint_t  nalloc;
+    ngx_pool_t *pool;
+};
+
+struct ngx_http_request_s {
+    int dummy;
+};
+
+struct ngx_http_complex_value_s {
+    ngx_str_t  value;
+};
+
+typedef struct {
+    ngx_conf_t                 *cf;
+    ngx_str_t                  *value;
+    ngx_http_complex_value_t   *complex_value;
+} ngx_http_compile_complex_value_t;
+
+struct ngx_conf_s {
+    ngx_pool_t  *pool;
+    ngx_array_t *args;
+};
+
+struct ngx_command_s {
+    ngx_str_t  name;
+};
+
+struct ngx_module_s {
+    int dummy;
+};
+
+typedef struct {
+    ngx_int_t (*handler)(ngx_http_request_t *r);
+} ngx_http_core_loc_conf_t;
+
+ngx_module_t ngx_http_markdown_filter_module;
+ngx_module_t ngx_http_core_module;
+
+static ngx_http_core_loc_conf_t *g_clcf;
+static ngx_int_t g_compile_complex_rc;
+
+static ngx_int_t
+ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    return NGX_OK;
+}
+
+static ngx_int_t
+ngx_ascii_strncasecmp(const u_char *s1, const u_char *s2, size_t n)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        u_char c1;
+        u_char c2;
+
+        c1 = (u_char) tolower((unsigned char) s1[i]);
+        c2 = (u_char) tolower((unsigned char) s2[i]);
+
+        if (c1 != c2) {
+            return (ngx_int_t) c1 - (ngx_int_t) c2;
+        }
+    }
+
+    return 0;
+}
+
+static ngx_int_t
+ngx_strcasecmp(u_char *s1, u_char *s2)
+{
+    size_t i;
+
+    if (s1 == NULL || s2 == NULL) {
+        return NGX_ERROR;
+    }
+
+    i = 0;
+    while (s1[i] != '\0' && s2[i] != '\0') {
+        ngx_int_t diff;
+
+        diff = ngx_ascii_strncasecmp(&s1[i], &s2[i], 1);
+        if (diff != 0) {
+            return diff;
+        }
+
+        i++;
+    }
+
+    return (ngx_int_t) tolower((unsigned char) s1[i])
+         - (ngx_int_t) tolower((unsigned char) s2[i]);
+}
+
+static ngx_int_t
+ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
+{
+    return ngx_ascii_strncasecmp(s1, s2, n);
+}
+
+static u_char *
+ngx_strlchr(u_char *p, u_char *last, u_char c)
+{
+    while (p < last) {
+        if (*p == c) {
+            return p;
+        }
+        p++;
+    }
+
+    return NULL;
+}
+
+static u_char *
+ngx_strchr(const u_char *s, int c)
+{
+    return (u_char *) strchr((const char *) s, c);
+}
+
+static void
+ngx_memzero(void *p, size_t n)
+{
+    memset(p, 0, n);
+}
+
+static void *
+ngx_palloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    return malloc(size);
+}
+
+static void *
+ngx_pcalloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    return calloc(1, size);
+}
+
+static ngx_array_t *
+ngx_array_create(ngx_pool_t *pool, ngx_uint_t n, size_t size)
+{
+    ngx_array_t *a;
+
+    UNUSED(pool);
+
+    a = calloc(1, sizeof(ngx_array_t));
+    if (a == NULL) {
+        return NULL;
+    }
+
+    a->size = size;
+    a->nalloc = (n == 0) ? 1 : n;
+    a->pool = pool;
+    a->elts = calloc(a->nalloc, size);
+    if (a->elts == NULL) {
+        free(a);
+        return NULL;
+    }
+
+    return a;
+}
+
+static void *
+ngx_array_push(ngx_array_t *a)
+{
+    void *elt;
+
+    if (a == NULL) {
+        return NULL;
+    }
+
+    if (a->nelts >= a->nalloc) {
+        void      *new_elts;
+        ngx_uint_t new_nalloc;
+
+        new_nalloc = a->nalloc * 2;
+        new_elts = realloc(a->elts, new_nalloc * a->size);
+        if (new_elts == NULL) {
+            return NULL;
+        }
+
+        memset((u_char *) new_elts + (a->nalloc * a->size),
+               0,
+               (new_nalloc - a->nalloc) * a->size);
+
+        a->elts = new_elts;
+        a->nalloc = new_nalloc;
+    }
+
+    elt = (u_char *) a->elts + (a->nelts * a->size);
+    memset(elt, 0, a->size);
+    a->nelts++;
+
+    return elt;
+}
+
+static size_t
+ngx_parse_size(ngx_str_t *line)
+{
+    char    buf[64];
+    char   *endptr;
+    size_t  len;
+    size_t  value;
+
+    if (line == NULL || line->data == NULL || line->len == 0) {
+        return (size_t) NGX_ERROR;
+    }
+
+    len = line->len;
+    if (len >= sizeof(buf)) {
+        return (size_t) NGX_ERROR;
+    }
+
+    memcpy(buf, line->data, len);
+    buf[len] = '\0';
+
+    if (len > 1 && (buf[len - 1] == 'k' || buf[len - 1] == 'K'
+                 || buf[len - 1] == 'm' || buf[len - 1] == 'M'))
+    {
+        char suffix;
+
+        suffix = buf[len - 1];
+        buf[len - 1] = '\0';
+
+        value = (size_t) strtoull(buf, &endptr, 10);
+        if (*endptr != '\0') {
+            return (size_t) NGX_ERROR;
+        }
+
+        if (suffix == 'k' || suffix == 'K') {
+            return value * 1024;
+        }
+
+        return value * 1024 * 1024;
+    }
+
+    value = (size_t) strtoull(buf, &endptr, 10);
+    if (*endptr != '\0') {
+        return (size_t) NGX_ERROR;
+    }
+
+    return value;
+}
+
+static ngx_int_t
+ngx_http_compile_complex_value(ngx_http_compile_complex_value_t *ccv)
+{
+    if (ccv == NULL || ccv->value == NULL || ccv->complex_value == NULL) {
+        return NGX_ERROR;
+    }
+
+    ccv->complex_value->value = *ccv->value;
+    return g_compile_complex_rc;
+}
+
+static void
+ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
+    const char *fmt, ...)
+{
+    va_list ap;
+
+    UNUSED(level);
+    UNUSED(cf);
+    UNUSED(err);
+
+    va_start(ap, fmt);
+    va_end(ap);
+}
+
+static void *
+ngx_http_conf_get_module_loc_conf(ngx_conf_t *cf, ngx_module_t module)
+{
+    UNUSED(cf);
+    UNUSED(module);
+    return g_clcf;
+}
+
+#include "../../src/ngx_http_markdown_config_handlers_impl.h"
+
+static ngx_pool_t g_pool;
+
+static void
+set_arg(ngx_str_t *arg, const char *s)
+{
+    arg->data = (u_char *) (uintptr_t) s;
+    arg->len = strlen(s);
+}
+
+static void
+setup_cf(ngx_conf_t *cf, ngx_array_t *args, ngx_str_t *values,
+    ngx_uint_t count)
+{
+    args->elts = values;
+    args->nelts = count;
+    args->size = sizeof(ngx_str_t);
+    args->nalloc = count;
+    args->pool = &g_pool;
+
+    cf->pool = &g_pool;
+    cf->args = args;
+}
+
+static void
+init_conf(ngx_http_markdown_conf_t *mcf)
+{
+    memset(mcf, 0, sizeof(*mcf));
+
+    mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_UNSET;
+    mcf->enabled_complex = NULL;
+    mcf->on_error = NGX_CONF_UNSET_UINT;
+    mcf->flavor = NGX_CONF_UNSET_UINT;
+    mcf->auth_policy = NGX_CONF_UNSET_UINT;
+    mcf->auth_cookies = NGX_CONF_UNSET_PTR;
+    mcf->conditional_requests = NGX_CONF_UNSET_UINT;
+    mcf->log_verbosity = NGX_CONF_UNSET_UINT;
+    mcf->stream_types = NGX_CONF_UNSET_PTR;
+    mcf->large_body_threshold = NGX_CONF_UNSET_SIZE;
+    mcf->ops.metrics_format = NGX_CONF_UNSET_UINT;
+    mcf->streaming_engine = NULL;
+}
+
+static void
+test_arg_equals(void)
+{
+    ngx_str_t arg;
+
+    TEST_SUBSECTION("arg_equals helper");
+
+    arg.data = NULL;
+    arg.len = 0;
+    TEST_ASSERT(ngx_http_markdown_arg_equals(&arg, (u_char *) "on", 2) == 0,
+        "NULL arg data should not match");
+
+    set_arg(&arg, "On");
+    TEST_ASSERT(ngx_http_markdown_arg_equals(&arg, (u_char *) "on", 2) == 1,
+        "matching token should be case-insensitive");
+
+    TEST_ASSERT(ngx_http_markdown_arg_equals(&arg, (u_char *) "on", 3) == 0,
+        "mismatched length should fail");
+
+    TEST_PASS("arg_equals branches covered");
+}
+
+static void
+test_markdown_filter_handler(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("markdown_filter handler");
+
+    init_conf(&mcf);
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&cmd.name, "markdown_filter");
+    set_arg(&values[0], "markdown_filter");
+
+    set_arg(&values[1], "on");
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "on should parse");
+    TEST_ASSERT(mcf.enabled == 1, "enabled should be 1");
+    TEST_ASSERT(mcf.enabled_source == NGX_HTTP_MARKDOWN_ENABLED_STATIC,
+        "enabled source should be static");
+
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate should be rejected");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "off should parse");
+    TEST_ASSERT(mcf.enabled == 0, "enabled should be 0");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "$convert");
+    g_compile_complex_rc = NGX_OK;
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "variable should compile");
+    TEST_ASSERT(mcf.enabled_source == NGX_HTTP_MARKDOWN_ENABLED_COMPLEX,
+        "variable should set complex source");
+    TEST_ASSERT(mcf.enabled_complex != NULL,
+        "complex value should be stored");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "yes");
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid static token should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "$bad_compile");
+    g_compile_complex_rc = NGX_ERROR;
+    rc = ngx_http_markdown_filter(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "compile failure should return error");
+
+    g_compile_complex_rc = NGX_OK;
+
+    TEST_PASS("markdown_filter branches covered");
+}
+
+static void
+test_simple_enum_handlers(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("on_error/flavor/auth_policy handlers");
+
+    setup_cf(&cf, &args, values, 2);
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_on_error");
+    set_arg(&values[0], "markdown_on_error");
+    set_arg(&values[1], "pass");
+    rc = ngx_http_markdown_on_error(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "pass should parse");
+    TEST_ASSERT(mcf.on_error == NGX_HTTP_MARKDOWN_ON_ERROR_PASS,
+        "on_error should be pass");
+    rc = ngx_http_markdown_on_error(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate on_error should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "bad");
+    rc = ngx_http_markdown_on_error(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid on_error should fail");
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_flavor");
+    set_arg(&values[0], "markdown_flavor");
+    set_arg(&values[1], "gfm");
+    rc = ngx_http_markdown_flavor(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "gfm should parse");
+    TEST_ASSERT(mcf.flavor == NGX_HTTP_MARKDOWN_FLAVOR_GFM,
+        "flavor should be gfm");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "markdown");
+    rc = ngx_http_markdown_flavor(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid flavor should fail");
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_auth_policy");
+    set_arg(&values[0], "markdown_auth_policy");
+    set_arg(&values[1], "deny");
+    rc = ngx_http_markdown_auth_policy(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "deny should parse");
+    TEST_ASSERT(mcf.auth_policy == NGX_HTTP_MARKDOWN_AUTH_POLICY_DENY,
+        "auth_policy should be deny");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "block");
+    rc = ngx_http_markdown_auth_policy(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid auth policy should fail");
+
+    TEST_PASS("simple enum handlers covered");
+}
+
+static void
+test_auth_cookies_handler(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[4];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    ngx_str_t               *elts;
+    char                    *rc;
+
+    TEST_SUBSECTION("auth_cookies handler");
+
+    init_conf(&mcf);
+    setup_cf(&cf, &args, values, 4);
+    set_arg(&cmd.name, "markdown_auth_cookies");
+
+    set_arg(&values[0], "markdown_auth_cookies");
+    set_arg(&values[1], "session*");
+    set_arg(&values[2], "*token");
+    set_arg(&values[3], "auth");
+
+    rc = ngx_http_markdown_auth_cookies(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "cookie patterns should parse");
+    TEST_ASSERT(mcf.auth_cookies != NULL, "cookie array should be created");
+    TEST_ASSERT(mcf.auth_cookies->nelts == 3, "three patterns expected");
+
+    elts = mcf.auth_cookies->elts;
+    TEST_ASSERT(elts[0].len == strlen("session*"), "pattern 0 length");
+    TEST_ASSERT(elts[1].len == strlen("*token"), "pattern 1 length");
+    TEST_ASSERT(elts[2].len == strlen("auth"), "pattern 2 length");
+
+    rc = ngx_http_markdown_auth_cookies(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate auth_cookies should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "");
+    rc = ngx_http_markdown_auth_cookies(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "empty pattern should fail");
+
+    TEST_PASS("auth_cookies branches covered");
+}
+
+static void
+test_conditional_and_log_verbosity_handlers(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("conditional_requests/log_verbosity handlers");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&values[0], "directive");
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_conditional_requests");
+    set_arg(&values[1], "if_modified_since_only");
+    rc = ngx_http_markdown_conditional_requests(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "ims_only should parse");
+    TEST_ASSERT(mcf.conditional_requests
+        == NGX_HTTP_MARKDOWN_CONDITIONAL_IF_MODIFIED_SINCE,
+        "conditional mode should match");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "disabled");
+    rc = ngx_http_markdown_conditional_requests(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "disabled should parse");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "invalid");
+    rc = ngx_http_markdown_conditional_requests(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid conditional mode should fail");
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_log_verbosity");
+    set_arg(&values[1], "debug");
+    rc = ngx_http_markdown_log_verbosity(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "debug should parse");
+    TEST_ASSERT(mcf.log_verbosity == NGX_HTTP_MARKDOWN_LOG_DEBUG,
+        "log verbosity should be debug");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "error");
+    rc = ngx_http_markdown_log_verbosity(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "error should parse");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "trace");
+    rc = ngx_http_markdown_log_verbosity(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid log verbosity should fail");
+
+    TEST_PASS("conditional/log_verbosity branches covered");
+}
+
+static void
+test_stream_types_handler(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[3];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("stream_types handler");
+
+    init_conf(&mcf);
+    setup_cf(&cf, &args, values, 3);
+
+    set_arg(&cmd.name, "markdown_stream_types");
+    set_arg(&values[0], "markdown_stream_types");
+    set_arg(&values[1], "text/event-stream");
+    set_arg(&values[2], "application/json");
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "valid stream types should parse");
+    TEST_ASSERT(mcf.stream_types != NULL, "stream types array should exist");
+    TEST_ASSERT(mcf.stream_types->nelts == 2,
+        "two stream types should be stored");
+
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate stream_types should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "noslash");
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "type without slash should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "/leading");
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "leading slash should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "trailing/");
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "trailing slash should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "a/b/c");
+    rc = ngx_http_markdown_stream_types(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "multiple slashes should fail");
+
+    TEST_PASS("stream_types branches covered");
+}
+
+static void
+test_large_body_threshold_handler(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("large_body_threshold handler");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&values[0], "markdown_large_body_threshold");
+    set_arg(&cmd.name, "markdown_large_body_threshold");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "off should parse");
+    TEST_ASSERT(mcf.large_body_threshold == 0, "off should map to zero");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "512k");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "size token should parse");
+    TEST_ASSERT(mcf.large_body_threshold == 512 * 1024,
+        "512k should map correctly");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "1m");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "1m should parse");
+    TEST_ASSERT(mcf.large_body_threshold == 1024 * 1024,
+        "1m should map correctly");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "bad");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid threshold token should fail");
+
+    init_conf(&mcf);
+    mcf.large_body_threshold = 1;
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_large_body_threshold(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate threshold directive should fail");
+
+    TEST_PASS("large_body_threshold branches covered");
+}
+
+static void
+test_metrics_handlers(void)
+{
+    ngx_conf_t                 cf;
+    ngx_array_t                args;
+    ngx_str_t                  values[2];
+    ngx_command_t              cmd;
+    ngx_http_markdown_conf_t   mcf;
+    ngx_http_core_loc_conf_t   clcf;
+    char                      *rc;
+
+    TEST_SUBSECTION("metrics handlers");
+
+    setup_cf(&cf, &args, values, 2);
+
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_metrics_format");
+    set_arg(&values[0], "markdown_metrics_format");
+    set_arg(&values[1], "auto");
+    rc = ngx_http_markdown_metrics_format(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "auto metrics format should parse");
+    TEST_ASSERT(mcf.ops.metrics_format == NGX_HTTP_MARKDOWN_METRICS_FORMAT_AUTO,
+        "metrics format should be auto");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "prometheus");
+    rc = ngx_http_markdown_metrics_format(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "prometheus metrics format should parse");
+    TEST_ASSERT(mcf.ops.metrics_format == NGX_HTTP_MARKDOWN_METRICS_FORMAT_PROMETHEUS,
+        "metrics format should be prometheus");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "json");
+    rc = ngx_http_markdown_metrics_format(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid metrics format should fail");
+
+    set_arg(&cmd.name, "markdown_metrics");
+
+    g_clcf = NULL;
+    rc = ngx_http_markdown_metrics_directive(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "missing core loc conf should fail");
+
+    memset(&clcf, 0, sizeof(clcf));
+    g_clcf = &clcf;
+    rc = ngx_http_markdown_metrics_directive(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "metrics directive should install handler");
+    TEST_ASSERT(clcf.handler == ngx_http_markdown_metrics_handler,
+        "metrics handler should be registered");
+
+    rc = ngx_http_markdown_metrics_directive(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "duplicate content handler should fail");
+
+    TEST_PASS("metrics handler branches covered");
+}
+
+static void
+test_streaming_engine_handler(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("streaming_engine handler");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&cmd.name, "markdown_streaming_engine");
+    set_arg(&values[0], "markdown_streaming_engine");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "auto");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK, "auto should parse");
+    TEST_ASSERT(mcf.streaming_engine != NULL,
+        "compiled streaming engine value should be set");
+
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "duplicate streaming_engine should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "invalid");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "invalid static value should fail");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "$streaming_mode");
+    g_compile_complex_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "variable expression should compile");
+
+    init_conf(&mcf);
+    set_arg(&values[1], "$compile_fails");
+    g_compile_complex_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "compile failure should return error");
+
+    g_compile_complex_rc = NGX_OK;
+
+    TEST_PASS("streaming_engine branches covered");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("config_handlers_impl Tests\n");
+    printf("========================================\n");
+
+    g_compile_complex_rc = NGX_OK;
+
+    test_arg_equals();
+    test_markdown_filter_handler();
+    test_simple_enum_handlers();
+    test_auth_cookies_handler();
+    test_conditional_and_log_verbosity_handlers();
+    test_stream_types_handler();
+    test_large_body_threshold_handler();
+    test_metrics_handlers();
+    test_streaming_engine_handler();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+
+    return 0;
+}

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -43,6 +43,11 @@ struct MarkdownResult {
 
 struct MarkdownConverterHandle;
 
+/*
+ * Test-controlled stub state.  Each global allows tests to inject
+ * specific return codes or trigger one-shot allocation failures
+ * without modifying the stub function bodies.
+ */
 static ngx_int_t g_forward_headers_rc = 0;
 static ngx_int_t g_update_headers_rc = 0;
 static ngx_int_t g_failopen_rc = 0;
@@ -87,6 +92,15 @@ markdown_convert(struct MarkdownConverterHandle *handle, /* NOSONAR: must match 
     memset(result, 0, sizeof(*result));
 }
 
+/*
+ * FFI lifecycle stub for markdown_result_free.  Clears all public ABI
+ * fields (pointer, length, and numeric/error fields) to prevent
+ * stale-state regressions, and increments g_markdown_result_free_calls
+ * so tests can verify the expected number of free invocations.
+ *
+ * Per AGENTS.md rule 15: partial clears create false confidence and
+ * can mask stale-state regressions, so every field is zeroed.
+ */
 static void
 markdown_result_free(struct MarkdownResult *result) /* NOSONAR: must match FFI signature */
 {
@@ -268,6 +282,11 @@ ngx_pfree(ngx_pool_t *pool, void *p)
     return NGX_OK;
 }
 
+/*
+ * Pool allocator stub delegating to malloc(3).  When g_pnalloc_fail_once
+ * is set, returns NULL once and clears the flag, simulating allocation
+ * failure.
+ */
 static ngx_inline void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
 {
@@ -279,6 +298,11 @@ ngx_pnalloc(ngx_pool_t *pool, size_t size)
     return malloc(size);
 }
 
+/*
+ * Pool allocator stub delegating to calloc(3) with zero-initialization.
+ * When g_pcalloc_fail_once is set, returns NULL once and clears the flag,
+ * simulating allocation failure.
+ */
 static ngx_inline void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
@@ -293,6 +317,10 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     return p;
 }
 
+/*
+ * Chain link allocator stub.  When g_alloc_chain_fail_once is set,
+ * returns NULL once and clears the flag, simulating allocation failure.
+ */
 static ngx_inline ngx_chain_t *
 ngx_alloc_chain_link(ngx_pool_t *pool)
 {
@@ -348,6 +376,10 @@ struct MarkdownConverterHandle *ngx_http_markdown_converter = NULL;
 ngx_http_markdown_metrics_t *ngx_http_markdown_metrics = NULL;
 ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r, ngx_chain_t *in) = NULL;
 
+/*
+ * Forward-headers stub returning the test-controlled g_forward_headers_rc,
+ * allowing tests to simulate header forwarding failures.
+ */
 static ngx_int_t
 ngx_http_markdown_forward_headers(
     ngx_http_request_t *r,     /* NOSONAR c:S995 — must match production signature */
@@ -365,6 +397,11 @@ ngx_http_markdown_metric_inc_failopen(
     UNUSED(conf);
 }
 
+/*
+ * Fail-open stub.  Increments g_failopen_call_count and returns
+ * g_failopen_rc, allowing tests to verify invocation count and control
+ * return behavior.
+ */
 static ngx_int_t
 ngx_http_markdown_reject_or_fail_open_buffered_response(
     ngx_http_request_t *r,     /* NOSONAR c:S995 — must match impl forward decl */
@@ -379,6 +416,12 @@ ngx_http_markdown_reject_or_fail_open_buffered_response(
     return g_failopen_rc;
 }
 
+/*
+ * Classify FFI error codes into semantic categories.  PARSE/ENCODING/
+ * INVALID_INPUT map to CONVERSION, TIMEOUT/MEMORY_LIMIT map to
+ * RESOURCE_LIMIT, all others map to SYSTEM.  Mirrors the production
+ * classification contract.
+ */
 ngx_http_markdown_error_category_t
 ngx_http_markdown_classify_error(uint32_t error_code)
 {
@@ -395,6 +438,10 @@ ngx_http_markdown_classify_error(uint32_t error_code)
     }
 }
 
+/*
+ * Return a human-readable string for each error category.  Covers
+ * CONVERSION, RESOURCE_LIMIT, and SYSTEM categories.
+ */
 const ngx_str_t *
 ngx_http_markdown_error_category_string(
     ngx_http_markdown_error_category_t category)
@@ -420,6 +467,10 @@ ngx_http_markdown_error_category_string(
     return &system_str;
 }
 
+/*
+ * Header-update stub returning the test-controlled g_update_headers_rc,
+ * allowing tests to simulate header update failures.
+ */
 ngx_int_t
 ngx_http_markdown_update_headers(
     ngx_http_request_t *r,     /* NOSONAR c:S995 — must match module header decl */
@@ -500,6 +551,10 @@ assert_str_eq(const ngx_str_t *actual, const char *expected, const char *msg)
     TEST_ASSERT(memcmp(actual->data, expected, expected_len) == 0, msg);
 }
 
+/*
+ * Body filter chain stub returning the test-controlled
+ * g_next_body_filter_rc.
+ */
 static ngx_int_t
 test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
@@ -1005,6 +1060,12 @@ test_find_request_header_multi_part(void)
     TEST_PASS("find_request_header_value multi-part correct");
 }
 
+/*
+ * Verify validate_conversion_result invariant checks: NULL markdown with
+ * non-zero length triggers fail-open; NULL error_message with non-zero
+ * length triggers fail-open; NULL etag with non-zero length triggers
+ * fail-open; valid result passes without invoking fail-open.
+ */
 static void
 test_validate_conversion_result_paths(void)
 {
@@ -1060,6 +1121,12 @@ test_validate_conversion_result_paths(void)
     TEST_PASS("validate_conversion_result branches covered");
 }
 
+/*
+ * Verify handle_conversion_failure error category classification:
+ * PARSE errors map to CONVERSION category; TIMEOUT errors map to
+ * RESOURCE_LIMIT category; INTERNAL errors map to SYSTEM category.
+ * Each path propagates the fail-open return code.
+ */
 static void
 test_handle_conversion_failure_paths(void)
 {
@@ -1119,6 +1186,10 @@ test_handle_conversion_failure_paths(void)
     TEST_PASS("handle_conversion_failure branches covered");
 }
 
+/*
+ * Verify handle_converter_not_initialized follows the configured
+ * fail-open strategy and records the system error category.
+ */
 static void
 test_converter_not_initialized_path(void)
 {
@@ -1145,6 +1216,12 @@ test_converter_not_initialized_path(void)
     TEST_PASS("converter_not_initialized covered");
 }
 
+/*
+ * Verify send_conversion_output branch coverage: HEAD method output,
+ * body output, header update failure, forward header failure, buffer
+ * allocation failure (pcalloc), body allocation failure (pnalloc),
+ * chain allocation failure.
+ */
 static void
 test_send_conversion_output_paths(void)
 {
@@ -1246,6 +1323,12 @@ test_send_conversion_output_paths(void)
     TEST_PASS("send_conversion_output branches covered");
 }
 
+/*
+ * Verify miscellaneous conversion helper branches:
+ * record_conversion_latency, record_system_failure, and
+ * record_token_savings_if_enabled with various token_estimate
+ * configurations.
+ */
 static void
 test_misc_conversion_helpers(void)
 {

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -46,6 +46,7 @@ struct MarkdownConverterHandle;
 static ngx_int_t g_forward_headers_rc = 0;
 static ngx_int_t g_update_headers_rc = 0;
 static ngx_int_t g_failopen_rc = 0;
+static ngx_uint_t g_failopen_call_count = 0;
 static ngx_int_t g_next_body_filter_rc = 0;
 static ngx_uint_t g_markdown_result_free_calls = 0;
 static ngx_uint_t g_pnalloc_fail_once = 0;
@@ -54,6 +55,24 @@ static ngx_uint_t g_alloc_chain_fail_once = 0;
 
 /* FFI stub constants and functions used by conversion_impl.h */
 #define ERROR_SUCCESS 0
+#ifndef ERROR_PARSE
+#define ERROR_PARSE 1
+#endif
+#ifndef ERROR_ENCODING
+#define ERROR_ENCODING 2
+#endif
+#ifndef ERROR_TIMEOUT
+#define ERROR_TIMEOUT 3
+#endif
+#ifndef ERROR_MEMORY_LIMIT
+#define ERROR_MEMORY_LIMIT 4
+#endif
+#ifndef ERROR_INVALID_INPUT
+#define ERROR_INVALID_INPUT 5
+#endif
+#ifndef ERROR_INTERNAL
+#define ERROR_INTERNAL 99
+#endif
 
 static void
 markdown_convert(struct MarkdownConverterHandle *handle, /* NOSONAR: must match FFI signature */
@@ -78,7 +97,10 @@ markdown_result_free(struct MarkdownResult *result) /* NOSONAR: must match FFI s
         result->error_message = NULL;
         result->markdown_len = 0;
         result->etag_len = 0;
+        result->token_estimate = 0;
+        result->error_code = 0;
         result->error_len = 0;
+        result->peak_memory_estimate = 0;
     }
 }
 
@@ -353,19 +375,24 @@ ngx_http_markdown_reject_or_fail_open_buffered_response(
     UNUSED(ctx);
     UNUSED(conf);
     UNUSED(debug_message);
+    g_failopen_call_count++;
     return g_failopen_rc;
 }
 
 ngx_http_markdown_error_category_t
 ngx_http_markdown_classify_error(uint32_t error_code)
 {
-    if (error_code == 1) {
-        return NGX_HTTP_MARKDOWN_ERROR_CONVERSION;
+    switch (error_code) {
+        case ERROR_PARSE:
+        case ERROR_ENCODING:
+        case ERROR_INVALID_INPUT:
+            return NGX_HTTP_MARKDOWN_ERROR_CONVERSION;
+        case ERROR_TIMEOUT:
+        case ERROR_MEMORY_LIMIT:
+            return NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT;
+        default:
+            return NGX_HTTP_MARKDOWN_ERROR_SYSTEM;
     }
-    if (error_code == 2) {
-        return NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT;
-    }
-    return NGX_HTTP_MARKDOWN_ERROR_SYSTEM;
 }
 
 const ngx_str_t *
@@ -481,12 +508,23 @@ test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     return g_next_body_filter_rc;
 }
 
+/*
+ * Reset all stub state to deterministic defaults for each test section.
+ *
+ * Inputs: none.
+ * Output: none.
+ * Side effects:
+ * - restores default return values for forwarding/update/fail-open stubs
+ * - clears one-shot allocation failure injectors and call counters
+ * - reinstalls ngx_http_next_body_filter to the local test stub
+ */
 static void
 reset_stub_state(void)
 {
     g_forward_headers_rc = NGX_OK;
     g_update_headers_rc = NGX_OK;
     g_failopen_rc = NGX_OK;
+    g_failopen_call_count = 0;
     g_next_body_filter_rc = NGX_OK;
     g_markdown_result_free_calls = 0;
     g_pnalloc_fail_once = 0;
@@ -989,6 +1027,8 @@ test_validate_conversion_result_paths(void)
     g_failopen_rc = NGX_DECLINED;
     rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
     TEST_ASSERT(rc == NGX_DECLINED, "invalid markdown invariants should fail-open");
+    TEST_ASSERT(g_failopen_call_count == 1,
+                "invalid markdown invariants should invoke fail-open stub");
     TEST_ASSERT(g_markdown_result_free_calls == 1,
                 "invalid result should be freed");
 
@@ -998,6 +1038,8 @@ test_validate_conversion_result_paths(void)
     result.error_len = 3;
     rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
     TEST_ASSERT(rc == NGX_OK, "stub fail-open default should propagate as NGX_OK");
+    TEST_ASSERT(g_failopen_call_count == 1,
+                "error message invariant failure should invoke fail-open stub");
 
     reset_stub_state();
     memset(&result, 0, sizeof(result));
@@ -1005,11 +1047,15 @@ test_validate_conversion_result_paths(void)
     result.etag_len = 2;
     rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
     TEST_ASSERT(rc == NGX_OK, "etag invariant failure should route through fail-open");
+    TEST_ASSERT(g_failopen_call_count == 1,
+                "etag invariant failure should invoke fail-open stub");
 
     reset_stub_state();
     memset(&result, 0, sizeof(result));
     rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
     TEST_ASSERT(rc == NGX_OK, "valid invariants should pass");
+    TEST_ASSERT(g_failopen_call_count == 0,
+                "valid invariants should not invoke fail-open stub");
 
     TEST_PASS("validate_conversion_result branches covered");
 }
@@ -1031,7 +1077,7 @@ test_handle_conversion_failure_paths(void)
     memset(&ctx, 0, sizeof(ctx));
     memset(&conf, 0, sizeof(conf));
     memset(&result, 0, sizeof(result));
-    result.error_code = 1;
+    result.error_code = ERROR_PARSE;
     result.error_message = msg;
     result.error_len = sizeof(msg) - 1;
     g_failopen_rc = NGX_DONE;
@@ -1045,7 +1091,7 @@ test_handle_conversion_failure_paths(void)
     reset_stub_state();
     memset(&ctx, 0, sizeof(ctx));
     memset(&result, 0, sizeof(result));
-    result.error_code = 2;
+    result.error_code = ERROR_TIMEOUT;
     /*
      * Exercise oversized length handling without risking reads past a tiny
      * stack buffer: NULL message means no payload should be dereferenced.
@@ -1061,7 +1107,7 @@ test_handle_conversion_failure_paths(void)
     reset_stub_state();
     memset(&ctx, 0, sizeof(ctx));
     memset(&result, 0, sizeof(result));
-    result.error_code = 99;
+    result.error_code = ERROR_INTERNAL;
     result.error_message = NULL;
     result.error_len = 0;
     rc = ngx_http_markdown_handle_conversion_failure(

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -5,6 +5,7 @@
 
 #include "../include/test_common.h"
 #include <ctype.h>
+#include <limits.h>
 #include <time.h>
 
 #include "../../src/ngx_http_markdown_filter_module.h"
@@ -42,6 +43,15 @@ struct MarkdownResult {
 
 struct MarkdownConverterHandle;
 
+static ngx_int_t g_forward_headers_rc = 0;
+static ngx_int_t g_update_headers_rc = 0;
+static ngx_int_t g_failopen_rc = 0;
+static ngx_int_t g_next_body_filter_rc = 0;
+static ngx_uint_t g_markdown_result_free_calls = 0;
+static ngx_uint_t g_pnalloc_fail_once = 0;
+static ngx_uint_t g_pcalloc_fail_once = 0;
+static ngx_uint_t g_alloc_chain_fail_once = 0;
+
 /* FFI stub constants and functions used by conversion_impl.h */
 #define ERROR_SUCCESS 0
 
@@ -61,7 +71,15 @@ markdown_convert(struct MarkdownConverterHandle *handle, /* NOSONAR: must match 
 static void
 markdown_result_free(struct MarkdownResult *result) /* NOSONAR: must match FFI signature */
 {
-    UNUSED(result);
+    g_markdown_result_free_calls++;
+    if (result != NULL) {
+        result->markdown = NULL;
+        result->etag = NULL;
+        result->error_message = NULL;
+        result->markdown_len = 0;
+        result->etag_len = 0;
+        result->error_len = 0;
+    }
 }
 
 typedef struct ngx_list_part_s ngx_list_part_t;
@@ -163,17 +181,20 @@ struct ngx_http_request_s {
 #ifndef NGX_ERROR
 #define NGX_ERROR (-1)
 #endif
+#ifndef NGX_DONE
+#define NGX_DONE (-4)
+#endif
 #ifndef NGX_DECLINED
 #define NGX_DECLINED (-5)
 #endif
 #ifndef NGX_HTTP_HEAD
-#define NGX_HTTP_HEAD 2
+#define NGX_HTTP_HEAD 4
 #endif
 #ifndef NGX_HTTP_NOT_MODIFIED
 #define NGX_HTTP_NOT_MODIFIED 304
 #endif
 #ifndef NGX_HTTP_MARKDOWN_BUFFERED
-#define NGX_HTTP_MARKDOWN_BUFFERED 0x00000001
+#define NGX_HTTP_MARKDOWN_BUFFERED 0x08
 #endif
 #ifndef NGX_LOG_DEBUG_HTTP
 #define NGX_LOG_DEBUG_HTTP 0
@@ -229,6 +250,10 @@ static ngx_inline void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
 {
     (void) pool;
+    if (g_pnalloc_fail_once) {
+        g_pnalloc_fail_once = 0;
+        return NULL;
+    }
     return malloc(size);
 }
 
@@ -238,6 +263,10 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     void *p;
 
     (void) pool;
+    if (g_pcalloc_fail_once) {
+        g_pcalloc_fail_once = 0;
+        return NULL;
+    }
     p = calloc(1, size);
     return p;
 }
@@ -246,6 +275,10 @@ static ngx_inline ngx_chain_t *
 ngx_alloc_chain_link(ngx_pool_t *pool)
 {
     (void) pool;
+    if (g_alloc_chain_fail_once) {
+        g_alloc_chain_fail_once = 0;
+        return NULL;
+    }
     return calloc(1, sizeof(ngx_chain_t));
 }
 
@@ -300,7 +333,7 @@ ngx_http_markdown_forward_headers(
 {
     UNUSED(r);
     UNUSED(ctx);
-    return NGX_OK;
+    return g_forward_headers_rc;
 }
 
 static void
@@ -320,13 +353,18 @@ ngx_http_markdown_reject_or_fail_open_buffered_response(
     UNUSED(ctx);
     UNUSED(conf);
     UNUSED(debug_message);
-    return NGX_OK;
+    return g_failopen_rc;
 }
 
 ngx_http_markdown_error_category_t
 ngx_http_markdown_classify_error(uint32_t error_code)
 {
-    UNUSED(error_code);
+    if (error_code == 1) {
+        return NGX_HTTP_MARKDOWN_ERROR_CONVERSION;
+    }
+    if (error_code == 2) {
+        return NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT;
+    }
     return NGX_HTTP_MARKDOWN_ERROR_SYSTEM;
 }
 
@@ -334,11 +372,24 @@ const ngx_str_t *
 ngx_http_markdown_error_category_string(
     ngx_http_markdown_error_category_t category)
 {
+    static u_char conversion_str_data[] = "FAIL_CONVERSION";
+    static u_char resource_str_data[] = "FAIL_RESOURCE_LIMIT";
     static u_char system_str_data[] = "FAIL_SYSTEM";
+    static ngx_str_t conversion_str = {
+        sizeof("FAIL_CONVERSION") - 1, conversion_str_data
+    };
+    static ngx_str_t resource_str = {
+        sizeof("FAIL_RESOURCE_LIMIT") - 1, resource_str_data
+    };
     static ngx_str_t system_str = {
         sizeof("FAIL_SYSTEM") - 1, system_str_data
     };
-    UNUSED(category);
+    if (category == NGX_HTTP_MARKDOWN_ERROR_CONVERSION) {
+        return &conversion_str;
+    }
+    if (category == NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT) {
+        return &resource_str;
+    }
     return &system_str;
 }
 
@@ -351,7 +402,7 @@ ngx_http_markdown_update_headers(
     UNUSED(r);
     UNUSED(result);
     UNUSED(conf);
-    return NGX_OK;
+    return g_update_headers_rc;
 }
 
 ngx_int_t
@@ -420,6 +471,28 @@ assert_str_eq(const ngx_str_t *actual, const char *expected, const char *msg)
     expected_len = strlen(expected);
     TEST_ASSERT(actual->len == expected_len, msg);
     TEST_ASSERT(memcmp(actual->data, expected, expected_len) == 0, msg);
+}
+
+static ngx_int_t
+test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    UNUSED(r);
+    UNUSED(in);
+    return g_next_body_filter_rc;
+}
+
+static void
+reset_stub_state(void)
+{
+    g_forward_headers_rc = NGX_OK;
+    g_update_headers_rc = NGX_OK;
+    g_failopen_rc = NGX_OK;
+    g_next_body_filter_rc = NGX_OK;
+    g_markdown_result_free_calls = 0;
+    g_pnalloc_fail_once = 0;
+    g_pcalloc_fail_once = 0;
+    g_alloc_chain_fail_once = 0;
+    ngx_http_next_body_filter = test_next_body_filter;
 }
 
 static void
@@ -894,6 +967,279 @@ test_find_request_header_multi_part(void)
     TEST_PASS("find_request_header_value multi-part correct");
 }
 
+static void
+test_validate_conversion_result_paths(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+    ngx_int_t                 rc;
+
+    TEST_SUBSECTION("validate_conversion_result invariants");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+
+    memset(&result, 0, sizeof(result));
+    result.markdown = NULL;
+    result.markdown_len = 1;
+    g_failopen_rc = NGX_DECLINED;
+    rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
+    TEST_ASSERT(rc == NGX_DECLINED, "invalid markdown invariants should fail-open");
+    TEST_ASSERT(g_markdown_result_free_calls == 1,
+                "invalid result should be freed");
+
+    reset_stub_state();
+    memset(&result, 0, sizeof(result));
+    result.error_message = NULL;
+    result.error_len = 3;
+    rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
+    TEST_ASSERT(rc == NGX_OK, "stub fail-open default should propagate as NGX_OK");
+
+    reset_stub_state();
+    memset(&result, 0, sizeof(result));
+    result.etag = NULL;
+    result.etag_len = 2;
+    rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
+    TEST_ASSERT(rc == NGX_OK, "etag invariant failure should route through fail-open");
+
+    reset_stub_state();
+    memset(&result, 0, sizeof(result));
+    rc = ngx_http_markdown_validate_conversion_result(&r, &ctx, &conf, &result);
+    TEST_ASSERT(rc == NGX_OK, "valid invariants should pass");
+
+    TEST_PASS("validate_conversion_result branches covered");
+}
+
+static void
+test_handle_conversion_failure_paths(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+    ngx_int_t                 rc;
+    u_char                    msg[] = "oops";
+
+    TEST_SUBSECTION("handle_conversion_failure categories");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.error_code = 1;
+    result.error_message = msg;
+    result.error_len = sizeof(msg) - 1;
+    g_failopen_rc = NGX_DONE;
+    rc = ngx_http_markdown_handle_conversion_failure(
+        &r, &ctx, &conf, &result, 12);
+    TEST_ASSERT(rc == NGX_DONE, "conversion category should propagate fail-open return");
+    TEST_ASSERT(ctx.has_error_category == 1, "error category should be recorded");
+    TEST_ASSERT(ctx.last_error_category == NGX_HTTP_MARKDOWN_ERROR_CONVERSION,
+                "conversion category expected");
+
+    reset_stub_state();
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&result, 0, sizeof(result));
+    result.error_code = 2;
+    /*
+     * Exercise oversized length handling without risking reads past a tiny
+     * stack buffer: NULL message means no payload should be dereferenced.
+     */
+    result.error_message = NULL;
+    result.error_len = (size_t) INT_MAX + 11U;
+    rc = ngx_http_markdown_handle_conversion_failure(
+        &r, &ctx, &conf, &result, 99);
+    TEST_ASSERT(rc == NGX_OK, "resource category should use default fail-open");
+    TEST_ASSERT(ctx.last_error_category == NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT,
+                "resource category expected");
+
+    reset_stub_state();
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&result, 0, sizeof(result));
+    result.error_code = 99;
+    result.error_message = NULL;
+    result.error_len = 0;
+    rc = ngx_http_markdown_handle_conversion_failure(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_OK, "system category should route through fail-open");
+    TEST_ASSERT(ctx.last_error_category == NGX_HTTP_MARKDOWN_ERROR_SYSTEM,
+                "system category expected");
+
+    TEST_PASS("handle_conversion_failure branches covered");
+}
+
+static void
+test_converter_not_initialized_path(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    ngx_int_t                 rc;
+
+    TEST_SUBSECTION("converter_not_initialized path");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    g_failopen_rc = NGX_DECLINED;
+
+    rc = ngx_http_markdown_handle_converter_not_initialized(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+                "converter_not_initialized should follow fail-open strategy");
+    TEST_ASSERT(ctx.has_error_category == 1,
+                "system failure should set error category flag");
+
+    TEST_PASS("converter_not_initialized covered");
+}
+
+static void
+test_send_conversion_output_paths(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+    ngx_int_t                 rc;
+    u_char                    out[] = "markdown";
+
+    TEST_SUBSECTION("send_conversion_output branches");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    r.method = NGX_HTTP_HEAD;
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_OK, "HEAD output path should succeed");
+    TEST_ASSERT(g_markdown_result_free_calls == 1,
+                "HEAD output should free result");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    r.method = 0;
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_OK, "body output path should succeed");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    g_update_headers_rc = NGX_ERROR;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_ERROR, "header update failure should return NGX_ERROR");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    g_forward_headers_rc = NGX_ERROR;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_ERROR, "forward header failure should propagate");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    g_pcalloc_fail_once = 1;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_ERROR, "buffer allocation failure should return NGX_ERROR");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    g_pnalloc_fail_once = 1;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_ERROR, "body allocation failure should return NGX_ERROR");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+    g_alloc_chain_fail_once = 1;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    TEST_ASSERT(rc == NGX_ERROR, "chain allocation failure should return NGX_ERROR");
+
+    TEST_PASS("send_conversion_output branches covered");
+}
+
+static void
+test_misc_conversion_helpers(void)
+{
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+
+    TEST_SUBSECTION("misc conversion helper branches");
+
+    reset_stub_state();
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+
+    ngx_http_markdown_record_conversion_latency(1);
+    ngx_http_markdown_record_conversion_latency(50);
+    ngx_http_markdown_record_conversion_latency(500);
+    ngx_http_markdown_record_conversion_latency(5000);
+
+    ngx_http_markdown_record_system_failure(&ctx);
+    TEST_ASSERT(ctx.has_error_category == 1,
+                "record_system_failure should set context flag");
+
+    ctx.buffer.size = 400;
+    conf.token_estimate = 1;
+    result.token_estimate = 50;
+    ngx_http_markdown_record_token_savings_if_enabled(
+        &ctx, &conf, &result);
+
+    result.token_estimate = 200;
+    ngx_http_markdown_record_token_savings_if_enabled(
+        &ctx, &conf, &result);
+
+    conf.token_estimate = 0;
+    ngx_http_markdown_record_token_savings_if_enabled(
+        &ctx, &conf, &result);
+
+    TEST_PASS("misc conversion helpers covered");
+}
+
 
 int
 main(void)
@@ -914,6 +1260,11 @@ main(void)
     test_prepare_conversion_options_no_base_url();
     test_scheme_is_http_family();
     test_find_request_header_multi_part();
+    test_validate_conversion_result_paths();
+    test_handle_conversion_failure_paths();
+    test_converter_not_initialized_path();
+    test_send_conversion_output_paths();
+    test_misc_conversion_helpers();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1320,21 +1320,29 @@ test_feed_empty_and_large_size_paths(void)
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail when initial output buffer allocation fails");
 
+    g_palloc_fail_once = 0;
+    g_palloc_return_static_once = 0;
     huge_in_len = ((size_t) -1 / 4) + 1;
-    g_palloc_fail_once = 1;
     one_byte = 'x';
+    out = NULL;
+    out_len = 0;
+    g_palloc_return_static_once = 1;
     rc = ngx_http_markdown_streaming_decomp_feed(
         decomp, &one_byte, huge_in_len, &out, &out_len,
         &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail safely on saturated initial size");
+    g_palloc_return_static_once = 0;
 
+    out = NULL;
+    out_len = 0;
     g_palloc_return_static_once = 1;
     rc = ngx_http_markdown_streaming_decomp_feed(
         decomp, &one_byte, ((size_t) UINT_MAX / 2) + 1,
         &out, &out_len, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail when output buffer size exceeds zlib uInt");
+    g_palloc_return_static_once = 0;
 
     free(decomp);
     TEST_PASS("feed empty/large-size branches covered");

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1,6 +1,19 @@
 /*
  * Test: streaming_decomp
- * Description: direct coverage for streaming decompression helpers
+ *
+ * Purpose: Unit tests for the streaming decompression pipeline used by the
+ * nginx markdown filter module.  Validates create/feed/finish lifecycle,
+ * error propagation, budget enforcement, buffer expansion, size-overflow
+ * guards, and cleanup semantics for gzip and deflate streams.
+ *
+ * When MARKDOWN_STREAMING_ENABLED is not defined the entire suite is
+ * compiled to a no-op that reports a skip banner.
+ *
+ * Stubs: ngx_palloc, ngx_pcalloc, ngx_alloc, ngx_free,
+ *        ngx_pool_cleanup_add, inflateInit2, inflateEnd, inflate
+ * are reimplemented here to inject allocation failures and controlled
+ * inflate behaviour without depending on exact compressed-payload shapes.
+ * See per-stub DIVERGENCE RISK notes below.
  */
 
 #include "../include/test_common.h"
@@ -15,6 +28,10 @@
 
 #include <ngx_http_markdown_filter_module.h>
 
+/*
+ * Skip path: when the streaming feature flag is absent at compile time,
+ * emit a skip banner and return 0 so the test binary still succeeds.
+ */
 #ifndef MARKDOWN_STREAMING_ENABLED
 
 int
@@ -29,6 +46,17 @@ main(void)
 
 #else /* MARKDOWN_STREAMING_ENABLED */
 
+/*
+ * test_pool_cleanup_t - Minimal stand-in for ngx_pool_cleanup_t.
+ * Mirrors the production linked-list cleanup structure so that
+ * ngx_pool_cleanup_add and test_pool_run_cleanups can exercise
+ * registration and execution of cleanup handlers.
+ *
+ * Fields:
+ *   handler - callback to invoke on pool destruction
+ *   data    - opaque context passed to handler
+ *   next    - linked-list pointer to the next cleanup entry
+ */
 typedef struct test_pool_cleanup_s test_pool_cleanup_t;
 typedef test_pool_cleanup_t ngx_pool_cleanup_t;
 
@@ -38,10 +66,25 @@ struct test_pool_cleanup_s {
     ngx_pool_cleanup_t    *next;
 };
 
+/*
+ * ngx_pool_s - Minimal stand-in for the NGINX pool structure.
+ * Only the cleanups list is needed for these tests.
+ *
+ * Fields:
+ *   cleanups - head of the linked list of registered cleanup handlers
+ */
 struct ngx_pool_s {
     ngx_pool_cleanup_t    *cleanups;
 };
 
+/*
+ * ngx_log_s - Minimal stand-in for the NGINX log structure.
+ * No fields are exercised by the tests; the struct exists only so
+ * that function signatures match production code.
+ *
+ * Fields:
+ *   unused - placeholder to avoid an empty struct
+ */
 struct ngx_log_s {
     int                    unused;
 };
@@ -49,15 +92,65 @@ struct ngx_log_s {
 #define ngx_memcpy memcpy
 #define NGX_MAX_SIZE_T_VALUE SIZE_MAX
 
+/* test_log - Dummy log instance passed to production APIs under test. */
 static ngx_log_t test_log;
+
+/*
+ * g_palloc_fail_once - When non-zero, the next call to ngx_palloc returns
+ * NULL and the flag is cleared.  Used to inject a single allocation failure.
+ */
 static ngx_uint_t g_palloc_fail_once = 0;
+
+/*
+ * g_palloc_return_static_once - When non-zero, the next call to ngx_palloc
+ * returns g_static_pool_buf instead of a malloc'd block and the flag is
+ * cleared.  Used to test the code path where the output buffer is a
+ * pool-allocated (non-heap) pointer.
+ */
 static ngx_uint_t g_palloc_return_static_once = 0;
+
+/*
+ * g_pcalloc_fail_once - When non-zero, the next call to ngx_pcalloc returns
+ * NULL and the flag is cleared.  Used to inject a single zeroed-allocation
+ * failure.
+ */
 static ngx_uint_t g_pcalloc_fail_once = 0;
+
+/*
+ * g_alloc_fail_once - When non-zero, the next call to ngx_alloc returns
+ * NULL and the flag is cleared.  Used to inject a single raw-allocation
+ * failure (e.g. for buffer expansion).
+ */
 static ngx_uint_t g_alloc_fail_once = 0;
+
+/*
+ * g_cleanup_add_fail_once - When non-zero, the next call to
+ * ngx_pool_cleanup_add returns NULL and the flag is cleared.
+ * Used to test cleanup-registration failure in create.
+ */
 static ngx_uint_t g_cleanup_add_fail_once = 0;
+
+/*
+ * g_inflate_init_fail_once - When non-zero, the next call to
+ * test_inflateInit2 returns Z_MEM_ERROR and the flag is cleared.
+ * Used to test inflateInit2 failure in create.
+ */
 static ngx_uint_t g_inflate_init_fail_once = 0;
+
+/*
+ * g_static_pool_buf - Fixed-size buffer returned by ngx_palloc when
+ * g_palloc_return_static_once is set.  Simulates a pool-allocated
+ * buffer whose lifetime is managed by the pool, not by free().
+ */
 static u_char g_static_pool_buf[8192];
 
+/*
+ * test_inflate_mode_t - Enumerates the controllable behaviours of the
+ * test_inflate mock.  Each mode exercises a specific inflate path in
+ * streaming_decomp_impl (feed expansion, finish error, budget exceed,
+ * multi-call finish, etc.).  TEST_INFLATE_MODE_REAL delegates to the
+ * real zlib inflate().
+ */
 typedef enum {
     TEST_INFLATE_MODE_REAL = 0,
     TEST_INFLATE_MODE_FEED_EXPAND_THEN_ERROR,
@@ -69,12 +162,28 @@ typedef enum {
     TEST_INFLATE_MODE_FINISH_EXPAND_THEN_END
 } test_inflate_mode_t;
 
+/* g_inflate_mode - Selects which mock behaviour test_inflate exhibits. */
 static test_inflate_mode_t g_inflate_mode = TEST_INFLATE_MODE_REAL;
+
+/* g_inflate_call_count - Counts invocations of test_inflate within the
+ * current test case; used by multi-call mock modes to vary behaviour
+ * on the first versus subsequent calls. */
 static ngx_uint_t g_inflate_call_count = 0;
 
+/* g_real_inflate_fn - Saved pointer to the real zlib inflate() function;
+ * used by TEST_INFLATE_MODE_REAL to delegate to genuine decompression. */
 static int (*g_real_inflate_fn)(z_streamp, int) = inflate;
+
+/* g_real_inflate_end_fn - Saved pointer to the real zlib inflateEnd();
+ * test_inflateEnd delegates to this so stream teardown is always real. */
 static int (*g_real_inflate_end_fn)(z_streamp) = inflateEnd;
 
+/*
+ * test_reset_inflate_mode - Reset the inflate mock to its default state
+ * (real zlib behaviour, call count zeroed).
+ *
+ * Side effects: clears g_inflate_mode and g_inflate_call_count.
+ */
 static void
 test_reset_inflate_mode(void)
 {
@@ -82,6 +191,24 @@ test_reset_inflate_mode(void)
     g_inflate_call_count = 0;
 }
 
+/*
+ * ngx_palloc - Stub for the NGINX pool allocator.
+ *
+ * DIVERGENCE RISK: Production ngx_palloc allocates from a pool chunk and
+ * never calls malloc().  This stub uses malloc() so allocations are
+ * individually freeable, and supports two test-only injection points:
+ *   - g_palloc_fail_once: return NULL once to simulate OOM
+ *   - g_palloc_return_static_once: return g_static_pool_buf once to
+ *     simulate a pool-managed (non-heap) buffer
+ * The semantic contract mirrored is: "returns NULL on failure, a valid
+ * pointer of at least `size` bytes on success."
+ *
+ * Parameters:
+ *   pool - ignored (UNUSED)
+ *   size - number of bytes to allocate
+ *
+ * Return: pointer to allocated memory, or NULL on injected failure.
+ */
 void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
@@ -97,6 +224,21 @@ ngx_palloc(ngx_pool_t *pool, size_t size)
     return malloc(size);
 }
 
+/*
+ * ngx_pcalloc - Stub for the NGINX zeroed pool allocator.
+ *
+ * DIVERGENCE RISK: Production ngx_pcalloc zeroes a pool chunk; this stub
+ * uses calloc(1, size) for the same zeroing semantics but with individual
+ * freeability.  Supports g_pcalloc_fail_once to inject a single failure.
+ * The semantic contract mirrored is: "returns NULL on failure, a
+ * zero-filled pointer of at least `size` bytes on success."
+ *
+ * Parameters:
+ *   pool - ignored (UNUSED)
+ *   size - number of bytes to allocate and zero
+ *
+ * Return: pointer to zeroed memory, or NULL on injected failure.
+ */
 void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
@@ -108,6 +250,20 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     return calloc(1, size);
 }
 
+/*
+ * ngx_alloc - Stub for the NGINX raw (non-pool) allocator.
+ *
+ * DIVERGENCE RISK: Production ngx_alloc logs on failure; this stub
+ * suppresses logging.  Supports g_alloc_fail_once to inject a single
+ * failure.  The semantic contract mirrored is: "returns NULL on failure,
+ * a valid pointer of at least `size` bytes on success."
+ *
+ * Parameters:
+ *   size - number of bytes to allocate
+ *   log  - ignored (UNUSED)
+ *
+ * Return: pointer to allocated memory, or NULL on injected failure.
+ */
 void *
 ngx_alloc(size_t size, ngx_log_t *log)
 {
@@ -119,12 +275,39 @@ ngx_alloc(size_t size, ngx_log_t *log)
     return malloc(size);
 }
 
+/*
+ * ngx_free - Stub for the NGINX deallocator.
+ *
+ * DIVERGENCE RISK: Production ngx_free may differ from libc free on
+ * platforms with custom allocators; this stub simply calls free().
+ * The semantic contract mirrored is: "releases memory allocated by
+ * ngx_alloc or ngx_palloc stubs."
+ *
+ * Parameters:
+ *   p - pointer to memory to free
+ */
 void
 ngx_free(void *p)
 {
     free(p);
 }
 
+/*
+ * ngx_pool_cleanup_add - Stub for the NGINX pool cleanup registration API.
+ *
+ * DIVERGENCE RISK: Production ngx_pool_cleanup_add allocates the cleanup
+ * structure from the pool itself; this stub uses calloc() so it is
+ * individually freeable.  Supports g_cleanup_add_fail_once to inject a
+ * single registration failure.  The semantic contract mirrored is:
+ * "returns NULL on failure (or NULL pool), otherwise a cleanup entry
+ * linked into pool->cleanups."
+ *
+ * Parameters:
+ *   pool - pool to register the cleanup on; NULL causes immediate failure
+ *   size - size of cleanup data (ignored in this stub)
+ *
+ * Return: pointer to new cleanup entry, or NULL on failure.
+ */
 ngx_pool_cleanup_t *
 ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
 {
@@ -150,6 +333,23 @@ ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
     return cln;
 }
 
+/*
+ * test_inflateInit2 - Stub for zlib inflateInit2.
+ *
+ * DIVERGENCE RISK: Production inflateInit2 always attempts real
+ * initialisation; this stub can inject Z_MEM_ERROR via
+ * g_inflate_init_fail_once to test the create-failure path.
+ * On the non-failure path it delegates to inflateInit2_() (the
+ * versioned entry point) to perform genuine initialisation.
+ * The semantic contract mirrored is: "returns Z_OK on success,
+ * a zlib error code on failure."
+ *
+ * Parameters:
+ *   strm        - zlib stream to initialise
+ *   window_bits - window size / format selector (gzip vs deflate)
+ *
+ * Return: Z_OK on success, Z_MEM_ERROR on injected failure.
+ */
 int
 test_inflateInit2(z_streamp strm, int window_bits)
 {
@@ -161,6 +361,19 @@ test_inflateInit2(z_streamp strm, int window_bits)
                          (int) sizeof(z_stream));
 }
 
+/*
+ * test_inflateEnd - Stub for zlib inflateEnd.
+ *
+ * DIVERGENCE RISK: None.  This stub unconditionally delegates to the
+ * real inflateEnd via g_real_inflate_end_fn so that zlib stream teardown
+ * is always genuine.  The semantic contract mirrored is identical to
+ * inflateEnd: "releases inflate working memory, returns Z_OK on success."
+ *
+ * Parameters:
+ *   strm - zlib stream to finalise
+ *
+ * Return: zlib return code from the real inflateEnd.
+ */
 int
 test_inflateEnd(z_streamp strm)
 {
@@ -283,6 +496,12 @@ test_inflate(z_streamp strm, int flush)
     return g_real_inflate_fn(strm, flush);
 }
 
+/*
+ * Redirect zlib inflate/inflateInit2/inflateEnd to the test stubs so that
+ * the production implementation (included next) calls our mockable
+ * versions.  This must precede the #include of the implementation header
+ * so that the macros take effect during its compilation.
+ */
 #ifdef inflate
 #undef inflate
 #endif
@@ -296,12 +515,33 @@ test_inflate(z_streamp strm, int flush)
 #define inflateInit2 test_inflateInit2
 #define inflateEnd test_inflateEnd
 
+/* Include the production streaming decompression implementation so that
+ * its functions are compiled against the stubs defined above. */
 #include "../src/ngx_http_markdown_streaming_decomp_impl.h"
 
+/*
+ * test_pool_t - Wrapper around ngx_pool_s that provides a local pool
+ * instance for tests.  The embedded pool field is passed to production
+ * APIs under test.
+ *
+ * Fields:
+ *   pool - embedded NGINX pool structure (minimal stub)
+ */
 typedef struct {
     ngx_pool_t            pool;
 } test_pool_t;
 
+/*
+ * test_pool_reset - Zero-initialise a test pool and clear all failure-injection
+ * flags and inflate mock state.  Call at the start of every test case to
+ * ensure a clean slate.
+ *
+ * Parameters:
+ *   tp - test pool to reset
+ *
+ * Side effects: zeroes *tp, clears all g_*_fail_once flags,
+ *               resets inflate mode to real.
+ */
 static void
 test_pool_reset(test_pool_t *tp)
 {
@@ -315,6 +555,17 @@ test_pool_reset(test_pool_t *tp)
     test_reset_inflate_mode();
 }
 
+/*
+ * test_pool_run_cleanups - Execute all registered cleanup handlers on a
+ * test pool, then free each cleanup entry and clear the list.
+ * Mirrors the behaviour of NGINX pool destruction for test assertions.
+ *
+ * Parameters:
+ *   tp - test pool whose cleanups should be run
+ *
+ * Side effects: invokes each handler, frees each cleanup node,
+ *               sets tp->pool.cleanups to NULL.
+ */
 static void
 test_pool_run_cleanups(test_pool_t *tp)
 {
@@ -334,6 +585,23 @@ test_pool_run_cleanups(test_pool_t *tp)
     tp->pool.cleanups = NULL;
 }
 
+/*
+ * compress_payload - Compress a plain-text buffer using zlib deflate with
+ * the specified compression type (gzip or deflate).  Used by round-trip
+ * and budget tests to produce valid compressed input for the decompressor.
+ *
+ * Parameters:
+ *   in      - input bytes to compress
+ *   in_len  - length of in
+ *   type    - compression format (GZIP or DEFLATE)
+ *   out     - [out] receives a malloc'd buffer with the compressed data
+ *   out_len - [out] receives the length of the compressed data
+ *
+ * Return: NGX_OK on success, NGX_ERROR on any failure (NULL args,
+ *         unsupported type, zlib error, or malloc failure).
+ *
+ * Side effects: allocates via malloc; caller must free(*out) on success.
+ */
 static int
 compress_payload(const u_char *in, size_t in_len,
     ngx_http_markdown_compression_type_e type,
@@ -408,6 +676,14 @@ compress_payload(const u_char *in, size_t in_len,
     return NGX_OK;
 }
 
+/*
+ * test_size_to_uint_guards - Verify the size_to_uint narrowing helper
+ * correctly rejects values above UINT_MAX and accepts values within range.
+ *
+ * Branches covered:
+ *   - overflow path (value > UINT_MAX returns 1)
+ *   - success path  (value <= UINT_MAX returns 0, preserves value)
+ */
 static void
 test_size_to_uint_guards(void)
 {
@@ -431,6 +707,18 @@ test_size_to_uint_guards(void)
     TEST_PASS("size_to_uint guard branches covered");
 }
 
+/*
+ * test_create_and_cleanup - Verify the create/cleanup lifecycle for the
+ * streaming decompressor.
+ *
+ * Branches covered:
+ *   - NULL pool returns NULL
+ *   - unsupported compression type returns NULL
+ *   - successful gzip create sets initialized and registers cleanup
+ *   - cleanup(NULL) is a safe no-op
+ *   - cleanup on zeroed (uninitialised) struct leaves initialized == 0
+ *   - registered cleanup handler clears initialized flag
+ */
 static void
 test_create_and_cleanup(void)
 {
@@ -479,6 +767,17 @@ test_create_and_cleanup(void)
     TEST_PASS("create and cleanup branches covered");
 }
 
+/*
+ * test_create_failure_paths_and_cleanup_default - Verify create failure
+ * when sub-allocations fail and the default switch arm in cleanup.
+ *
+ * Branches covered:
+ *   - ngx_pcalloc failure returns NULL
+ *   - inflateInit2 failure for gzip returns NULL
+ *   - inflateInit2 failure for deflate returns NULL
+ *   - cleanup with NGX_HTTP_MARKDOWN_COMPRESSION_UNKNOWN type clears
+ *     initialized (default switch arm)
+ */
 static void
 test_create_failure_paths_and_cleanup_default(void)
 {
@@ -518,6 +817,15 @@ test_create_failure_paths_and_cleanup_default(void)
     TEST_PASS("create failure/default cleanup branches covered");
 }
 
+/*
+ * test_roundtrip_and_empty_feed - Verify end-to-end decompression round-trip
+ * for both gzip and deflate, plus empty-input and post-stream finish no-ops.
+ *
+ * Branches covered:
+ *   - feed of a fully-compressed payload produces the original text
+ *   - feed with NULL/zero-length input is a no-op (no output emitted)
+ *   - finish after a completed stream is a no-op (no tail output)
+ */
 static void
 test_roundtrip_and_empty_feed(void)
 {
@@ -602,6 +910,16 @@ test_roundtrip_and_empty_feed(void)
     TEST_PASS("feed round-trip and empty-input branches covered");
 }
 
+/*
+ * test_budget_and_invalid_type_branches - Verify budget-exceeded detection
+ * and the invalid-type decline/error paths in feed and finish.
+ *
+ * Branches covered:
+ *   - feed returns NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED when
+ *     decompressed output exceeds the configured limit
+ *   - feed returns NGX_DECLINED for UNKNOWN compression type
+ *   - finish returns NGX_ERROR for UNKNOWN compression type
+ */
 static void
 test_budget_and_invalid_type_branches(void)
 {
@@ -673,6 +991,14 @@ test_budget_and_invalid_type_branches(void)
     TEST_PASS("budget and invalid-type branches covered");
 }
 
+/*
+ * test_truncated_finish_errors - Verify that finish returns NGX_ERROR when
+ * the compressed stream was truncated (incomplete gzip trailer).
+ *
+ * Branches covered:
+ *   - feed of a truncated payload succeeds and emits partial output
+ *   - finish on an incomplete stream returns NGX_ERROR
+ */
 static void
 test_truncated_finish_errors(void)
 {
@@ -732,6 +1058,20 @@ test_truncated_finish_errors(void)
     TEST_PASS("finish error branch covered");
 }
 
+/*
+ * test_create_helper_and_limit_branches - Verify cleanup-registration
+ * failure in create, check_limit boundary conditions, expand_buf overflow
+ * and allocation-failure paths, and finalize_buf allocation-failure path.
+ *
+ * Branches covered:
+ *   - cleanup_add failure causes create to return NULL
+ *   - check_limit fails when total already exceeds max
+ *   - check_limit fails when produced exceeds remaining budget
+ *   - check_limit passes on exact boundary
+ *   - expand_buf fails on size_t overflow
+ *   - expand_buf fails when ngx_alloc returns NULL
+ *   - finalize_buf fails when ngx_palloc returns NULL
+ */
 static void
 test_create_helper_and_limit_branches(void)
 {
@@ -810,6 +1150,17 @@ test_create_helper_and_limit_branches(void)
     TEST_PASS("create/helper/limit branches covered");
 }
 
+/*
+ * test_feed_guard_and_overflow_branches - Verify feed's early-exit guard
+ * clauses and size-overflow checks.
+ *
+ * Branches covered:
+ *   - NULL decompressor returns NGX_ERROR
+ *   - finished decompressor returns NGX_OK with empty output (no-op)
+ *   - exhausted budget returns NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED
+ *   - input length exceeding uInt range returns NGX_ERROR
+ *   - total_decompressed overflow check returns NGX_ERROR
+ */
 static void
 test_feed_guard_and_overflow_branches(void)
 {
@@ -872,6 +1223,15 @@ test_feed_guard_and_overflow_branches(void)
     TEST_PASS("feed guard/overflow branches covered");
 }
 
+/*
+ * test_finish_guard_and_alloc_branches - Verify finish's early-exit guard
+ * clauses and output-buffer allocation failure.
+ *
+ * Branches covered:
+ *   - NULL decompressor returns NGX_ERROR
+ *   - finished decompressor returns NGX_OK with empty output (no-op)
+ *   - ngx_palloc failure for the output buffer returns NGX_ERROR
+ */
 static void
 test_finish_guard_and_alloc_branches(void)
 {
@@ -915,6 +1275,17 @@ test_finish_guard_and_alloc_branches(void)
     TEST_PASS("finish guard/allocation branches covered");
 }
 
+/*
+ * test_feed_empty_and_large_size_paths - Verify feed behaviour with
+ * zero-length input, initial buffer allocation failure, and saturated
+ * size calculations that would overflow uInt.
+ *
+ * Branches covered:
+ *   - zero-length input is a no-op (no output)
+ *   - initial output buffer allocation failure returns NGX_ERROR
+ *   - saturated initial size (near SIZE_MAX) returns NGX_ERROR
+ *   - output buffer size exceeding zlib uInt range returns NGX_ERROR
+ */
 static void
 test_feed_empty_and_large_size_paths(void)
 {
@@ -969,6 +1340,17 @@ test_feed_empty_and_large_size_paths(void)
     TEST_PASS("feed empty/large-size branches covered");
 }
 
+/*
+ * test_feed_mocked_inflate_paths - Verify feed's inflate-loop error,
+ * budget, and expansion paths using the controlled inflate mock.
+ *
+ * Branches covered:
+ *   - expand_buf failure during inflate loop returns NGX_ERROR
+ *   - inflate error after heap expansion returns NGX_ERROR
+ *   - mocked oversized output classified as budget exceeded
+ *   - finalize_buf allocation failure returns NGX_ERROR
+ *   - total_decompressed overflow on feed completion returns NGX_ERROR
+ */
 static void
 test_feed_mocked_inflate_paths(void)
 {
@@ -1048,6 +1430,20 @@ test_feed_mocked_inflate_paths(void)
     TEST_PASS("feed mocked inflate branches covered");
 }
 
+/*
+ * test_finish_zlib_paths_and_helpers - Verify the finish_zlib helper's
+ * error, budget, overflow, expansion, and finalize-failure paths, plus
+ * the finish_free_heap helper.
+ *
+ * Branches covered:
+ *   - finish_free_heap frees and clears a non-NULL heap pointer
+ *   - inflate error during Z_FINISH returns NGX_ERROR
+ *   - budget exceeded during finish tail returns
+ *     NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED
+ *   - initial finish buffer exceeding uInt range returns NGX_ERROR
+ *   - expand-then-end flow succeeds and reports produced > old size
+ *   - finalize_buf allocation failure during finish returns NGX_ERROR
+ */
 static void
 test_finish_zlib_paths_and_helpers(void)
 {
@@ -1154,6 +1550,17 @@ test_finish_zlib_paths_and_helpers(void)
     TEST_PASS("finish_zlib helper/error/budget/expand branches covered");
 }
 
+/*
+ * test_finish_wrapper_success_and_overflow_paths - Verify the finish
+ * wrapper's success path and total_decompressed overflow saturation.
+ *
+ * Branches covered:
+ *   - finish succeeds for a mocked continue-then-end inflate flow
+ *   - finish marks the decompressor as finished
+ *   - finish publishes tail output on success
+ *   - finish accumulates produced bytes into total_decompressed
+ *   - finish saturates total_decompressed to (size_t)-1 on overflow
+ */
 static void
 test_finish_wrapper_success_and_overflow_paths(void)
 {
@@ -1206,6 +1613,10 @@ test_finish_wrapper_success_and_overflow_paths(void)
     TEST_PASS("finish wrapper success/overflow branches covered");
 }
 
+/*
+ * main - Test entry point.  Runs all streaming decompression test cases
+ * and prints a summary banner.  Returns 0 on success.
+ */
 int
 main(void)
 {

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -380,6 +380,14 @@ compress_payload(const u_char *in, size_t in_len,
         return NGX_ERROR;
     }
 
+    if (in_len > (size_t) UINT_MAX || cap > (size_t) UINT_MAX) {
+        free(*out);
+        free(in_copy);
+        *out = NULL;
+        deflateEnd(&s);
+        return NGX_ERROR;
+    }
+
     s.next_in = in_copy;
     s.avail_in = (uInt) in_len;
     s.next_out = *out;

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -50,11 +50,50 @@ struct ngx_log_s {
 #define NGX_MAX_SIZE_T_VALUE SIZE_MAX
 
 static ngx_log_t test_log;
+static ngx_uint_t g_palloc_fail_once = 0;
+static ngx_uint_t g_palloc_return_static_once = 0;
+static ngx_uint_t g_pcalloc_fail_once = 0;
+static ngx_uint_t g_alloc_fail_once = 0;
+static ngx_uint_t g_cleanup_add_fail_once = 0;
+static ngx_uint_t g_inflate_init_fail_once = 0;
+static u_char g_static_pool_buf[8192];
+
+typedef enum {
+    TEST_INFLATE_MODE_REAL = 0,
+    TEST_INFLATE_MODE_FEED_EXPAND_THEN_ERROR,
+    TEST_INFLATE_MODE_FEED_EXPAND_THEN_BUDGET,
+    TEST_INFLATE_MODE_FEED_EXPAND_THEN_DONE,
+    TEST_INFLATE_MODE_FINISH_ERROR,
+    TEST_INFLATE_MODE_FINISH_BUDGET,
+    TEST_INFLATE_MODE_FINISH_CONTINUE_THEN_END,
+    TEST_INFLATE_MODE_FINISH_EXPAND_THEN_END
+} test_inflate_mode_t;
+
+static test_inflate_mode_t g_inflate_mode = TEST_INFLATE_MODE_REAL;
+static ngx_uint_t g_inflate_call_count = 0;
+
+static int (*g_real_inflate_fn)(z_streamp, int) = inflate;
+static int (*g_real_inflate_end_fn)(z_streamp) = inflateEnd;
+
+static void
+test_reset_inflate_mode(void)
+{
+    g_inflate_mode = TEST_INFLATE_MODE_REAL;
+    g_inflate_call_count = 0;
+}
 
 void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
     UNUSED(pool);
+    if (g_palloc_fail_once) {
+        g_palloc_fail_once = 0;
+        return NULL;
+    }
+    if (g_palloc_return_static_once) {
+        g_palloc_return_static_once = 0;
+        return g_static_pool_buf;
+    }
     return malloc(size);
 }
 
@@ -62,6 +101,10 @@ void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
     UNUSED(pool);
+    if (g_pcalloc_fail_once) {
+        g_pcalloc_fail_once = 0;
+        return NULL;
+    }
     return calloc(1, size);
 }
 
@@ -69,6 +112,10 @@ void *
 ngx_alloc(size_t size, ngx_log_t *log)
 {
     UNUSED(log);
+    if (g_alloc_fail_once) {
+        g_alloc_fail_once = 0;
+        return NULL;
+    }
     return malloc(size);
 }
 
@@ -88,6 +135,10 @@ ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
     if (pool == NULL) {
         return NULL;
     }
+    if (g_cleanup_add_fail_once) {
+        g_cleanup_add_fail_once = 0;
+        return NULL;
+    }
 
     cln = calloc(1, sizeof(ngx_pool_cleanup_t));
     if (cln == NULL) {
@@ -99,6 +150,152 @@ ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
     return cln;
 }
 
+int
+test_inflateInit2(z_streamp strm, int window_bits)
+{
+    if (g_inflate_init_fail_once) {
+        g_inflate_init_fail_once = 0;
+        return Z_MEM_ERROR;
+    }
+    return inflateInit2_(strm, window_bits, ZLIB_VERSION,
+                         (int) sizeof(z_stream));
+}
+
+int
+test_inflateEnd(z_streamp strm)
+{
+    return g_real_inflate_end_fn(strm);
+}
+
+/*
+ * DIVERGENCE RISK:
+ * test_inflate() is a controlled mock used to drive rare error/expand paths
+ * in streaming_decomp_impl without depending on exact compressed payload
+ * shapes. The contract is keyed by g_inflate_mode and g_inflate_call_count:
+ * it only returns Z_OK, Z_STREAM_END, or Z_DATA_ERROR and mutates
+ * strm->avail_in/avail_out to model buffer growth and finish behavior for
+ * FEED_EXPAND_THEN_ERROR/_BUDGET/_DONE and FINISH_ERROR/_BUDGET/
+ * _CONTINUE_THEN_END/_EXPAND_THEN_END.
+ *
+ * TEST_INFLATE_MODE_REAL (and default fallthrough) delegates to
+ * g_real_inflate_fn so baseline behavior remains the real zlib inflate().
+ * If production inflate expectations change, update this mock contract and
+ * the dependent tests in the same changeset.
+ */
+int
+test_inflate(z_streamp strm, int flush)
+{
+    g_inflate_call_count++;
+
+    switch (g_inflate_mode) {
+    case TEST_INFLATE_MODE_FEED_EXPAND_THEN_ERROR:
+        if (g_inflate_call_count == 1) {
+            strm->avail_out = 0;
+            strm->avail_in = 1;
+            return Z_OK;
+        }
+        return Z_DATA_ERROR;
+
+    case TEST_INFLATE_MODE_FEED_EXPAND_THEN_BUDGET:
+        if (g_inflate_call_count == 1) {
+            strm->avail_out = 0;
+            strm->avail_in = 1;
+            return Z_OK;
+        }
+        if (strm->avail_out > 128) {
+            strm->avail_out -= 128;
+        } else {
+            strm->avail_out = 0;
+        }
+        strm->avail_in = 0;
+        return Z_OK;
+
+    case TEST_INFLATE_MODE_FEED_EXPAND_THEN_DONE:
+        if (g_inflate_call_count == 1) {
+            strm->avail_out = 0;
+            strm->avail_in = 1;
+            return Z_OK;
+        }
+        if (strm->avail_out > 32) {
+            strm->avail_out -= 32;
+        } else {
+            strm->avail_out = 0;
+        }
+        strm->avail_in = 0;
+        return Z_OK;
+
+    case TEST_INFLATE_MODE_FINISH_ERROR:
+        if (flush == Z_FINISH) {
+            return Z_DATA_ERROR;
+        }
+        break;
+
+    case TEST_INFLATE_MODE_FINISH_BUDGET:
+        if (flush == Z_FINISH) {
+            if (strm->avail_out > 128) {
+                strm->avail_out -= 128;
+            } else {
+                strm->avail_out = 0;
+            }
+            return Z_OK;
+        }
+        break;
+
+    case TEST_INFLATE_MODE_FINISH_CONTINUE_THEN_END:
+        if (flush == Z_FINISH) {
+            if (g_inflate_call_count == 1) {
+                if (strm->avail_out > 48) {
+                    strm->avail_out -= 48;
+                } else {
+                    strm->avail_out = 0;
+                }
+                return Z_OK;
+            }
+            if (strm->avail_out > 24) {
+                strm->avail_out -= 24;
+            } else {
+                strm->avail_out = 0;
+            }
+            return Z_STREAM_END;
+        }
+        break;
+
+    case TEST_INFLATE_MODE_FINISH_EXPAND_THEN_END:
+        if (flush == Z_FINISH) {
+            if (g_inflate_call_count == 1) {
+                strm->avail_out = 0;
+                return Z_OK;
+            }
+            if (strm->avail_out > 32) {
+                strm->avail_out -= 32;
+            } else {
+                strm->avail_out = 0;
+            }
+            return Z_STREAM_END;
+        }
+        break;
+
+    case TEST_INFLATE_MODE_REAL:
+    default:
+        break;
+    }
+
+    return g_real_inflate_fn(strm, flush);
+}
+
+#ifdef inflate
+#undef inflate
+#endif
+#ifdef inflateInit2
+#undef inflateInit2
+#endif
+#ifdef inflateEnd
+#undef inflateEnd
+#endif
+#define inflate test_inflate
+#define inflateInit2 test_inflateInit2
+#define inflateEnd test_inflateEnd
+
 #include "../src/ngx_http_markdown_streaming_decomp_impl.h"
 
 typedef struct {
@@ -109,6 +306,13 @@ static void
 test_pool_reset(test_pool_t *tp)
 {
     memset(tp, 0, sizeof(*tp));
+    g_palloc_fail_once = 0;
+    g_palloc_return_static_once = 0;
+    g_pcalloc_fail_once = 0;
+    g_alloc_fail_once = 0;
+    g_cleanup_add_fail_once = 0;
+    g_inflate_init_fail_once = 0;
+    test_reset_inflate_mode();
 }
 
 static void
@@ -265,6 +469,45 @@ test_create_and_cleanup(void)
 
     free(decomp);
     TEST_PASS("create and cleanup branches covered");
+}
+
+static void
+test_create_failure_paths_and_cleanup_default(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    ngx_http_markdown_streaming_decomp_t  local;
+
+    TEST_SUBSECTION("create failure paths and cleanup default switch arm");
+
+    test_pool_reset(&tp);
+
+    g_pcalloc_fail_once = 1;
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 1024);
+    TEST_ASSERT(decomp == NULL,
+        "create should fail when ngx_pcalloc returns NULL");
+
+    g_inflate_init_fail_once = 1;
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 1024);
+    TEST_ASSERT(decomp == NULL,
+        "gzip create should fail when inflateInit2 errors");
+
+    g_inflate_init_fail_once = 1;
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_DEFLATE, 1024);
+    TEST_ASSERT(decomp == NULL,
+        "deflate create should fail when inflateInit2 errors");
+
+    memset(&local, 0, sizeof(local));
+    local.initialized = 1;
+    local.type = NGX_HTTP_MARKDOWN_COMPRESSION_UNKNOWN;
+    ngx_http_markdown_streaming_decomp_cleanup(&local);
+    TEST_ASSERT(local.initialized == 0,
+        "cleanup should clear initialized flag for unknown type");
+
+    TEST_PASS("create failure/default cleanup branches covered");
 }
 
 static void
@@ -481,6 +724,480 @@ test_truncated_finish_errors(void)
     TEST_PASS("finish error branch covered");
 }
 
+static void
+test_create_helper_and_limit_branches(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    ngx_http_markdown_streaming_decomp_t  local;
+    u_char                               *heap_buf;
+    u_char                               *buf;
+    size_t                                buf_size;
+    ngx_int_t                             rc;
+
+    TEST_SUBSECTION("create helper and limit guard branches");
+
+    test_pool_reset(&tp);
+    g_cleanup_add_fail_once = 1;
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 1024);
+    TEST_ASSERT(decomp == NULL,
+        "cleanup registration failure should fail create");
+
+    memset(&local, 0, sizeof(local));
+    local.max_decompressed_size = 10;
+    local.total_decompressed = 11;
+    TEST_ASSERT(
+        ngx_http_markdown_streaming_decomp_check_limit(&local, 0) == 1,
+        "check_limit should fail when total already exceeds max");
+    local.total_decompressed = 3;
+    TEST_ASSERT(
+        ngx_http_markdown_streaming_decomp_check_limit(&local, 8) == 1,
+        "check_limit should fail when produced exceeds remaining");
+    TEST_ASSERT(
+        ngx_http_markdown_streaming_decomp_check_limit(&local, 7) == 0,
+        "check_limit should pass on boundary");
+
+    heap_buf = malloc(8);
+    TEST_ASSERT(heap_buf != NULL, "heap allocation should succeed");
+    memcpy(heap_buf, "1234567", 8);
+    buf = heap_buf;
+    buf_size = (size_t) -1;
+    rc = ngx_http_markdown_streaming_decomp_expand_buf(
+        &heap_buf, &buf, &buf_size, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "expand_buf should fail on size overflow");
+    TEST_ASSERT(heap_buf == NULL,
+        "expand_buf overflow should clear heap pointer");
+
+    heap_buf = malloc(8);
+    TEST_ASSERT(heap_buf != NULL, "heap allocation should succeed");
+    memcpy(heap_buf, "abcdefg", 8);
+    buf = heap_buf;
+    buf_size = 8;
+    g_alloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_expand_buf(
+        &heap_buf, &buf, &buf_size, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "expand_buf should fail when ngx_alloc fails");
+    TEST_ASSERT(heap_buf == NULL,
+        "expand_buf alloc failure should clear heap pointer");
+
+    heap_buf = malloc(16);
+    TEST_ASSERT(heap_buf != NULL, "heap allocation should succeed");
+    memcpy(heap_buf, "payload", 8);
+    buf = heap_buf;
+    buf_size = 16;
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_finalize_buf(
+        heap_buf, &buf, &buf_size, 8, &tp.pool);
+    /*
+     * finalize_buf() takes ownership of heap_buf and frees it on
+     * both success and error paths.
+     */
+    heap_buf = NULL;
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finalize_buf should fail when pool allocation fails");
+
+    TEST_PASS("create/helper/limit branches covered");
+}
+
+static void
+test_feed_guard_and_overflow_branches(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    ngx_http_markdown_streaming_decomp_t  fake;
+    u_char                               *out;
+    size_t                                out_len;
+    ngx_int_t                             rc;
+
+    TEST_SUBSECTION("feed guard, budget, and overflow branches");
+
+    test_pool_reset(&tp);
+    out = NULL;
+    out_len = 0;
+
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        NULL, (const u_char *) "x", 1, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR, "NULL decompressor should return NGX_ERROR");
+
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+
+    decomp->finished = 1;
+    out = (u_char *) 0x1;
+    out_len = 1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK, "finished decompressor should no-op");
+    TEST_ASSERT(out == NULL && out_len == 0,
+        "finished decompressor should emit empty output");
+
+    decomp->finished = 0;
+    decomp->max_decompressed_size = 16;
+    decomp->total_decompressed = 16;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED,
+        "exhausted budget should fail early");
+
+    decomp->max_decompressed_size = 0;
+    decomp->total_decompressed = 0;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", ((size_t) UINT_MAX) + 1,
+        &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when input length exceeds uInt");
+
+    memset(&fake, 0, sizeof(fake));
+    fake.initialized = 1;
+    fake.type = NGX_HTTP_MARKDOWN_COMPRESSION_GZIP;
+    fake.total_decompressed = (size_t) -1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        &fake, (const u_char *) "x", 1, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "total size overflow check should fail");
+
+    free(decomp);
+    TEST_PASS("feed guard/overflow branches covered");
+}
+
+static void
+test_finish_guard_and_alloc_branches(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    u_char                               *out;
+    size_t                                out_len;
+    ngx_int_t                             rc;
+
+    TEST_SUBSECTION("finish guard and allocation branches");
+
+    test_pool_reset(&tp);
+    out = NULL;
+    out_len = 0;
+
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        NULL, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR, "NULL decompressor should error in finish");
+
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+
+    decomp->finished = 1;
+    out = (u_char *) 0x1;
+    out_len = 1;
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        decomp, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK, "finished decompressor should no-op in finish");
+    TEST_ASSERT(out == NULL && out_len == 0,
+        "finished decompressor should emit empty finish output");
+
+    decomp->finished = 0;
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        decomp, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finish should fail when output buffer allocation fails");
+
+    free(decomp);
+    TEST_PASS("finish guard/allocation branches covered");
+}
+
+static void
+test_feed_empty_and_large_size_paths(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    u_char                               *out;
+    size_t                                out_len;
+    ngx_int_t                             rc;
+    size_t                                huge_in_len;
+    u_char                                one_byte;
+
+    TEST_SUBSECTION("feed empty input and large-size guard paths");
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+
+    out = (u_char *) 0x1;
+    out_len = 1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 0, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK, "zero-length input should be a no-op");
+    TEST_ASSERT(out == NULL && out_len == 0,
+        "zero-length input should not produce output");
+
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when initial output buffer allocation fails");
+
+    huge_in_len = ((size_t) -1 / 4) + 1;
+    g_palloc_fail_once = 1;
+    one_byte = 'x';
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, &one_byte, huge_in_len, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail safely on saturated initial size");
+
+    g_palloc_return_static_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, &one_byte, ((size_t) UINT_MAX / 2) + 1,
+        &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when output buffer size exceeds zlib uInt");
+
+    free(decomp);
+    TEST_PASS("feed empty/large-size branches covered");
+}
+
+static void
+test_feed_mocked_inflate_paths(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    u_char                               *out;
+    size_t                                out_len;
+    ngx_int_t                             rc;
+
+    TEST_SUBSECTION("feed mocked inflate error/budget/expand paths");
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FEED_EXPAND_THEN_DONE;
+    g_alloc_fail_once = 1;
+    out = NULL;
+    out_len = 0;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when expand_buf fails during inflate loop");
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FEED_EXPAND_THEN_ERROR;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when inflate errors after heap expansion");
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 64);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FEED_EXPAND_THEN_BUDGET;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED,
+        "feed should classify mocked oversized output as budget exceeded");
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FEED_EXPAND_THEN_DONE;
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when finalize_buf cannot allocate pool memory");
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FEED_EXPAND_THEN_DONE;
+    decomp->total_decompressed = (size_t) -8;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, (const u_char *) "x", 1, &out, &out_len,
+        &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed should fail when total_decompressed would overflow size_t");
+    free(decomp);
+
+    TEST_PASS("feed mocked inflate branches covered");
+}
+
+static void
+test_finish_zlib_paths_and_helpers(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    ngx_int_t                             rc;
+    u_char                               *heap_buf;
+    size_t                                buf_size;
+    size_t                                produced;
+    u_char                               *buf;
+
+    TEST_SUBSECTION("finish_zlib helper/error/budget/expand branches");
+
+    heap_buf = malloc(16);
+    TEST_ASSERT(heap_buf != NULL, "heap allocation should succeed");
+    ngx_http_markdown_streaming_decomp_finish_free_heap(&heap_buf);
+    TEST_ASSERT(heap_buf == NULL,
+        "finish helper should free and clear non-NULL heap pointer");
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_ERROR;
+    buf = malloc(128);
+    TEST_ASSERT(buf != NULL, "finish buffer allocation should succeed");
+    buf_size = 128;
+    produced = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish_zlib(
+        decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finish_zlib should fail on inflate error");
+    free(buf);
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 32);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_BUDGET;
+    buf = malloc(4096);
+    TEST_ASSERT(buf != NULL, "finish buffer allocation should succeed");
+    buf_size = 4096;
+    produced = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish_zlib(
+        decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED,
+        "finish_zlib should return budget exceeded when tail is too large");
+    free(buf);
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    buf = g_static_pool_buf;
+    buf_size = ((size_t) UINT_MAX) + 1;
+    produced = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish_zlib(
+        decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finish_zlib should fail when initial finish buffer exceeds uInt");
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_EXPAND_THEN_END;
+    buf = malloc(64);
+    TEST_ASSERT(buf != NULL, "finish buffer allocation should succeed");
+    buf_size = 64;
+    produced = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish_zlib(
+        decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK,
+        "finish_zlib should succeed when mocked flow expands then ends");
+    TEST_ASSERT(produced > 64,
+        "finish_zlib expand path should report produced bytes above old size");
+    free(buf);
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_EXPAND_THEN_END;
+    g_palloc_fail_once = 1;
+    buf = malloc(64);
+    TEST_ASSERT(buf != NULL, "finish buffer allocation should succeed");
+    buf_size = 64;
+    produced = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish_zlib(
+        decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finish_zlib should fail when finalize_buf cannot allocate");
+    /*
+     * finish_zlib() owns the expanded heap buffer and finalize_buf()
+     * frees it on this error path, so buf is dangling here by design.
+     */
+    buf = NULL;
+    free(decomp);
+
+    TEST_PASS("finish_zlib helper/error/budget/expand branches covered");
+}
+
+static void
+test_finish_wrapper_success_and_overflow_paths(void)
+{
+    test_pool_t                           tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    u_char                               *out;
+    size_t                                out_len;
+    ngx_int_t                             rc;
+
+    TEST_SUBSECTION("finish wrapper success and total-size overflow branches");
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_CONTINUE_THEN_END;
+    decomp->total_decompressed = 1;
+    out = NULL;
+    out_len = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        decomp, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK,
+        "finish should succeed for mocked continue-then-end flow");
+    TEST_ASSERT(decomp->finished == 1,
+        "finish should mark decompressor as finished");
+    TEST_ASSERT(out != NULL && out_len > 0,
+        "finish should publish tail output on success");
+    TEST_ASSERT(decomp->total_decompressed > 1,
+        "finish should add produced bytes into running total");
+    free(out);
+    free(decomp);
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, 0);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+    g_inflate_mode = TEST_INFLATE_MODE_FINISH_CONTINUE_THEN_END;
+    decomp->total_decompressed = (size_t) -8;
+    out = NULL;
+    out_len = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        decomp, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK,
+        "finish should still succeed when total would overflow");
+    TEST_ASSERT(decomp->total_decompressed == (size_t) -1,
+        "finish should saturate total_decompressed on overflow");
+    free(out);
+    free(decomp);
+
+    TEST_PASS("finish wrapper success/overflow branches covered");
+}
+
 int
 main(void)
 {
@@ -490,9 +1207,17 @@ main(void)
 
     test_size_to_uint_guards();
     test_create_and_cleanup();
+    test_create_failure_paths_and_cleanup_default();
     test_roundtrip_and_empty_feed();
     test_budget_and_invalid_type_branches();
     test_truncated_finish_errors();
+    test_create_helper_and_limit_branches();
+    test_feed_guard_and_overflow_branches();
+    test_finish_guard_and_alloc_branches();
+    test_feed_empty_and_large_size_paths();
+    test_feed_mocked_inflate_paths();
+    test_finish_zlib_paths_and_helpers();
+    test_finish_wrapper_success_and_overflow_paths();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/streaming_impl_test.c
+++ b/components/nginx-module/tests/unit/streaming_impl_test.c
@@ -268,22 +268,34 @@ ngx_module_t ngx_http_markdown_filter_module = { 0 };
         UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
     } while (0)
 
+#ifdef ngx_log_debug0
+#undef ngx_log_debug0
+#endif
 #define ngx_log_debug0(level, log, err, fmt)                                        \
     do {                                                                             \
         UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
     } while (0)
 
+#ifdef ngx_log_debug1
+#undef ngx_log_debug1
+#endif
 #define ngx_log_debug1(level, log, err, fmt, arg1)                                  \
     do {                                                                             \
         UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt); UNUSED(arg1);          \
     } while (0)
 
+#ifdef ngx_log_debug3
+#undef ngx_log_debug3
+#endif
 #define ngx_log_debug3(level, log, err, fmt, arg1, arg2, arg3)                      \
     do {                                                                             \
         UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
         UNUSED(arg1); UNUSED(arg2); UNUSED(arg3);                                    \
     } while (0)
 
+#ifdef ngx_log_debug4
+#undef ngx_log_debug4
+#endif
 #define ngx_log_debug4(level, log, err, fmt, arg1, arg2, arg3, arg4)                \
     do {                                                                             \
         UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
@@ -1322,8 +1334,8 @@ test_null_input_tracking_and_body_filter_entry(void)
     ngx_chain_t             pending;
     ngx_buf_t               pending_buf;
     ngx_int_t               rc;
-    ngx_flag_t              last_buf;
-    ngx_chain_t            *fallback_cl;
+    ngx_flag_t              last_buf = 0;
+    ngx_chain_t            *fallback_cl = NULL;
 
     TEST_SUBSECTION("null-input, failopen tracking, and body_filter entry");
     reset_globals();
@@ -1781,8 +1793,8 @@ test_process_chain_and_body_filter_deep_paths(void)
     ngx_event_t             read_event;
     ngx_chain_t             in;
     ngx_buf_t               in_buf;
-    ngx_chain_t            *fallback_cl;
-    ngx_flag_t              last_buf;
+    ngx_chain_t            *fallback_cl = NULL;
+    ngx_flag_t              last_buf = 0;
     ngx_int_t               rc;
     ngx_buf_t              *saved_bufs[2] = { NULL, NULL };
     u_char                 *saved_pos[2] = { NULL, NULL };

--- a/components/nginx-module/tests/unit/streaming_impl_test.c
+++ b/components/nginx-module/tests/unit/streaming_impl_test.c
@@ -726,6 +726,12 @@ reset_globals(void)
     g_streaming_finalize_rc = ERROR_SUCCESS;
     ngx_memzero(&g_streaming_finalize_result,
         sizeof(g_streaming_finalize_result));
+    /*
+     * Tests frequently bind ngx_http_markdown_metrics to stack-local
+     * storage; always clear it here so later tests cannot read a stale
+     * out-of-scope pointer.
+     */
+    ngx_http_markdown_metrics = NULL;
 }
 
 static void

--- a/components/nginx-module/tests/unit/streaming_impl_test.c
+++ b/components/nginx-module/tests/unit/streaming_impl_test.c
@@ -1,0 +1,2199 @@
+/*
+ * Test: streaming_impl
+ * Description: direct branch coverage for streaming_impl helper paths.
+ */
+
+#include "../include/test_common.h"
+#include <ctype.h>
+#include <limits.h>
+#include <time.h>
+
+#include "../../src/ngx_http_markdown_filter_module.h"
+#include <markdown_converter.h>
+
+#ifndef MARKDOWN_STREAMING_ENABLED
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("streaming_impl Tests (SKIPPED)\n");
+    printf("MARKDOWN_STREAMING_ENABLED not defined\n");
+    printf("========================================\n\n");
+    return 0;
+}
+
+#else  /* MARKDOWN_STREAMING_ENABLED */
+
+/*
+ * DIVERGENCE RISK:
+ * This unit reimplements a minimal subset of NGINX runtime structs
+ * (ngx_connection_t, ngx_buf_t, ngx_chain_t, ngx_http_request_t,
+ * ngx_http_headers_in_t, ngx_http_headers_out_t, ngx_pool_t) so
+ * ngx_http_markdown_streaming_impl.h can run without linking nginx.
+ *
+ * Contract we preserve from production:
+ * - connection->log/read/error and request->buffered/method/header_only
+ * - buffer flags used by streaming send paths (last_buf/flush/memory)
+ * - header fields read or mutated by streaming logic
+ * - pool cleanup chaining behavior used by teardown tests
+ *
+ * Fields not used by the streaming helper paths are intentionally omitted.
+ * If production structs or streaming invariants change, update these stubs
+ * and extend tests in the same change set.
+ */
+typedef struct ngx_list_part_s ngx_list_part_t;
+typedef struct ngx_table_elt_s ngx_table_elt_t;
+typedef struct ngx_http_headers_in_s ngx_http_headers_in_t;
+typedef struct ngx_http_headers_out_s ngx_http_headers_out_t;
+typedef struct ngx_http_core_srv_conf_s ngx_http_core_srv_conf_t;
+typedef struct ngx_connection_s ngx_connection_t;
+typedef struct ngx_log_s ngx_log_t;
+typedef struct ngx_pool_s ngx_pool_t;
+typedef struct ngx_pool_cleanup_s ngx_pool_cleanup_t;
+typedef struct ngx_time_s ngx_time_t;
+typedef struct ngx_event_s ngx_event_t;
+
+struct ngx_event_s {
+    unsigned pending_eof:1;
+};
+
+struct ngx_list_part_s {
+    void            *elts;
+    ngx_uint_t       nelts;
+    ngx_list_part_t *next;
+};
+
+typedef struct {
+    ngx_list_part_t part;
+} ngx_list_t;
+
+struct ngx_table_elt_s {
+    ngx_str_t key;
+    ngx_str_t value;
+    ngx_uint_t hash;
+};
+
+struct ngx_log_s {
+    int dummy;
+};
+
+struct ngx_connection_s {
+    ngx_log_t   *log;
+    ngx_event_t *read;
+    unsigned     error:1;
+};
+
+struct ngx_pool_cleanup_s {
+    void               (*handler)(void *data);
+    void                *data;
+    ngx_pool_cleanup_t  *next;
+};
+
+struct ngx_pool_s {
+    ngx_pool_cleanup_t *cleanups;
+};
+
+struct ngx_buf_s {
+    u_char   *pos;
+    u_char   *last;
+    u_char   *start;
+    u_char   *end;
+    unsigned  temporary:1;
+    unsigned  memory:1;
+    unsigned  last_buf:1;
+    unsigned  last_in_chain:1;
+    unsigned  flush:1;
+    unsigned  sync:1;
+};
+
+struct ngx_chain_s {
+    ngx_buf_t   *buf;
+    ngx_chain_t *next;
+};
+
+struct ngx_array_s {
+    void      *elts;
+    ngx_uint_t nelts;
+};
+
+struct ngx_http_headers_in_s {
+    ngx_list_t headers;
+    ngx_str_t  server;
+};
+
+struct ngx_http_headers_out_s {
+    ngx_str_t   content_type;
+    off_t       content_length_n;
+    ngx_uint_t  status;
+    size_t      content_type_len;
+    ngx_str_t   charset;
+};
+
+struct ngx_http_core_srv_conf_s {
+    ngx_str_t server_name;
+};
+
+struct ngx_http_request_s {
+    ngx_connection_t      *connection;
+    ngx_pool_t            *pool;
+    ngx_uint_t             method;
+    ngx_uint_t             header_only;
+    ngx_uint_t             buffered;
+    ngx_http_headers_in_t  headers_in;
+    ngx_http_headers_out_t headers_out;
+    ngx_str_t              uri;
+    void                  *loc_conf;
+    void                  *ctx;
+    ngx_http_request_t    *main;
+};
+
+struct ngx_module_s {
+    int dummy;
+};
+
+struct ngx_conf_s {
+    int dummy;
+};
+
+struct ngx_http_complex_value_s {
+    int dummy;
+};
+
+struct ngx_time_s {
+    time_t    sec;
+    ngx_msec_t msec;
+};
+
+#ifndef NGX_OK
+#define NGX_OK 0
+#endif
+#ifndef NGX_ERROR
+#define NGX_ERROR (-1)
+#endif
+#ifndef NGX_AGAIN
+#define NGX_AGAIN (-2)
+#endif
+#ifndef NGX_DONE
+#define NGX_DONE (-4)
+#endif
+#ifndef NGX_DECLINED
+#define NGX_DECLINED (-5)
+#endif
+#ifndef NGX_HTTP_HEAD
+#define NGX_HTTP_HEAD 4
+#endif
+#ifndef NGX_HTTP_NOT_MODIFIED
+#define NGX_HTTP_NOT_MODIFIED 304
+#endif
+#ifndef NGX_LOG_DEBUG_HTTP
+#define NGX_LOG_DEBUG_HTTP 0
+#endif
+#ifndef NGX_LOG_ERR
+#define NGX_LOG_ERR 1
+#endif
+#ifndef NGX_LOG_WARN
+#define NGX_LOG_WARN 2
+#endif
+#ifndef NGX_LOG_INFO
+#define NGX_LOG_INFO 3
+#endif
+#ifndef NGX_HTTP_MARKDOWN_BUFFERED
+#define NGX_HTTP_MARKDOWN_BUFFERED 0x08
+#endif
+#ifndef NGX_MAX_SIZE_T_VALUE
+#define NGX_MAX_SIZE_T_VALUE SIZE_MAX
+#endif
+
+#ifndef ngx_memzero
+#define ngx_memzero(buf, n) memset((buf), 0, (n))
+#endif
+#ifndef ngx_memcpy
+#define ngx_memcpy memcpy
+#endif
+
+static ngx_int_t g_next_body_filter_rc = NGX_OK;
+static ngx_int_t g_next_header_filter_rc = NGX_OK;
+static ngx_int_t g_complex_value_rc = NGX_OK;
+static ngx_int_t g_add_vary_rc = NGX_OK;
+static ngx_int_t g_set_etag_rc = NGX_OK;
+static ngx_int_t g_buffer_init_rc = NGX_OK;
+static ngx_int_t g_buffer_append_rc = NGX_OK;
+static ngx_int_t g_forward_headers_rc = NGX_OK;
+static ngx_int_t g_body_filter_rc = NGX_OK;
+static ngx_int_t g_prepare_options_rc = NGX_OK;
+static uint32_t g_new_with_code_rc = ERROR_SUCCESS;
+static ngx_flag_t g_new_with_code_null_handle = 0;
+static ngx_uint_t g_remove_content_encoding_calls = 0;
+static ngx_uint_t g_abort_calls = 0;
+static ngx_uint_t g_output_free_calls = 0;
+static ngx_uint_t g_log_decision_calls = 0;
+static ngx_uint_t g_palloc_fail_once = 0;
+static ngx_uint_t g_pcalloc_fail_once = 0;
+static ngx_uint_t g_alloc_chain_fail_once = 0;
+static ngx_uint_t g_calloc_buf_fail_once = 0;
+static ngx_uint_t g_pool_cleanup_fail_once = 0;
+static ngx_str_t g_complex_value = { 2, (u_char *) "on" };
+static ngx_time_t g_now = { 100, 0 };
+static ngx_http_markdown_ctx_t *g_ctx = NULL;
+static ngx_int_t g_next_body_filter_seq[8];
+static ngx_uint_t g_next_body_filter_seq_len = 0;
+static ngx_uint_t g_next_body_filter_seq_idx = 0;
+static uint32_t g_streaming_feed_rc = ERROR_SUCCESS;
+static u_char *g_streaming_feed_out_data = NULL;
+static uintptr_t g_streaming_feed_out_len = 0;
+static uint32_t g_streaming_finalize_rc = ERROR_SUCCESS;
+static struct MarkdownResult g_streaming_finalize_result;
+
+u_char ngx_http_markdown_content_type[] =
+    NGX_HTTP_MARKDOWN_CONTENT_TYPE_LITERAL;
+ngx_http_markdown_metrics_t *ngx_http_markdown_metrics = NULL;
+ngx_module_t ngx_http_markdown_filter_module = { 0 };
+
+#define NGX_HTTP_MARKDOWN_METRIC_ADD(field, value)                                  \
+    do {                                                                             \
+        if (ngx_http_markdown_metrics != NULL) {                                     \
+            ngx_http_markdown_metrics->field += (value);                             \
+        }                                                                            \
+    } while (0)
+
+#define NGX_HTTP_MARKDOWN_METRIC_INC(field)                                          \
+    NGX_HTTP_MARKDOWN_METRIC_ADD(field, 1)
+
+#ifdef ngx_log_error
+#undef ngx_log_error
+#endif
+#define ngx_log_error(level, log, err, fmt, ...)                                    \
+    do {                                                                             \
+        UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
+    } while (0)
+
+#define ngx_log_debug0(level, log, err, fmt)                                        \
+    do {                                                                             \
+        UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
+    } while (0)
+
+#define ngx_log_debug1(level, log, err, fmt, arg1)                                  \
+    do {                                                                             \
+        UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt); UNUSED(arg1);          \
+    } while (0)
+
+#define ngx_log_debug3(level, log, err, fmt, arg1, arg2, arg3)                      \
+    do {                                                                             \
+        UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
+        UNUSED(arg1); UNUSED(arg2); UNUSED(arg3);                                    \
+    } while (0)
+
+#define ngx_log_debug4(level, log, err, fmt, arg1, arg2, arg3, arg4)                \
+    do {                                                                             \
+        UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);                        \
+        UNUSED(arg1); UNUSED(arg2); UNUSED(arg3); UNUSED(arg4);                      \
+    } while (0)
+
+static ngx_int_t
+ngx_http_next_body_filter_stub(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    UNUSED(r);
+    UNUSED(in);
+    if (g_next_body_filter_seq_idx < g_next_body_filter_seq_len) {
+        return g_next_body_filter_seq[g_next_body_filter_seq_idx++];
+    }
+    return g_next_body_filter_rc;
+}
+
+static ngx_int_t
+ngx_http_next_header_filter_stub(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    return g_next_header_filter_rc;
+}
+
+/*
+ * DIVERGENCE RISK:
+ * These stubs model the behavior of nginx core filter hooks
+ * (ngx_http_next_body_filter / ngx_http_next_header_filter) for deterministic
+ * unit control. Contract:
+ * - return codes are forwarded exactly from configured globals
+ * - body path can replay scripted responses via
+ *   g_next_body_filter_seq/g_next_body_filter_seq_len in-order
+ * - no hidden side effects beyond consuming one scripted slot
+ *
+ * If production filter chaining semantics or expected return-code handling
+ * change, update this stub contract and the dependent tests together.
+ */
+ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r, ngx_chain_t *in) =
+    ngx_http_next_body_filter_stub;
+ngx_int_t (*ngx_http_next_header_filter)(ngx_http_request_t *r) =
+    ngx_http_next_header_filter_stub;
+
+void *
+ngx_palloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    if (g_palloc_fail_once) {
+        g_palloc_fail_once = 0;
+        return NULL;
+    }
+    return malloc(size);
+}
+
+void *
+ngx_pcalloc(ngx_pool_t *pool, size_t size)
+{
+    void *p;
+    UNUSED(pool);
+    if (g_pcalloc_fail_once) {
+        g_pcalloc_fail_once = 0;
+        return NULL;
+    }
+    p = calloc(1, size);
+    return p;
+}
+
+void *
+ngx_pnalloc(ngx_pool_t *pool, size_t size)
+{
+    return ngx_palloc(pool, size);
+}
+
+void *
+ngx_alloc(size_t size, ngx_log_t *log)
+{
+    UNUSED(log);
+    return malloc(size);
+}
+
+void
+ngx_free(void *p)
+{
+    free(p);
+}
+
+ngx_buf_t *
+ngx_calloc_buf(ngx_pool_t *pool)
+{
+    UNUSED(pool);
+    if (g_calloc_buf_fail_once) {
+        g_calloc_buf_fail_once = 0;
+        return NULL;
+    }
+    return calloc(1, sizeof(ngx_buf_t));
+}
+
+ngx_chain_t *
+ngx_alloc_chain_link(ngx_pool_t *pool)
+{
+    UNUSED(pool);
+    if (g_alloc_chain_fail_once) {
+        g_alloc_chain_fail_once = 0;
+        return NULL;
+    }
+    return calloc(1, sizeof(ngx_chain_t));
+}
+
+ngx_pool_cleanup_t *
+ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
+{
+    ngx_pool_cleanup_t *cln;
+
+    UNUSED(size);
+    if (pool == NULL) {
+        return NULL;
+    }
+    if (g_pool_cleanup_fail_once) {
+        g_pool_cleanup_fail_once = 0;
+        return NULL;
+    }
+
+    cln = calloc(1, sizeof(ngx_pool_cleanup_t));
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    cln->next = pool->cleanups;
+    pool->cleanups = cln;
+    return cln;
+}
+
+void
+ngx_http_clear_content_length(ngx_http_request_t *r)
+{
+    r->headers_out.content_length_n = -1;
+}
+
+ngx_int_t
+ngx_http_complex_value(ngx_http_request_t *r,
+    ngx_http_complex_value_t *cv, ngx_str_t *val)
+{
+    UNUSED(r);
+    UNUSED(cv);
+    if (g_complex_value_rc != NGX_OK) {
+        return g_complex_value_rc;
+    }
+    *val = g_complex_value;
+    return NGX_OK;
+}
+
+ngx_int_t
+ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
+{
+    for (size_t i = 0; i < n; i++) {
+        int c1 = tolower((unsigned char) s1[i]);
+        int c2 = tolower((unsigned char) s2[i]);
+        if (c1 != c2) {
+            return c1 - c2;
+        }
+    }
+    return 0;
+}
+
+ngx_time_t *
+ngx_timeofday(void)
+{
+    return &g_now;
+}
+
+void *
+ngx_http_get_module_ctx(ngx_http_request_t *r, ngx_module_t module)
+{
+    UNUSED(module);
+    return r->ctx;
+}
+
+ngx_http_markdown_conf_t *
+ngx_http_get_module_loc_conf(ngx_http_request_t *r, ngx_module_t module)
+{
+    UNUSED(module);
+    return (ngx_http_markdown_conf_t *) r->loc_conf;
+}
+
+void
+ngx_http_set_ctx(ngx_http_request_t *r, void *c, ngx_module_t module)
+{
+    UNUSED(module);
+    r->ctx = c;
+}
+
+void
+markdown_streaming_abort(struct StreamingConverterHandle *handle)
+{
+    UNUSED(handle);
+    g_abort_calls++;
+}
+
+void
+markdown_streaming_output_free(uint8_t *data, uintptr_t len)
+{
+    UNUSED(data);
+    UNUSED(len);
+    g_output_free_calls++;
+}
+
+uint32_t
+markdown_streaming_feed(struct StreamingConverterHandle *handle,
+    const uint8_t *html_chunk, uintptr_t chunk_len,
+    uint8_t **out_data, uintptr_t *out_len)
+{
+    UNUSED(handle);
+    UNUSED(html_chunk);
+    UNUSED(chunk_len);
+    if (out_data != NULL) {
+        *out_data = g_streaming_feed_out_data;
+    }
+    if (out_len != NULL) {
+        *out_len = g_streaming_feed_out_len;
+    }
+    return g_streaming_feed_rc;
+}
+
+uint32_t
+markdown_streaming_finalize(struct StreamingConverterHandle *handle,
+    struct MarkdownResult *result)
+{
+    UNUSED(handle);
+    if (result != NULL) {
+        *result = g_streaming_finalize_result;
+    }
+    return g_streaming_finalize_rc;
+}
+
+uint32_t
+markdown_streaming_new_with_code(const struct MarkdownOptions *options,
+    struct StreamingConverterHandle **out_handle)
+{
+    UNUSED(options);
+    if (out_handle != NULL && !g_new_with_code_null_handle) {
+        *out_handle = (struct StreamingConverterHandle *) (uintptr_t) 0x1;
+    }
+    return g_new_with_code_rc;
+}
+
+void
+markdown_result_free(struct MarkdownResult *result)
+{
+    if (result != NULL) {
+        ngx_memzero(result, sizeof(*result));
+    }
+}
+
+ngx_int_t
+ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    return g_add_vary_rc;
+}
+
+void
+ngx_http_markdown_remove_content_encoding(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    g_remove_content_encoding_calls++;
+}
+
+ngx_int_t
+ngx_http_markdown_set_etag(ngx_http_request_t *r,
+    const u_char *etag, size_t etag_len)
+{
+    UNUSED(r);
+    UNUSED(etag);
+    UNUSED(etag_len);
+    return g_set_etag_rc;
+}
+
+ngx_int_t
+ngx_http_markdown_forward_headers(ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx)
+{
+    UNUSED(r);
+    UNUSED(ctx);
+    return g_forward_headers_rc;
+}
+
+ngx_int_t
+ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    UNUSED(r);
+    UNUSED(in);
+    return g_body_filter_rc;
+}
+
+ngx_int_t
+ngx_http_markdown_buffer_init(ngx_http_markdown_buffer_t *buf, size_t max_size,
+    ngx_pool_t *pool)
+{
+    UNUSED(pool);
+    if (g_buffer_init_rc != NGX_OK) {
+        return g_buffer_init_rc;
+    }
+    buf->data = malloc(max_size ? max_size : 64);
+    if (buf->data == NULL) {
+        return NGX_ERROR;
+    }
+    buf->size = 0;
+    buf->capacity = max_size ? max_size : 64;
+    buf->max_size = max_size;
+    return NGX_OK;
+}
+
+ngx_int_t
+ngx_http_markdown_buffer_append(ngx_http_markdown_buffer_t *buf,
+    const u_char *data, size_t len)
+{
+    if (g_buffer_append_rc != NGX_OK) {
+        return g_buffer_append_rc;
+    }
+    if (buf->data == NULL || buf->capacity < len) {
+        return NGX_ERROR;
+    }
+    if (len > 0) {
+        ngx_memcpy(buf->data, data, len);
+    }
+    buf->size = len;
+    return NGX_OK;
+}
+
+ngx_int_t
+ngx_http_markdown_prepare_conversion_options(ngx_http_request_t *r,
+    const ngx_http_markdown_conf_t *conf, struct MarkdownOptions *options)
+{
+    UNUSED(r);
+    UNUSED(conf);
+    UNUSED(options);
+    return g_prepare_options_rc;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_convert(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_CONVERT") - 1,
+        (u_char *) "STREAMING_CONVERT" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_fail_postcommit(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_FAIL_POSTCOMMIT") - 1,
+        (u_char *) "STREAMING_FAIL_POSTCOMMIT" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_fallback(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_FALLBACK") - 1,
+        (u_char *) "STREAMING_FALLBACK" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_skip_unsupported(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_SKIP_UNSUPPORTED") - 1,
+        (u_char *) "STREAMING_SKIP_UNSUPPORTED" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_budget_exceeded(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_BUDGET_EXCEEDED") - 1,
+        (u_char *) "STREAMING_BUDGET_EXCEEDED" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_precommit_failopen(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_PRECOMMIT_FAILOPEN") - 1,
+        (u_char *) "STREAMING_PRECOMMIT_FAILOPEN" };
+    return &s;
+}
+
+const ngx_str_t *
+ngx_http_markdown_reason_streaming_precommit_reject(void)
+{
+    static ngx_str_t s = { sizeof("STREAMING_PRECOMMIT_REJECT") - 1,
+        (u_char *) "STREAMING_PRECOMMIT_REJECT" };
+    return &s;
+}
+
+void
+ngx_http_markdown_log_decision(ngx_http_request_t *r,
+    const ngx_http_markdown_conf_t *conf, const ngx_str_t *reason_code)
+{
+    UNUSED(r);
+    UNUSED(conf);
+    UNUSED(reason_code);
+    g_log_decision_calls++;
+}
+
+#include "../../src/ngx_http_markdown_streaming_impl.h"
+
+static void
+reset_globals(void)
+{
+    g_next_body_filter_rc = NGX_OK;
+    g_next_header_filter_rc = NGX_OK;
+    g_complex_value_rc = NGX_OK;
+    g_add_vary_rc = NGX_OK;
+    g_set_etag_rc = NGX_OK;
+    g_buffer_init_rc = NGX_OK;
+    g_buffer_append_rc = NGX_OK;
+    g_forward_headers_rc = NGX_OK;
+    g_body_filter_rc = NGX_OK;
+    g_prepare_options_rc = NGX_OK;
+    g_new_with_code_rc = ERROR_SUCCESS;
+    g_new_with_code_null_handle = 0;
+    g_remove_content_encoding_calls = 0;
+    g_abort_calls = 0;
+    g_output_free_calls = 0;
+    g_log_decision_calls = 0;
+    g_palloc_fail_once = 0;
+    g_pcalloc_fail_once = 0;
+    g_alloc_chain_fail_once = 0;
+    g_calloc_buf_fail_once = 0;
+    g_pool_cleanup_fail_once = 0;
+    g_complex_value = (ngx_str_t) { 2, (u_char *) "on" };
+    g_now.sec = 100;
+    g_now.msec = 0;
+    g_ctx = NULL;
+    g_next_body_filter_seq_len = 0;
+    g_next_body_filter_seq_idx = 0;
+    g_streaming_feed_rc = ERROR_SUCCESS;
+    g_streaming_feed_out_data = NULL;
+    g_streaming_feed_out_len = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    ngx_memzero(&g_streaming_finalize_result,
+        sizeof(g_streaming_finalize_result));
+}
+
+static void
+set_next_body_filter_sequence(const ngx_int_t *seq, ngx_uint_t count)
+{
+    ngx_uint_t i;
+
+    if (count > (sizeof(g_next_body_filter_seq)
+                 / sizeof(g_next_body_filter_seq[0])))
+    {
+        count = (sizeof(g_next_body_filter_seq)
+                 / sizeof(g_next_body_filter_seq[0]));
+    }
+
+    for (i = 0; i < count; i++) {
+        g_next_body_filter_seq[i] = seq[i];
+    }
+    g_next_body_filter_seq_len = count;
+    g_next_body_filter_seq_idx = 0;
+}
+
+static void
+init_request_ctx_conf(ngx_http_request_t *r, ngx_http_markdown_ctx_t *ctx,
+    ngx_http_markdown_conf_t *conf, ngx_pool_t *pool, ngx_connection_t *conn,
+    ngx_log_t *log, ngx_event_t *read_event)
+{
+    ngx_memzero(r, sizeof(*r));
+    ngx_memzero(ctx, sizeof(*ctx));
+    ngx_memzero(conf, sizeof(*conf));
+    ngx_memzero(pool, sizeof(*pool));
+    ngx_memzero(conn, sizeof(*conn));
+    ngx_memzero(log, sizeof(*log));
+    ngx_memzero(read_event, sizeof(*read_event));
+
+    conn->log = log;
+    conn->read = read_event;
+    r->connection = conn;
+    r->pool = pool;
+    r->main = r;
+    r->loc_conf = conf;
+    r->ctx = ctx;
+
+    ctx->request = r;
+    ctx->processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+}
+
+static void
+test_cleanup_paths(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_chain_t             cl;
+    ngx_buf_t               b;
+
+    TEST_SUBSECTION("cleanup aborts handle and frees pending buffers");
+    reset_globals();
+    ngx_http_markdown_streaming_cleanup(NULL);
+    ngx_memzero(&ctx, sizeof(ctx));
+    ngx_memzero(&cl, sizeof(cl));
+    ngx_memzero(&b, sizeof(b));
+
+    b.pos = (u_char *) "abc";
+    b.last = b.pos + 3;
+    b.temporary = 1;
+    cl.buf = &b;
+    cl.next = NULL;
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x1;
+    ctx.streaming.pending_output = &cl;
+    ngx_http_markdown_streaming_cleanup(&ctx);
+
+    TEST_ASSERT(ctx.streaming.handle == NULL, "cleanup should clear handle");
+    TEST_ASSERT(ctx.streaming.pending_output == NULL,
+        "cleanup should clear pending chain");
+    TEST_ASSERT(g_abort_calls == 1, "cleanup should abort streaming handle once");
+    TEST_ASSERT(g_output_free_calls == 1,
+        "cleanup should free temporary pending buffer");
+    TEST_PASS("cleanup paths covered");
+}
+
+static void
+test_select_processing_path(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_str_t               excluded[1];
+    ngx_array_t             arr;
+    ngx_uint_t              path;
+
+    TEST_SUBSECTION("select_processing_path engine and skip branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+
+    conf.streaming_engine = (ngx_http_complex_value_t *) (uintptr_t) 0x1;
+    conf.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_DISABLED;
+    conf.large_body_threshold = 1024;
+    r.headers_out.content_type = (ngx_str_t) { 9, (u_char *) "text/html" };
+    r.headers_out.content_length_n = 2048;
+
+    g_complex_value = (ngx_str_t) { 3, (u_char *) "off" };
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "engine=off should route full-buffer");
+
+    g_complex_value = (ngx_str_t) { 2, (u_char *) "on" };
+    r.method = NGX_HTTP_HEAD;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "HEAD should route full-buffer");
+    r.method = 0;
+
+    r.headers_out.status = NGX_HTTP_NOT_MODIFIED;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "304 should route full-buffer");
+    r.headers_out.status = 200;
+
+    conf.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_FULL_SUPPORT;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "full_support should route full-buffer");
+    conf.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_DISABLED;
+
+    r.headers_out.content_type = (ngx_str_t) { 17, (u_char *) "text/event-stream" };
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "SSE should route full-buffer");
+
+    r.headers_out.content_type = (ngx_str_t) { 9, (u_char *) "text/html" };
+    excluded[0] = (ngx_str_t) { 4, (u_char *) "text" };
+    arr.elts = excluded;
+    arr.nelts = 1;
+    conf.stream_types = &arr;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "excluded stream_types should route full-buffer");
+
+    conf.stream_types = NULL;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_STREAMING,
+        "engine=on should route streaming");
+
+    excluded[0] = (ngx_str_t) { 11, (u_char *) "application" };
+    arr.elts = excluded;
+    arr.nelts = 1;
+    conf.stream_types = &arr;
+    r.headers_out.content_type = (ngx_str_t) { 9, (u_char *) "text/html" };
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_STREAMING,
+        "non-matching stream_types should keep streaming enabled");
+
+    r.headers_out.content_type = (ngx_str_t) { 0, NULL };
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_STREAMING,
+        "NULL content-type data should not trigger exclusions");
+
+    conf.stream_types = NULL;
+    r.headers_out.content_type = (ngx_str_t) { 9, (u_char *) "text/html" };
+    conf.conditional_requests =
+        NGX_HTTP_MARKDOWN_CONDITIONAL_IF_MODIFIED_SINCE;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_STREAMING,
+        "if_modified_since_only should keep streaming path");
+    conf.conditional_requests = NGX_HTTP_MARKDOWN_CONDITIONAL_DISABLED;
+
+    g_complex_value = (ngx_str_t) { 4, (u_char *) "auto" };
+    r.headers_out.content_length_n = 10;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "auto with small content-length should route full-buffer");
+
+    r.headers_out.content_length_n = -1;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_STREAMING,
+        "auto without content-length should route streaming");
+
+    g_complex_value_rc = NGX_ERROR;
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "complex-value failure should route full-buffer");
+    g_complex_value_rc = NGX_OK;
+
+    g_complex_value = (ngx_str_t) { 3, (u_char *) "bad" };
+    path = ngx_http_markdown_select_processing_path(&r, &conf);
+    TEST_ASSERT(path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "invalid engine value should route full-buffer");
+
+    TEST_PASS("path-selection branches covered");
+}
+
+static void
+test_update_headers_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("update_headers success and failure branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+
+    ctx.decompression.needed = 1;
+    rc = ngx_http_markdown_streaming_update_headers(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "update_headers should succeed");
+    TEST_ASSERT(r.headers_out.content_type.len == NGX_HTTP_MARKDOWN_CONTENT_TYPE_LEN,
+        "content-type should be markdown");
+    TEST_ASSERT(r.headers_out.content_length_n == -1,
+        "content-length should be cleared");
+    TEST_ASSERT(g_remove_content_encoding_calls == 1,
+        "decompression path should remove content-encoding");
+
+    g_add_vary_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_update_headers(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR, "vary add failure should return error");
+    g_add_vary_rc = NGX_OK;
+
+    g_set_etag_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_update_headers(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR, "etag clear failure should return error");
+
+    TEST_PASS("update_headers branches covered");
+}
+
+static void
+test_send_output_and_resume_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    ngx_buf_t               b_ok;
+    ngx_chain_t             c_ok;
+    ngx_buf_t               b_err;
+    ngx_chain_t             c_err;
+    u_char                  data[] = "hello";
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("send_output and resume_pending backpressure branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    ctx.streaming.feed_start_ms = 10;
+    g_now.sec = 11;
+    g_now.msec = 0;
+
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_send_output(
+        &r, &ctx, data, sizeof(data) - 1, 0);
+    TEST_ASSERT(rc == NGX_OK, "send_output should succeed");
+    TEST_ASSERT(ctx.streaming.flushes_sent == 1,
+        "flush counter should increment on success");
+    TEST_ASSERT(ctx.streaming.ttfb_recorded == 1,
+        "successful first send should record TTFB");
+
+    ctx.streaming.feed_start_ms = 20;
+    ctx.streaming.ttfb_recorded = 0;
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_streaming_send_output(
+        &r, &ctx, data, sizeof(data) - 1, 0);
+    TEST_ASSERT(rc == NGX_AGAIN, "send_output should propagate NGX_AGAIN");
+    TEST_ASSERT(ctx.streaming.pending_output != NULL,
+        "NGX_AGAIN should store pending output");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
+        "NGX_AGAIN should set buffered flag");
+
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "resume_pending should drain pending chain");
+    TEST_ASSERT(ctx.streaming.pending_output == NULL,
+        "resume should clear pending chain");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) == 0,
+        "resume should clear buffered flag");
+
+    ngx_memzero(&b_ok, sizeof(b_ok));
+    ngx_memzero(&c_ok, sizeof(c_ok));
+    c_ok.buf = &b_ok;
+    c_ok.next = NULL;
+    ctx.streaming.pending_terminal_metrics = 1;
+    ctx.streaming.pending_output = &c_ok;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "terminal metric latch should not fail resume");
+    TEST_ASSERT(ctx.streaming.pending_terminal_metrics == 0,
+        "resume should clear pending terminal metrics");
+
+    ngx_memzero(&b_err, sizeof(b_err));
+    ngx_memzero(&c_err, sizeof(c_err));
+    c_err.buf = &b_err;
+    c_err.next = NULL;
+    ctx.streaming.pending_output = &c_err;
+    g_next_body_filter_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR, "resume should propagate downstream error");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "resume error should record post-commit failure");
+
+    ctx.streaming.finalize_pending_lastbuf = 1;
+    ctx.streaming.pending_output = NULL;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "deferred last_buf should be sent on resume");
+
+    TEST_PASS("send_output/resume_pending branches covered");
+}
+
+static void
+test_send_output_error_and_deferred_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    u_char                  data[] = "hello";
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("send_output allocation errors and deferred-lastbuf branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    g_calloc_buf_fail_once = 1;
+    rc = ngx_http_markdown_streaming_send_output(
+        &r, &ctx, data, sizeof(data) - 1, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "send_output should fail when buffer allocation fails");
+
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_send_output(
+        &r, &ctx, data, sizeof(data) - 1, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "send_output should fail when payload copy allocation fails");
+
+    g_alloc_chain_fail_once = 1;
+    rc = ngx_http_markdown_streaming_send_output(
+        &r, &ctx, NULL, 0, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "send_output should fail when chain-link allocation fails");
+
+    r.buffered = 0;
+    rc = ngx_http_markdown_streaming_handle_backpressure(&r, &ctx);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "backpressure helper should return NGX_AGAIN");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
+        "backpressure helper should set buffered flag");
+
+    ctx.streaming.failure_recorded = 0;
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_streaming_send_deferred_lastbuf(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "deferred last_buf should propagate backpressure");
+    TEST_ASSERT(ctx.streaming.pending_terminal_metrics == 1,
+        "deferred last_buf backpressure should latch terminal metrics");
+
+    ctx.streaming.pending_terminal_metrics = 0;
+    ctx.streaming.failure_recorded = 0;
+    g_next_body_filter_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_send_deferred_lastbuf(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "deferred last_buf should propagate hard downstream errors");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "deferred last_buf hard error should record postcommit failure");
+
+    TEST_PASS("send_output error/deferred branches covered");
+}
+
+static void
+test_fallback_to_fullbuffer_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    u_char                  prebuf[] = "xyz";
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("fallback_to_fullbuffer success and error branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    conf.max_size = 64;
+    ctx.conversion_attempted = 1;
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x2;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf;
+    ctx.streaming.prebuffer.size = sizeof(prebuf);
+    ngx_http_markdown_metrics->path_hits.streaming = 2;
+
+    rc = ngx_http_markdown_streaming_fallback_to_fullbuffer(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED, "fallback should return NGX_DECLINED");
+    TEST_ASSERT(ctx.processing_path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "fallback should switch to full-buffer path");
+    TEST_ASSERT(ctx.conversion_attempted == 0,
+        "fallback should clear conversion_attempted");
+    TEST_ASSERT(ctx.buffer_initialized == 1,
+        "fallback should initialize main buffer");
+    TEST_ASSERT(ctx.decompression.done == 1,
+        "fallback should mark decompression done");
+
+    ctx.buffer_initialized = 0;
+    g_buffer_init_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_fallback_to_fullbuffer(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "buffer_init failure should propagate NGX_ERROR");
+
+    TEST_PASS("fallback branches covered");
+}
+
+static void
+test_postcommit_and_precommit_error_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("postcommit/precommit error policy branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x3;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_handle_postcommit_error(
+        &r, &ctx, &conf, ERROR_MEMORY_LIMIT);
+    TEST_ASSERT(rc == NGX_OK, "postcommit error should send terminal chunk");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "postcommit error should record failure once");
+    TEST_ASSERT(metrics.streaming.budget_exceeded_total == 1,
+        "memory-limit postcommit should classify budget exceeded");
+
+    ctx.streaming.failure_recorded = 0;
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x4;
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_REJECT;
+    rc = ngx_http_markdown_streaming_precommit_error(
+        &r, &ctx, &conf, ERROR_INTERNAL);
+    TEST_ASSERT(rc == NGX_ERROR, "precommit reject policy should fail-closed");
+    TEST_ASSERT(metrics.streaming.precommit_reject_total == 1,
+        "precommit reject metric should increment");
+
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+    ctx.eligible = 1;
+    rc = ngx_http_markdown_streaming_precommit_error(
+        &r, &ctx, &conf, ERROR_MEMORY_LIMIT);
+    TEST_ASSERT(rc == NGX_DECLINED, "precommit pass policy should fail-open");
+    TEST_ASSERT(ctx.eligible == 0, "precommit fail-open should mark ineligible");
+    TEST_ASSERT(metrics.streaming.precommit_failopen_total == 1,
+        "precommit fail-open metric should increment");
+
+    rc = ngx_http_markdown_streaming_precommit_error(
+        &r, &ctx, &conf, ERROR_STREAMING_FALLBACK);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "streaming fallback error should route through fallback");
+
+    TEST_PASS("postcommit/precommit branches covered");
+}
+
+static void
+test_abort_passthrough_and_reentry_helpers(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_chain_t             in;
+    ngx_buf_t               in_buf;
+    ngx_chain_t             cur;
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("abort, passthrough, and reentry helpers");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&in, sizeof(in));
+    ngx_memzero(&in_buf, sizeof(in_buf));
+    ngx_memzero(&cur, sizeof(cur));
+    in.buf = &in_buf;
+    cur.next = &in;
+
+    rc = ngx_http_markdown_streaming_check_client_abort(&r, &ctx);
+    TEST_ASSERT(rc == 0, "no connection error should continue");
+
+    r.connection->error = 1;
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x5;
+    rc = ngx_http_markdown_streaming_check_client_abort(&r, &ctx);
+    TEST_ASSERT(rc == NGX_ERROR, "connection error should abort request");
+    TEST_ASSERT(ctx.streaming.handle == NULL,
+        "client abort should clear streaming handle");
+    r.connection->error = 0;
+
+    g_next_body_filter_rc = NGX_OK;
+    ctx.headers_forwarded = 0;
+    g_forward_headers_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_passthrough(&r, &ctx, &in);
+    TEST_ASSERT(rc == NGX_OK, "passthrough should forward headers then body");
+
+    ctx.headers_forwarded = 0;
+    g_forward_headers_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_passthrough(&r, &ctx, &in);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "passthrough should fail when forwarding headers fails");
+    g_forward_headers_rc = NGX_OK;
+
+    ctx.headers_forwarded = 1;
+    g_next_body_filter_rc = NGX_DONE;
+    rc = ngx_http_markdown_streaming_passthrough(&r, &ctx, &in);
+    TEST_ASSERT(rc == NGX_DONE,
+        "passthrough should call next body filter when headers already forwarded");
+
+    g_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+        &r, &cur, 0);
+    TEST_ASSERT(rc == NGX_OK,
+        "reentry should pass cl->next to full-buffer body filter");
+
+    cur.next = NULL;
+    g_calloc_buf_fail_once = 1;
+    rc = ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+        &r, &cur, 1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "reentry should fail when terminal buffer allocation fails");
+
+    g_alloc_chain_fail_once = 1;
+    rc = ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+        &r, &cur, 1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "reentry should fail when terminal chain allocation fails");
+
+    g_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback(
+        &r, &cur, 1);
+    TEST_ASSERT(rc == NGX_OK,
+        "reentry should synthesize terminal buffer when needed");
+
+    TEST_PASS("abort/passthrough/reentry helpers covered");
+}
+
+static void
+test_null_input_tracking_and_body_filter_entry(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_chain_t             c1;
+    ngx_buf_t               b1;
+    ngx_chain_t             c2;
+    ngx_buf_t               b2;
+    ngx_chain_t             pending;
+    ngx_buf_t               pending_buf;
+    ngx_int_t               rc;
+    ngx_flag_t              last_buf;
+    ngx_chain_t            *fallback_cl;
+
+    TEST_SUBSECTION("null-input, failopen tracking, and body_filter entry");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    conf.streaming_engine = (ngx_http_complex_value_t *) (uintptr_t) 0x1;
+
+    ngx_memzero(&c1, sizeof(c1));
+    ngx_memzero(&b1, sizeof(b1));
+    ngx_memzero(&c2, sizeof(c2));
+    ngx_memzero(&b2, sizeof(b2));
+    ngx_memzero(&pending, sizeof(pending));
+    ngx_memzero(&pending_buf, sizeof(pending_buf));
+
+    c1.buf = &b1;
+    c1.next = &c2;
+    c2.buf = &b2;
+    c2.next = NULL;
+    b1.pos = (u_char *) "a";
+    b1.last = b1.pos + 1;
+    b2.pos = (u_char *) "b";
+    b2.last = b2.pos + 1;
+
+    rc = ngx_http_markdown_streaming_count_chain_bufs(&c1);
+    TEST_ASSERT(rc == 2, "count_chain_bufs should count only non-NULL buffers");
+
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    rc = ngx_http_markdown_streaming_prepare_failopen_tracking(
+        &r, &ctx, &c1);
+    TEST_ASSERT(rc == NGX_OK,
+        "post-commit tracking should short-circuit");
+
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 0;
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_prepare_failopen_tracking(
+        &r, &ctx, &c1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "tracking allocation failure should return NGX_ERROR");
+
+    {
+        ngx_buf_t *old_bufs[1];
+        u_char    *old_pos[1];
+
+        old_bufs[0] = &b1;
+        old_pos[0] = b1.pos;
+        ctx.streaming.failopen_consumed_bufs = old_bufs;
+        ctx.streaming.failopen_consumed_pos = old_pos;
+        ctx.streaming.failopen_consumed_count = 1;
+        ctx.streaming.failopen_consumed_capacity = 1;
+
+        rc = ngx_http_markdown_streaming_prepare_failopen_tracking(
+            &r, &ctx, &c1);
+        TEST_ASSERT(rc == NGX_OK,
+            "tracking should grow storage and copy prior consumed slots");
+    }
+
+    pending.buf = &pending_buf;
+    pending.next = NULL;
+    ctx.streaming.pending_output = &pending;
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_streaming_handle_null_input(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "null-input handler should propagate resume backpressure");
+
+    ctx.streaming.pending_output = NULL;
+    ctx.streaming.finalize_after_pending = 1;
+    ctx.streaming.handle = NULL;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_handle_null_input(
+        &r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "null-input handler should finalize when pending drain completes");
+
+    last_buf = 0;
+    fallback_cl = NULL;
+    c1.buf = NULL;
+    c1.next = NULL;
+    rc = ngx_http_markdown_streaming_process_chain(
+        &r, &ctx, &conf, &c1, &last_buf, 0, &fallback_cl);
+    TEST_ASSERT(rc == NGX_OK,
+        "process_chain should skip NULL buffers safely");
+
+    r.ctx = NULL;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &c1);
+    TEST_ASSERT(rc == g_next_body_filter_rc,
+        "body_filter should passthrough when ctx is missing");
+    r.ctx = &ctx;
+
+    r.loc_conf = NULL;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &c1);
+    TEST_ASSERT(rc == g_next_body_filter_rc,
+        "body_filter should passthrough when conf is missing");
+    r.loc_conf = &conf;
+
+    r.connection->error = 1;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &c1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "body_filter should stop on client abort");
+    r.connection->error = 0;
+
+    ctx.eligible = 0;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &c1);
+    TEST_ASSERT(rc == g_next_body_filter_rc,
+        "ineligible ctx should passthrough body filter");
+    ctx.eligible = 1;
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *) (uintptr_t) 0x6;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 0;
+    c1.buf = &b1;
+    b1.pos = (u_char *) "x";
+    b1.last = b1.pos + 1;
+    b1.last_buf = 0;
+    c1.next = NULL;
+    g_palloc_fail_once = 1;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &c1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "body_filter should surface failopen tracking allocation errors");
+
+    TEST_PASS("null-input/tracking/body-filter entry branches covered");
+}
+
+static void
+test_init_handle_and_chunk_result_helpers(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    ngx_chain_t             in;
+    ngx_buf_t               in_buf;
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("init_handle and chunk_result helper branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    conf.streaming_budget = 256;
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "init_handle should succeed on happy path");
+    TEST_ASSERT(ctx.streaming.handle != NULL,
+        "init_handle should set streaming handle");
+    TEST_ASSERT(ctx.streaming.commit_state == NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE,
+        "init_handle should enter pre-commit state");
+    TEST_ASSERT(ctx.conversion_attempted == 1,
+        "init_handle should mark conversion attempted");
+
+    ctx.streaming.handle = NULL;
+    g_prepare_options_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "prepare-options failure should route through precommit_error");
+    g_prepare_options_rc = NGX_OK;
+
+    ctx.streaming.handle = NULL;
+    g_new_with_code_rc = ERROR_INTERNAL;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "handle-create failure should route through precommit_error");
+    g_new_with_code_rc = ERROR_SUCCESS;
+
+    ctx.streaming.handle = NULL;
+    g_new_with_code_null_handle = 1;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "NULL handle on success code should still fail");
+    g_new_with_code_null_handle = 0;
+
+    ctx.streaming.handle = NULL;
+    g_pool_cleanup_fail_once = 1;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "cleanup registration failure should return NGX_ERROR");
+
+    ctx.streaming.handle = NULL;
+    ctx.decompression.needed = 1;
+    ctx.decompression.type = NGX_HTTP_MARKDOWN_COMPRESSION_UNKNOWN;
+    rc = ngx_http_markdown_streaming_init_handle(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "decompressor init failure should route through precommit_error");
+
+    ngx_memzero(&in, sizeof(in));
+    ngx_memzero(&in_buf, sizeof(in_buf));
+    in.buf = &in_buf;
+    in.next = NULL;
+
+    rc = ngx_http_markdown_streaming_handle_chunk_result(
+        &r, &ctx, &in, NGX_AGAIN, 0);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "chunk_result should propagate NGX_AGAIN");
+
+    rc = ngx_http_markdown_streaming_handle_chunk_result(
+        &r, &ctx, &in, NGX_OK, 0);
+    TEST_ASSERT(rc == NGX_OK, "chunk_result should keep NGX_OK");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_FULLBUFFER;
+    rc = ngx_http_markdown_streaming_handle_chunk_result(
+        &r, &ctx, &in, NGX_ERROR, 0);
+    TEST_ASSERT(rc == NGX_DONE,
+        "chunk_result should return NGX_DONE after fallback switch");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.eligible = 0;
+    g_forward_headers_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_handle_chunk_result(
+        &r, &ctx, &in, NGX_ERROR, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "chunk_result fail-open should surface header-forward errors");
+
+    ctx.eligible = 1;
+    rc = ngx_http_markdown_streaming_handle_chunk_result(
+        &r, &ctx, &in, NGX_ERROR, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "chunk_result should propagate non-special errors");
+
+    TEST_PASS("init_handle/chunk_result branches covered");
+}
+
+static void
+test_commit_feed_and_finalize_core_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_http_markdown_metrics_t metrics;
+    u_char                  prebuf_data[16];
+    u_char                  out_data[] = "xyz";
+    ngx_int_t               rc;
+
+    TEST_SUBSECTION("commit/feed-result/finalize core branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    ngx_memzero(&metrics, sizeof(metrics));
+    ngx_http_markdown_metrics = &metrics;
+
+    conf.max_size = 64;
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.size = 3;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x11;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+
+    g_add_vary_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_commit(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "commit should fail when header update fails");
+    g_add_vary_rc = NGX_OK;
+
+    g_next_header_filter_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_commit(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "commit should propagate next header filter errors");
+
+    g_next_header_filter_rc = 1;
+    rc = ngx_http_markdown_streaming_commit(&r, &ctx, &conf);
+    TEST_ASSERT(rc == 1,
+        "commit should propagate positive next header filter rc");
+    g_next_header_filter_rc = NGX_OK;
+
+    rc = ngx_http_markdown_streaming_commit(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK, "commit should succeed on happy path");
+    TEST_ASSERT(ctx.streaming.commit_state
+        == NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST,
+        "commit should switch state to post-commit");
+    TEST_ASSERT(ctx.headers_forwarded == 1,
+        "commit should mark headers as forwarded");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x12;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.prebuffer.size = 3;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_STREAMING_FALLBACK, out_data, 3);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "fallback feed result should switch to full-buffer");
+    TEST_ASSERT(ctx.processing_path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "fallback feed result should update processing path");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x13;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    g_next_body_filter_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_INTERNAL, NULL, 0);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "post-commit feed errors should terminate with downstream rc");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "post-commit feed errors should record failure once");
+
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.failure_recorded = 0;
+    ctx.eligible = 1;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_INTERNAL, NULL, 0);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "pre-commit feed errors should honor pass policy");
+    TEST_ASSERT(ctx.eligible == 0,
+        "pre-commit pass policy should mark request ineligible");
+
+    ctx.eligible = 1;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.total_output_bytes = NGX_MAX_SIZE_T_VALUE;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_SUCCESS, out_data, 1);
+    TEST_ASSERT(rc == NGX_OK,
+        "successful feed result should send output");
+    TEST_ASSERT(ctx.streaming.total_output_bytes == NGX_MAX_SIZE_T_VALUE,
+        "output byte counter should saturate on overflow");
+
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x14;
+    ctx.streaming.total_output_bytes = 0;
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_SUCCESS, out_data, 2);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "successful feed should surface backpressure");
+
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_SUCCESS, out_data, 0);
+    TEST_ASSERT(rc == NGX_OK,
+        "empty successful feed output should no-op");
+
+    ctx.streaming.handle = NULL;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "finalize should emit terminal buffer when handle is null");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x15;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    g_streaming_finalize_rc = ERROR_INTERNAL;
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "pre-commit finalize errors should honor pass policy");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x16;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    g_streaming_finalize_rc = ERROR_INTERNAL;
+    g_next_body_filter_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "post-commit finalize errors should terminate downstream");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x17;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 3;
+    g_streaming_finalize_result.etag = (uint8_t *) "etag";
+    g_streaming_finalize_result.etag_len = 4;
+    g_streaming_finalize_result.token_estimate = 9;
+    g_streaming_finalize_result.peak_memory_estimate = 128;
+    {
+        ngx_int_t seq[] = { NGX_OK, NGX_OK };
+        set_next_body_filter_sequence(seq, 2);
+    }
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "finalize should succeed when final body and terminal buffer send");
+    TEST_ASSERT(metrics.streaming.succeeded_total >= 1,
+        "successful finalize should increment success metrics");
+    TEST_ASSERT(metrics.streaming.last_peak_memory_bytes == 128,
+        "finalize should store peak memory gauge from result");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x18;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.finalize_pending_lastbuf = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 3;
+    {
+        ngx_int_t seq[] = { NGX_AGAIN };
+        set_next_body_filter_sequence(seq, 1);
+    }
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "finalize should defer terminal last_buf when markdown send is NGX_AGAIN");
+    TEST_ASSERT(ctx.streaming.finalize_pending_lastbuf == 1,
+        "finalize should latch deferred terminal last_buf");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x19;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.pending_terminal_metrics = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 3;
+    {
+        ngx_int_t seq[] = { NGX_OK, NGX_AGAIN };
+        set_next_body_filter_sequence(seq, 2);
+    }
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "terminal last_buf backpressure should propagate NGX_AGAIN");
+    TEST_ASSERT(ctx.streaming.pending_terminal_metrics == 1,
+        "terminal backpressure should latch pending terminal metrics");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x1A;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.pending_terminal_metrics = 0;
+    ctx.streaming.failure_recorded = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 3;
+    {
+        ngx_int_t seq[] = { NGX_OK, NGX_ERROR };
+        set_next_body_filter_sequence(seq, 2);
+    }
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "terminal last_buf hard errors should propagate");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "terminal last_buf hard errors should record failure");
+
+    TEST_PASS("commit/feed-result/finalize core branches covered");
+}
+
+static void
+test_process_chain_and_body_filter_deep_paths(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_chain_t             in;
+    ngx_buf_t               in_buf;
+    ngx_chain_t            *fallback_cl;
+    ngx_flag_t              last_buf;
+    ngx_int_t               rc;
+    ngx_buf_t              *saved_bufs[2] = { NULL, NULL };
+    u_char                 *saved_pos[2] = { NULL, NULL };
+    u_char                  prebuf_data[16];
+    u_char                  chunk_data[] = "chunk";
+
+    TEST_SUBSECTION("process-chain/failopen/body-filter deep branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+    conf.max_size = 0;
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+
+    ngx_memzero(&in, sizeof(in));
+    ngx_memzero(&in_buf, sizeof(in_buf));
+    in.buf = &in_buf;
+    in.next = NULL;
+    in_buf.pos = chunk_data;
+    in_buf.last = chunk_data + 5;
+    in_buf.last_buf = 1;
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x21;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+
+    saved_bufs[0] = &in_buf;
+    saved_pos[0] = in_buf.pos;
+    ctx.streaming.failopen_consumed_bufs = saved_bufs;
+    ctx.streaming.failopen_consumed_pos = saved_pos;
+    ctx.streaming.failopen_consumed_count = 1;
+
+    rc = ngx_http_markdown_streaming_failopen_passthrough(
+        &r, &ctx, &in, 0);
+    TEST_ASSERT(rc == NGX_OK,
+        "failopen passthrough should pass current chain for first invocation");
+
+    g_alloc_chain_fail_once = 1;
+    rc = ngx_http_markdown_streaming_failopen_passthrough(
+        &r, &ctx, &in, 1);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "failopen passthrough should fail on prefix chain allocation errors");
+
+    rc = ngx_http_markdown_streaming_failopen_passthrough(
+        &r, &ctx, &in, 1);
+    TEST_ASSERT(rc == NGX_OK,
+        "failopen passthrough should rebuild prefix chain on reentry");
+
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 0;
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_REJECT;
+    g_streaming_feed_rc = ERROR_SUCCESS;
+    g_streaming_feed_out_data = NULL;
+    g_streaming_feed_out_len = 0;
+    rc = ngx_http_markdown_streaming_process_chain(
+        &r, &ctx, &conf, &in, &last_buf, 0, &fallback_cl);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "process_chain should fail when failopen tracking capacity is exhausted");
+
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x22;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.size = 3;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 2;
+    saved_bufs[0] = &in_buf;
+    saved_pos[0] = in_buf.pos;
+    ctx.streaming.failopen_consumed_bufs = saved_bufs;
+    ctx.streaming.failopen_consumed_pos = saved_pos;
+    g_streaming_feed_rc = ERROR_STREAMING_FALLBACK;
+    rc = ngx_http_markdown_streaming_process_chain(
+        &r, &ctx, &conf, &in, &last_buf, 0, &fallback_cl);
+    TEST_ASSERT(rc == NGX_DONE,
+        "process_chain should return NGX_DONE when fallback switches path");
+    TEST_ASSERT(fallback_cl == &in,
+        "process_chain should return fallback location");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.eligible = 1;
+    ctx.headers_forwarded = 0;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x23;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.size = 3;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 2;
+    ctx.streaming.failopen_consumed_bufs = saved_bufs;
+    ctx.streaming.failopen_consumed_pos = saved_pos;
+    g_streaming_feed_rc = ERROR_STREAMING_FALLBACK;
+    g_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &in);
+    TEST_ASSERT(rc == NGX_OK,
+        "body_filter should reenter full-buffer path after fallback");
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.eligible = 1;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x24;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.size = 1;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 2;
+    ctx.streaming.failopen_consumed_bufs = saved_bufs;
+    ctx.streaming.failopen_consumed_pos = saved_pos;
+    g_streaming_feed_rc = ERROR_SUCCESS;
+    g_streaming_feed_out_data = NULL;
+    g_streaming_feed_out_len = 0;
+    g_streaming_finalize_rc = ERROR_INTERNAL;
+    g_next_body_filter_rc = NGX_OK;
+    in_buf.pos = chunk_data;
+    in_buf.last = chunk_data + 5;
+    in_buf.last_buf = 1;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &in);
+    TEST_ASSERT(rc == NGX_OK,
+        "body_filter should fail-open passthrough when finalize declines");
+
+    TEST_PASS("process-chain/failopen/body-filter deep branches covered");
+}
+
+static void
+test_streaming_gap_branches(void)
+{
+    ngx_http_request_t      r;
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_pool_t              pool;
+    ngx_connection_t        conn;
+    ngx_log_t               log;
+    ngx_event_t             read_event;
+    ngx_chain_t             in;
+    ngx_buf_t               in_buf;
+    ngx_int_t               rc;
+    u_char                  prebuf_data[16];
+    u_char                  mainbuf_data[16];
+    u_char                  out_data[] = "zz";
+    ngx_buf_t               pending_buf;
+    ngx_chain_t             pending_cl;
+    ngx_uint_t              selected_path;
+    ngx_uint_t              free_before;
+
+    TEST_SUBSECTION("streaming helper gap branches");
+    reset_globals();
+    init_request_ctx_conf(&r, &ctx, &conf, &pool, &conn, &log, &read_event);
+
+    conf.streaming_on_error = NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS;
+    conf.max_size = 64;
+
+    selected_path = ngx_http_markdown_select_processing_path(&r, NULL);
+    TEST_ASSERT(selected_path == NGX_HTTP_MARKDOWN_PATH_FULLBUFFER,
+        "selector should use full-buffer when conf is NULL");
+
+    ctx.streaming.finalize_pending_lastbuf = 1;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "resume_pending should send deferred last_buf branch");
+
+    ngx_memzero(&pending_buf, sizeof(pending_buf));
+    ngx_memzero(&pending_cl, sizeof(pending_cl));
+    pending_buf.pos = out_data;
+    pending_buf.last = out_data + 2;
+    pending_cl.buf = &pending_buf;
+    pending_cl.next = NULL;
+    ctx.streaming.pending_output = &pending_cl;
+    ctx.streaming.finalize_pending_lastbuf = 1;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "resume_pending should send deferred last_buf after pending drain");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x31;
+    ctx.streaming.prebuffer_initialized = 1;
+    ctx.streaming.prebuffer.data = prebuf_data;
+    ctx.streaming.prebuffer.capacity = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.max_size = sizeof(prebuf_data);
+    ctx.streaming.prebuffer.size = 2;
+    ctx.buffer_initialized = 1;
+    ctx.buffer.data = mainbuf_data;
+    ctx.buffer.capacity = sizeof(mainbuf_data);
+    ctx.buffer.max_size = sizeof(mainbuf_data);
+    g_buffer_append_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_fallback_to_fullbuffer(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "fallback should fail when prebuffer append fails");
+    g_buffer_append_rc = NGX_OK;
+
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.eligible = 1;
+    free_before = g_output_free_calls;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_INTERNAL, out_data, 2);
+    TEST_ASSERT(rc == NGX_DECLINED,
+        "feed errors with output should fail-open in pre-commit pass mode");
+    TEST_ASSERT(g_output_free_calls == free_before + 1,
+        "feed error branch should free provided output buffer");
+
+    ctx.eligible = 1;
+    ctx.processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x32;
+    g_add_vary_rc = NGX_ERROR;
+    free_before = g_output_free_calls;
+    rc = ngx_http_markdown_streaming_handle_feed_result(
+        &r, &ctx, &conf, ERROR_SUCCESS, out_data, 2);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "feed success should propagate commit failure");
+    TEST_ASSERT(g_output_free_calls == free_before + 1,
+        "commit failure should still free feed output");
+    g_add_vary_rc = NGX_OK;
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x33;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.total_output_bytes = NGX_MAX_SIZE_T_VALUE;
+    ctx.streaming.failure_recorded = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 2;
+    {
+        ngx_int_t seq[] = { NGX_ERROR };
+        set_next_body_filter_sequence(seq, 1);
+    }
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finalize should propagate markdown send errors");
+    TEST_ASSERT(ctx.streaming.total_output_bytes == NGX_MAX_SIZE_T_VALUE,
+        "finalize markdown send should preserve saturated output counter");
+    TEST_ASSERT(ctx.streaming.failure_recorded == 1,
+        "finalize markdown send error should record failure");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x34;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_PRE;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = out_data;
+    g_streaming_finalize_result.markdown_len = 2;
+    g_add_vary_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finalize pre-commit should surface commit errors");
+    g_add_vary_rc = NGX_OK;
+
+    rc = ngx_http_markdown_streaming_process_chunk(
+        &r, &ctx, &conf, NULL);
+    TEST_ASSERT(rc == NGX_OK,
+        "process_chunk should short-circuit on NULL buffer");
+
+    ngx_memzero(&in_buf, sizeof(in_buf));
+    in_buf.pos = out_data;
+    in_buf.last = out_data;
+    rc = ngx_http_markdown_streaming_process_chunk(
+        &r, &ctx, &conf, &in_buf);
+    TEST_ASSERT(rc == NGX_OK,
+        "process_chunk should short-circuit on empty buffers");
+
+    in_buf.pos = out_data + 1;
+    in_buf.last = out_data;
+    rc = ngx_http_markdown_streaming_process_chunk(
+        &r, &ctx, &conf, &in_buf);
+    TEST_ASSERT(rc == NGX_OK,
+        "process_chunk should ignore invalid pointer ordering");
+    in_buf.pos = out_data;
+    in_buf.last = out_data + 2;
+
+    ngx_memzero(&in, sizeof(in));
+    in.buf = &in_buf;
+    in.next = NULL;
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = NULL;
+    ctx.headers_forwarded = 0;
+    g_prepare_options_rc = NGX_ERROR;
+    g_forward_headers_rc = NGX_ERROR;
+    rc = ngx_http_markdown_streaming_ensure_handle(&r, &ctx, &conf, &in);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "ensure_handle should fail when fail-open header forwarding fails");
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = NULL;
+    ctx.headers_forwarded = 0;
+    g_prepare_options_rc = NGX_ERROR;
+    g_forward_headers_rc = NGX_OK;
+    g_next_body_filter_rc = NGX_DONE;
+    rc = ngx_http_markdown_streaming_ensure_handle(&r, &ctx, &conf, &in);
+    TEST_ASSERT(rc == NGX_DONE,
+        "ensure_handle should passthrough when init declines");
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = NULL;
+    g_prepare_options_rc = NGX_OK;
+    g_new_with_code_rc = ERROR_SUCCESS;
+    g_new_with_code_null_handle = 0;
+    g_pool_cleanup_fail_once = 1;
+    rc = ngx_http_markdown_streaming_ensure_handle(&r, &ctx, &conf, &in);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "ensure_handle should propagate hard init failures");
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = NULL;
+    g_prepare_options_rc = NGX_OK;
+    g_new_with_code_rc = ERROR_SUCCESS;
+    g_new_with_code_null_handle = 0;
+    rc = ngx_http_markdown_streaming_ensure_handle(&r, &ctx, &conf, &in);
+    TEST_ASSERT(rc == NGX_OK,
+        "ensure_handle should return NGX_OK when init succeeds");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x35;
+    ctx.streaming.pending_output = NULL;
+    ctx.streaming.finalize_after_pending = 0;
+    rc = ngx_http_markdown_streaming_body_filter(&r, NULL);
+    TEST_ASSERT(rc == NGX_OK,
+        "body_filter NULL input should use null-input helper success path");
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = NULL;
+    ctx.headers_forwarded = 0;
+    g_prepare_options_rc = NGX_ERROR;
+    g_forward_headers_rc = NGX_OK;
+    g_next_body_filter_rc = NGX_DONE;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &in);
+    TEST_ASSERT(rc == NGX_DONE,
+        "body_filter should return non-OK ensure_handle result");
+
+    ctx.eligible = 1;
+    ctx.headers_forwarded = 1;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x36;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 2;
+    in_buf.last_buf = 0;
+    g_streaming_feed_rc = ERROR_SUCCESS;
+    g_streaming_feed_out_data = NULL;
+    g_streaming_feed_out_len = 0;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &in);
+    TEST_ASSERT(rc == NGX_OK,
+        "body_filter should return NGX_OK for non-terminal successful chunks");
+
+    ctx.eligible = 1;
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x37;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.failopen_consumed_count = 0;
+    ctx.streaming.failopen_consumed_capacity = 2;
+    in_buf.last_buf = 1;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = NULL;
+    g_streaming_finalize_result.markdown_len = 0;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_body_filter(&r, &in);
+    TEST_ASSERT(rc == NGX_OK,
+        "body_filter should return finalize rc on terminal buffer");
+
+    ctx.streaming.handle = (struct StreamingConverterHandle *)
+        (uintptr_t) 0x38;
+    ctx.streaming.commit_state = NGX_HTTP_MARKDOWN_STREAMING_COMMIT_POST;
+    ctx.streaming.total_output_bytes = 0;
+    g_streaming_finalize_rc = ERROR_SUCCESS;
+    g_streaming_finalize_result.markdown = NULL;
+    g_streaming_finalize_result.markdown_len = 0;
+    g_next_body_filter_rc = NGX_OK;
+    rc = ngx_http_markdown_streaming_finalize_request(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "finalize should handle empty markdown result path");
+
+    rc = ngx_http_markdown_streaming_handle_null_input(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_OK,
+        "null-input helper should return NGX_OK when nothing is pending");
+
+    TEST_PASS("streaming helper gap branches covered");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("streaming_impl Tests\n");
+    printf("========================================\n");
+
+    test_cleanup_paths();
+    test_select_processing_path();
+    test_update_headers_paths();
+    test_send_output_and_resume_paths();
+    test_send_output_error_and_deferred_paths();
+    test_fallback_to_fullbuffer_paths();
+    test_postcommit_and_precommit_error_paths();
+    test_abort_passthrough_and_reentry_helpers();
+    test_null_input_tracking_and_body_filter_entry();
+    test_init_handle_and_chunk_result_helpers();
+    test_commit_feed_and_finalize_core_paths();
+    test_process_chain_and_body_filter_deep_paths();
+    test_streaming_gap_branches();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+    return 0;
+}
+
+#endif  /* MARKDOWN_STREAMING_ENABLED */

--- a/components/nginx-module/tests/unit/streaming_impl_test.c
+++ b/components/nginx-module/tests/unit/streaming_impl_test.c
@@ -1,6 +1,17 @@
 /*
  * Test: streaming_impl
- * Description: direct branch coverage for streaming_impl helper paths.
+ *
+ * Unit tests for the NGINX markdown filter module's streaming implementation
+ * helpers (ngx_http_markdown_streaming_impl.h).  Provides direct branch
+ * coverage for path selection, header updates, output sending, backpressure,
+ * commit/finalize lifecycle, fail-open passthrough, and cleanup paths.
+ *
+ * When MARKDOWN_STREAMING_ENABLED is not defined, the test binary compiles
+ * to a skip stub that reports the missing feature and exits successfully.
+ *
+ * Otherwise, the file reimplements a minimal subset of NGINX runtime types
+ * and API stubs so the streaming implementation header can be included and
+ * exercised without linking against the full NGINX core library.
  */
 
 #include "../include/test_common.h"
@@ -13,6 +24,11 @@
 
 #ifndef MARKDOWN_STREAMING_ENABLED
 
+/*
+ * Skip stub entry point.  When streaming is disabled at compile time,
+ * print a skip banner and return 0 so the test harness records success
+ * without exercising any streaming code paths.
+ */
 int
 main(void)
 {
@@ -23,7 +39,7 @@ main(void)
     return 0;
 }
 
-#else  /* MARKDOWN_STREAMING_ENABLED */
+#else  /* MARKDOWN_STREAMING_ENABLED — main test body follows */
 
 /*
  * DIVERGENCE RISK:
@@ -54,46 +70,86 @@ typedef struct ngx_pool_cleanup_s ngx_pool_cleanup_t;
 typedef struct ngx_time_s ngx_time_t;
 typedef struct ngx_event_s ngx_event_t;
 
+/*
+ * Minimal ngx_event_s stub.  Only the pending_eof bit-field is retained
+ * because the streaming abort-check path reads it via connection->read.
+ * Divergence risk: if production adds event fields used by streaming,
+ * this stub must be extended.
+ */
 struct ngx_event_s {
     unsigned pending_eof:1;
 };
 
+/*
+ * Minimal ngx_list_part_s stub.  Retains elts/nelts/next for header list
+ * traversal.  Divergence risk: if streaming inspects other list-part
+ * fields, this stub must be extended.
+ */
 struct ngx_list_part_s {
     void            *elts;
     ngx_uint_t       nelts;
     ngx_list_part_t *next;
 };
 
+/*
+ * Minimal ngx_list_t wrapper.  Only the first part is needed for header
+ * iteration in streaming paths.
+ */
 typedef struct {
     ngx_list_part_t part;
 } ngx_list_t;
 
+/*
+ * Minimal ngx_table_elt_s stub.  Retains key/value/hash fields used by
+ * header comparison logic in streaming paths.
+ */
 struct ngx_table_elt_s {
     ngx_str_t key;
     ngx_str_t value;
     ngx_uint_t hash;
 };
 
+/* Sentinel log struct; no fields are read by streaming code under test. */
 struct ngx_log_s {
     int dummy;
 };
 
+/*
+ * Minimal ngx_connection_s stub.  Retains log/read/error fields used by
+ * the streaming abort-check and logging paths.
+ * Divergence risk: if streaming reads additional connection fields
+ * (e.g. fd, sent, buffered), this stub must be extended.
+ */
 struct ngx_connection_s {
     ngx_log_t   *log;
     ngx_event_t *read;
     unsigned     error:1;
 };
 
+/*
+ * Minimal ngx_pool_cleanup_s stub.  Retains handler/data/next for pool
+ * cleanup chaining used by streaming teardown tests.
+ * Divergence risk: if production adds cleanup fields inspected by
+ * streaming, this stub must be extended.
+ */
 struct ngx_pool_cleanup_s {
     void               (*handler)(void *data);
     void                *data;
     ngx_pool_cleanup_t  *next;
 };
 
+/* Minimal pool stub; only the cleanups list head is needed for teardown. */
 struct ngx_pool_s {
     ngx_pool_cleanup_t *cleanups;
 };
 
+/*
+ * Minimal ngx_buf_s stub.  Retains pos/last/start/end pointers and the
+ * temporary/memory/last_buf/last_in_chain/flush/sync bit-fields used by
+ * the streaming send and cleanup paths.
+ * Divergence risk: if streaming inspects additional buffer flags
+ * (e.g. recycled, file, in_file), this stub must be extended.
+ */
 struct ngx_buf_s {
     u_char   *pos;
     u_char   *last;
@@ -107,21 +163,32 @@ struct ngx_buf_s {
     unsigned  sync:1;
 };
 
+/* Minimal chain node; buf/next are used throughout streaming send paths. */
 struct ngx_chain_s {
     ngx_buf_t   *buf;
     ngx_chain_t *next;
 };
 
+/* Minimal array struct for stream_types exclusion list in path selection. */
 struct ngx_array_s {
     void      *elts;
     ngx_uint_t nelts;
 };
 
+/*
+ * Minimal request headers-in stub.  Retains headers list and server
+ * string used by streaming conditional-request checks.
+ */
 struct ngx_http_headers_in_s {
     ngx_list_t headers;
     ngx_str_t  server;
 };
 
+/*
+ * Minimal response headers-out stub.  Retains content_type, content_length_n,
+ * status, content_type_len, and charset fields read or mutated by the
+ * streaming header-update path.
+ */
 struct ngx_http_headers_out_s {
     ngx_str_t   content_type;
     off_t       content_length_n;
@@ -130,10 +197,18 @@ struct ngx_http_headers_out_s {
     ngx_str_t   charset;
 };
 
+/* Minimal server config stub; only server_name is retained for logging. */
 struct ngx_http_core_srv_conf_s {
     ngx_str_t server_name;
 };
 
+/*
+ * Minimal ngx_http_request_s stub.  Retains connection/pool/method/
+ * header_only/buffered/headers_in/headers_out/uri/loc_conf/ctx/main fields
+ * that are read or mutated by streaming helper paths.
+ * Divergence risk: if production streaming reads additional request fields
+ * (e.g. count, subrequests, postponed), this stub must be extended.
+ */
 struct ngx_http_request_s {
     ngx_connection_t      *connection;
     ngx_pool_t            *pool;
@@ -148,23 +223,32 @@ struct ngx_http_request_s {
     ngx_http_request_t    *main;
 };
 
+/* Sentinel module struct; not inspected by streaming code under test. */
 struct ngx_module_s {
     int dummy;
 };
 
+/* Sentinel conf struct; not inspected by streaming code under test. */
 struct ngx_conf_s {
     int dummy;
 };
 
+/* Sentinel complex-value struct; only the pointer existence is tested. */
 struct ngx_http_complex_value_s {
     int dummy;
 };
 
+/* Time struct used by ngx_timeofday() stub for deterministic timing. */
 struct ngx_time_s {
     time_t    sec;
     ngx_msec_t msec;
 };
 
+/*
+ * NGINX return-code and constant macros.  Guarded with #ifndef so the
+ * values from test_common.h or production headers take precedence when
+ * available.  These define the minimal set needed by streaming_impl.h.
+ */
 #ifndef NGX_OK
 #define NGX_OK 0
 #endif
@@ -198,6 +282,7 @@ struct ngx_time_s {
 #ifndef NGX_LOG_INFO
 #define NGX_LOG_INFO 3
 #endif
+/* Streaming-specific and utility macros for constants and memory ops. */
 #ifndef NGX_HTTP_MARKDOWN_BUFFERED
 #define NGX_HTTP_MARKDOWN_BUFFERED 0x08
 #endif
@@ -212,6 +297,20 @@ struct ngx_time_s {
 #define ngx_memcpy memcpy
 #endif
 
+/*
+ * Global stub control variables.  Each g_* variable configures the
+ * corresponding stub's return code or behaviour so tests can inject
+ * success, failure, or scripted sequences without modifying stub code.
+ *
+ * Return-code globals: set before a test to make the stub return that
+ * code on the next call.
+ *
+ * Counter globals: incremented by stubs on each invocation; tests read
+ * them to verify call counts.
+ *
+ * Fail-once globals: when non-zero, the stub returns NULL/failure once
+ * and then auto-clears, simulating a transient allocation failure.
+ */
 static ngx_int_t g_next_body_filter_rc = NGX_OK;
 static ngx_int_t g_next_header_filter_rc = NGX_OK;
 static ngx_int_t g_complex_value_rc = NGX_OK;
@@ -245,11 +344,25 @@ static uintptr_t g_streaming_feed_out_len = 0;
 static uint32_t g_streaming_finalize_rc = ERROR_SUCCESS;
 static struct MarkdownResult g_streaming_finalize_result;
 
+/*
+ * Production globals that must be defined for the streaming impl header to
+ * link.  ngx_http_markdown_content_type provides the module's content-type
+ * literal; ngx_http_markdown_metrics is the optional metrics collector
+ * (NULL by default, tests bind it to stack-local storage); the filter
+ * module struct is a sentinel.
+ */
 u_char ngx_http_markdown_content_type[] =
     NGX_HTTP_MARKDOWN_CONTENT_TYPE_LITERAL;
 ngx_http_markdown_metrics_t *ngx_http_markdown_metrics = NULL;
 ngx_module_t ngx_http_markdown_filter_module = { 0 };
 
+/*
+ * Metric macros.  NGX_HTTP_MARKDOWN_METRIC_ADD conditionally adds a value
+ * to a metrics struct field when the global metrics pointer is non-NULL.
+ * NGX_HTTP_MARKDOWN_METRIC_INC is a convenience wrapper that adds 1.
+ * These mirror the production macros so streaming code under test can
+ * update metrics without modification.
+ */
 #define NGX_HTTP_MARKDOWN_METRIC_ADD(field, value)                                  \
     do {                                                                             \
         if (ngx_http_markdown_metrics != NULL) {                                     \
@@ -260,6 +373,12 @@ ngx_module_t ngx_http_markdown_filter_module = { 0 };
 #define NGX_HTTP_MARKDOWN_METRIC_INC(field)                                          \
     NGX_HTTP_MARKDOWN_METRIC_ADD(field, 1)
 
+/*
+ * Logging macros (no-op stubs).  Production NGINX logging is replaced with
+ * macros that suppress all output and silence compiler warnings about
+ * unused parameters.  This avoids console noise during test runs while
+ * keeping the streaming code's log calls compilable.
+ */
 #ifdef ngx_log_error
 #undef ngx_log_error
 #endif
@@ -302,6 +421,12 @@ ngx_module_t ngx_http_markdown_filter_module = { 0 };
         UNUSED(arg1); UNUSED(arg2); UNUSED(arg3); UNUSED(arg4);                      \
     } while (0)
 
+/*
+ * Stub for ngx_http_next_body_filter.  Returns the next value from the
+ * scripted sequence (g_next_body_filter_seq) if available, otherwise
+ * returns g_next_body_filter_rc.  Ignores request and chain arguments.
+ * Side effect: consumes one slot from the sequence on each call.
+ */
 static ngx_int_t
 ngx_http_next_body_filter_stub(ngx_http_request_t *r, ngx_chain_t *in)
 {
@@ -313,6 +438,10 @@ ngx_http_next_body_filter_stub(ngx_http_request_t *r, ngx_chain_t *in)
     return g_next_body_filter_rc;
 }
 
+/*
+ * Stub for ngx_http_next_header_filter.  Always returns
+ * g_next_header_filter_rc.  Ignores the request argument.
+ */
 static ngx_int_t
 ngx_http_next_header_filter_stub(ngx_http_request_t *r)
 {
@@ -338,6 +467,14 @@ ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r, ngx_chain_t *in) =
 ngx_int_t (*ngx_http_next_header_filter)(ngx_http_request_t *r) =
     ngx_http_next_header_filter_stub;
 
+/*
+ * Stub for ngx_palloc.  Delegates to malloc(3).  If g_palloc_fail_once is
+ * set, returns NULL once and clears the flag, simulating a transient
+ * allocation failure.
+ * Divergence risk: production ngx_palloc uses the pool allocator; this
+ * stub uses the C heap, so objects allocated here must be freed with
+ * free(3), not pool-based cleanup.
+ */
 void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
@@ -349,6 +486,11 @@ ngx_palloc(ngx_pool_t *pool, size_t size)
     return malloc(size);
 }
 
+/*
+ * Stub for ngx_pcalloc.  Same as ngx_palloc but zero-initialises the
+ * allocation via calloc(3).  Honours g_pcalloc_fail_once for one-shot
+ * failure injection.
+ */
 void *
 ngx_pcalloc(ngx_pool_t *pool, size_t size)
 {
@@ -362,12 +504,21 @@ ngx_pcalloc(ngx_pool_t *pool, size_t size)
     return p;
 }
 
+/*
+ * Stub for ngx_pnalloc.  Delegates directly to ngx_palloc; production
+ * would use a separate non-padded path, but the distinction is irrelevant
+ * for unit tests.
+ */
 void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
 {
     return ngx_palloc(pool, size);
 }
 
+/*
+ * Stub for ngx_alloc.  Direct malloc(3) wrapper ignoring the log argument.
+ * Used by streaming code for off-pool allocations.
+ */
 void *
 ngx_alloc(size_t size, ngx_log_t *log)
 {
@@ -375,12 +526,20 @@ ngx_alloc(size_t size, ngx_log_t *log)
     return malloc(size);
 }
 
+/* Stub for ngx_free.  Direct free(3) wrapper. */
 void
 ngx_free(void *p)
 {
     free(p);
 }
 
+/*
+ * Stub for ngx_calloc_buf.  Allocates a zero-initialised ngx_buf_t via
+ * calloc(3).  Honours g_calloc_buf_fail_once for one-shot failure
+ * injection.
+ * Divergence risk: production allocates from the pool; this stub uses
+ * the C heap, so callers must free(3) the result.
+ */
 ngx_buf_t *
 ngx_calloc_buf(ngx_pool_t *pool)
 {
@@ -392,6 +551,12 @@ ngx_calloc_buf(ngx_pool_t *pool)
     return calloc(1, sizeof(ngx_buf_t));
 }
 
+/*
+ * Stub for ngx_alloc_chain_link.  Allocates a zero-initialised
+ * ngx_chain_t via calloc(3).  Honours g_alloc_chain_fail_once for
+ * one-shot failure injection.
+ * Divergence risk: same as ngx_calloc_buf — C heap vs pool.
+ */
 ngx_chain_t *
 ngx_alloc_chain_link(ngx_pool_t *pool)
 {
@@ -403,6 +568,14 @@ ngx_alloc_chain_link(ngx_pool_t *pool)
     return calloc(1, sizeof(ngx_chain_t));
 }
 
+/*
+ * Stub for ngx_pool_cleanup_add.  Allocates a cleanup node, prepends it
+ * to pool->cleanups, and returns it.  Returns NULL if pool is NULL or
+ * on one-shot failure (g_pool_cleanup_fail_once).
+ * Divergence risk: production also allocates a data buffer of the
+ * requested size; this stub ignores the size parameter because no test
+ * needs cleanup data.
+ */
 ngx_pool_cleanup_t *
 ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
 {
@@ -427,12 +600,22 @@ ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
     return cln;
 }
 
+/*
+ * Stub for ngx_http_clear_content_length.  Sets
+ * r->headers_out.content_length_n to -1, mirroring production behaviour.
+ */
 void
 ngx_http_clear_content_length(ngx_http_request_t *r)
 {
     r->headers_out.content_length_n = -1;
 }
 
+/*
+ * Stub for ngx_http_complex_value.  Returns g_complex_value_rc; on
+ * NGX_OK, copies g_complex_value into *val.
+ * Divergence risk: production evaluates the complex value script against
+ * the request; this stub returns a fixed string controlled by the test.
+ */
 ngx_int_t
 ngx_http_complex_value(ngx_http_request_t *r,
     ngx_http_complex_value_t *cv, ngx_str_t *val)
@@ -446,6 +629,10 @@ ngx_http_complex_value(ngx_http_request_t *r,
     return NGX_OK;
 }
 
+/*
+ * Stub for ngx_strncasecmp.  Case-insensitive comparison of the first n
+ * bytes, mirroring the production NGINX function.
+ */
 ngx_int_t
 ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
 {
@@ -459,12 +646,21 @@ ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
     return 0;
 }
 
+/*
+ * Stub for ngx_timeofday.  Returns a pointer to the deterministic
+ * g_now global so tests can control perceived time without touching
+ * the system clock.
+ */
 ngx_time_t *
 ngx_timeofday(void)
 {
     return &g_now;
 }
 
+/*
+ * Stub for ngx_http_get_module_ctx.  Returns r->ctx, mirroring the
+ * production macro that retrieves per-module context.
+ */
 void *
 ngx_http_get_module_ctx(ngx_http_request_t *r, ngx_module_t module)
 {
@@ -472,6 +668,10 @@ ngx_http_get_module_ctx(ngx_http_request_t *r, ngx_module_t module)
     return r->ctx;
 }
 
+/*
+ * Stub for ngx_http_get_module_loc_conf.  Returns r->loc_conf cast to
+ * the conf type, mirroring the production macro.
+ */
 ngx_http_markdown_conf_t *
 ngx_http_get_module_loc_conf(ngx_http_request_t *r, ngx_module_t module)
 {
@@ -479,6 +679,10 @@ ngx_http_get_module_loc_conf(ngx_http_request_t *r, ngx_module_t module)
     return (ngx_http_markdown_conf_t *) r->loc_conf;
 }
 
+/*
+ * Stub for ngx_http_set_ctx.  Sets r->ctx to the provided pointer,
+ * mirroring the production macro.
+ */
 void
 ngx_http_set_ctx(ngx_http_request_t *r, void *c, ngx_module_t module)
 {
@@ -486,6 +690,10 @@ ngx_http_set_ctx(ngx_http_request_t *r, void *c, ngx_module_t module)
     r->ctx = c;
 }
 
+/*
+ * Stub for markdown_streaming_abort.  Increments g_abort_calls so tests
+ * can verify the abort was invoked.  Ignores the handle argument.
+ */
 void
 markdown_streaming_abort(struct StreamingConverterHandle *handle)
 {
@@ -493,6 +701,11 @@ markdown_streaming_abort(struct StreamingConverterHandle *handle)
     g_abort_calls++;
 }
 
+/*
+ * Stub for markdown_streaming_output_free.  Increments
+ * g_output_free_calls so tests can verify the free was invoked.
+ * Ignores data and len arguments.
+ */
 void
 markdown_streaming_output_free(uint8_t *data, uintptr_t len)
 {
@@ -501,6 +714,14 @@ markdown_streaming_output_free(uint8_t *data, uintptr_t len)
     g_output_free_calls++;
 }
 
+/*
+ * Stub for markdown_streaming_feed.  Returns g_streaming_feed_rc and
+ * writes g_streaming_feed_out_data / g_streaming_feed_out_len into the
+ * output parameters if they are non-NULL.  Ignores handle, html_chunk,
+ * and chunk_len arguments.
+ * Divergence risk: production performs actual streaming conversion; this
+ * stub returns fixed test-controlled values.
+ */
 uint32_t
 markdown_streaming_feed(struct StreamingConverterHandle *handle,
     const uint8_t *html_chunk, uintptr_t chunk_len,
@@ -518,6 +739,12 @@ markdown_streaming_feed(struct StreamingConverterHandle *handle,
     return g_streaming_feed_rc;
 }
 
+/*
+ * Stub for markdown_streaming_finalize.  Returns g_streaming_finalize_rc
+ * and copies g_streaming_finalize_result into *result if non-NULL.
+ * Divergence risk: production finalizes the streaming converter; this
+ * stub returns fixed test-controlled values.
+ */
 uint32_t
 markdown_streaming_finalize(struct StreamingConverterHandle *handle,
     struct MarkdownResult *result)
@@ -529,6 +756,14 @@ markdown_streaming_finalize(struct StreamingConverterHandle *handle,
     return g_streaming_finalize_rc;
 }
 
+/*
+ * Stub for markdown_streaming_new_with_code.  Returns g_new_with_code_rc
+ * and sets *out_handle to a sentinel pointer (0x1) unless
+ * g_new_with_code_null_handle is set, which simulates a success return
+ * with a NULL handle.
+ * Divergence risk: production creates a real converter; this stub
+ * returns a fixed sentinel.
+ */
 uint32_t
 markdown_streaming_new_with_code(const struct MarkdownOptions *options,
     struct StreamingConverterHandle **out_handle)
@@ -540,6 +775,10 @@ markdown_streaming_new_with_code(const struct MarkdownOptions *options,
     return g_new_with_code_rc;
 }
 
+/*
+ * Stub for markdown_result_free.  Zeroes the result struct to simulate
+ * cleanup, mirroring production behaviour of releasing result resources.
+ */
 void
 markdown_result_free(struct MarkdownResult *result)
 {
@@ -548,6 +787,10 @@ markdown_result_free(struct MarkdownResult *result)
     }
 }
 
+/*
+ * Stub for ngx_http_markdown_add_vary_accept.  Returns g_add_vary_rc.
+ * Ignores the request argument.
+ */
 ngx_int_t
 ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
 {
@@ -555,6 +798,11 @@ ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
     return g_add_vary_rc;
 }
 
+/*
+ * Stub for ngx_http_markdown_remove_content_encoding.  Increments
+ * g_remove_content_encoding_calls so tests can verify invocation.
+ * Ignores the request argument.
+ */
 void
 ngx_http_markdown_remove_content_encoding(ngx_http_request_t *r)
 {
@@ -562,6 +810,10 @@ ngx_http_markdown_remove_content_encoding(ngx_http_request_t *r)
     g_remove_content_encoding_calls++;
 }
 
+/*
+ * Stub for ngx_http_markdown_set_etag.  Returns g_set_etag_rc.
+ * Ignores all arguments.
+ */
 ngx_int_t
 ngx_http_markdown_set_etag(ngx_http_request_t *r,
     const u_char *etag, size_t etag_len)
@@ -572,6 +824,10 @@ ngx_http_markdown_set_etag(ngx_http_request_t *r,
     return g_set_etag_rc;
 }
 
+/*
+ * Stub for ngx_http_markdown_forward_headers.  Returns g_forward_headers_rc.
+ * Ignores request and context arguments.
+ */
 ngx_int_t
 ngx_http_markdown_forward_headers(ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx)
@@ -581,6 +837,11 @@ ngx_http_markdown_forward_headers(ngx_http_request_t *r,
     return g_forward_headers_rc;
 }
 
+/*
+ * Stub for ngx_http_markdown_body_filter.  Returns g_body_filter_rc.
+ * Ignores request and chain arguments.  Used by the reentry-after-fallback
+ * tests.
+ */
 ngx_int_t
 ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
@@ -589,6 +850,13 @@ ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     return g_body_filter_rc;
 }
 
+/*
+ * Stub for ngx_http_markdown_buffer_init.  Allocates a data buffer via
+ * malloc(3) and initialises the buffer struct.  Returns g_buffer_init_rc
+ * if it is not NGX_OK; returns NGX_ERROR on malloc failure.
+ * Divergence risk: production uses pool allocation; this stub uses the
+ * C heap.
+ */
 ngx_int_t
 ngx_http_markdown_buffer_init(ngx_http_markdown_buffer_t *buf, size_t max_size,
     ngx_pool_t *pool)
@@ -607,6 +875,13 @@ ngx_http_markdown_buffer_init(ngx_http_markdown_buffer_t *buf, size_t max_size,
     return NGX_OK;
 }
 
+/*
+ * Stub for ngx_http_markdown_buffer_append.  Copies data into the buffer
+ * if capacity permits.  Returns g_buffer_append_rc if not NGX_OK; returns
+ * NGX_ERROR if buf->data is NULL or capacity is insufficient.
+ * Divergence risk: production uses pool-based reallocation; this stub
+ * performs a single memcpy and sets size = len.
+ */
 ngx_int_t
 ngx_http_markdown_buffer_append(ngx_http_markdown_buffer_t *buf,
     const u_char *data, size_t len)
@@ -624,6 +899,10 @@ ngx_http_markdown_buffer_append(ngx_http_markdown_buffer_t *buf,
     return NGX_OK;
 }
 
+/*
+ * Stub for ngx_http_markdown_prepare_conversion_options.  Returns
+ * g_prepare_options_rc.  Ignores all arguments.
+ */
 ngx_int_t
 ngx_http_markdown_prepare_conversion_options(ngx_http_request_t *r,
     const ngx_http_markdown_conf_t *conf, struct MarkdownOptions *options)
@@ -634,6 +913,11 @@ ngx_http_markdown_prepare_conversion_options(ngx_http_request_t *r,
     return g_prepare_options_rc;
 }
 
+/*
+ * Reason-code accessor stubs.  Each returns a static ngx_str_t containing
+ * the corresponding decision-reason literal.  These mirror the production
+ * accessors used by ngx_http_markdown_log_decision.
+ */
 const ngx_str_t *
 ngx_http_markdown_reason_streaming_convert(void)
 {
@@ -690,6 +974,11 @@ ngx_http_markdown_reason_streaming_precommit_reject(void)
     return &s;
 }
 
+/*
+ * Stub for ngx_http_markdown_log_decision.  Increments
+ * g_log_decision_calls so tests can verify invocation.  Ignores all
+ * arguments.
+ */
 void
 ngx_http_markdown_log_decision(ngx_http_request_t *r,
     const ngx_http_markdown_conf_t *conf, const ngx_str_t *reason_code)
@@ -700,8 +989,20 @@ ngx_http_markdown_log_decision(ngx_http_request_t *r,
     g_log_decision_calls++;
 }
 
+/*
+ * Include the streaming implementation header after all stubs are defined.
+ * This pulls in the inline/static helper functions that are the actual
+ * subjects under test, compiled against the stub NGINX runtime above.
+ */
 #include "../../src/ngx_http_markdown_streaming_impl.h"
 
+/*
+ * Reset all global stub control variables to their default (success)
+ * state.  Must be called at the start of every test function to ensure
+ * a clean slate with no residual state from a prior test.
+ * Side effect: sets ngx_http_markdown_metrics to NULL to avoid dangling
+ * pointers to stack-local metrics structs from previous tests.
+ */
 static void
 reset_globals(void)
 {
@@ -746,6 +1047,17 @@ reset_globals(void)
     ngx_http_markdown_metrics = NULL;
 }
 
+/*
+ * Program a sequence of return codes for ngx_http_next_body_filter_stub.
+ * Copies up to 8 entries from seq into g_next_body_filter_seq and resets
+ * the sequence index to 0.  Subsequent body-filter calls will return
+ * values from the sequence in order; once exhausted, the stub falls back
+ * to g_next_body_filter_rc.
+ *
+ * Parameters:
+ *   seq   - array of return codes to replay
+ *   count - number of entries in seq (clamped to array capacity)
+ */
 static void
 set_next_body_filter_sequence(const ngx_int_t *seq, ngx_uint_t count)
 {
@@ -765,6 +1077,24 @@ set_next_body_filter_sequence(const ngx_int_t *seq, ngx_uint_t count)
     g_next_body_filter_seq_idx = 0;
 }
 
+/*
+ * Initialise a request, context, config, pool, connection, log, and
+ * read-event struct to a consistent baseline state for streaming tests.
+ * Zeroes all structs, then wires the cross-pointers:
+ *   conn->log = log, conn->read = read_event,
+ *   r->connection = conn, r->pool = pool, r->main = r,
+ *   r->loc_conf = conf, r->ctx = ctx,
+ *   ctx->request = r, ctx->processing_path = STREAMING.
+ *
+ * Parameters:
+ *   r          - request to initialise
+ *   ctx        - module context to initialise
+ *   conf       - location config to initialise
+ *   pool       - pool to initialise
+ *   conn       - connection to initialise
+ *   log        - log to initialise
+ *   read_event - read event to initialise
+ */
 static void
 init_request_ctx_conf(ngx_http_request_t *r, ngx_http_markdown_ctx_t *ctx,
     ngx_http_markdown_conf_t *conf, ngx_pool_t *pool, ngx_connection_t *conn,
@@ -790,6 +1120,13 @@ init_request_ctx_conf(ngx_http_request_t *r, ngx_http_markdown_ctx_t *ctx,
     ctx->processing_path = NGX_HTTP_MARKDOWN_PATH_STREAMING;
 }
 
+/*
+ * Test streaming_cleanup paths.  Verifies that:
+ * - cleanup with NULL context is safe (no-op)
+ * - cleanup aborts the streaming handle and frees temporary pending
+ *   buffers, then clears both the handle and pending_output pointers
+ * Covers: ngx_http_markdown_streaming_cleanup
+ */
 static void
 test_cleanup_paths(void)
 {
@@ -823,6 +1160,24 @@ test_cleanup_paths(void)
     TEST_PASS("cleanup paths covered");
 }
 
+/*
+ * Test select_processing_path routing logic.  Verifies that:
+ * - engine=off routes to full-buffer
+ * - HEAD method routes to full-buffer
+ * - 304 status routes to full-buffer
+ * - full_support conditional mode routes to full-buffer
+ * - SSE content-type routes to full-buffer
+ * - excluded stream_types prefix routes to full-buffer
+ * - engine=on with no exclusions routes to streaming
+ * - non-matching stream_types keeps streaming enabled
+ * - NULL content-type data does not trigger exclusions
+ * - if_modified_since_only conditional mode keeps streaming
+ * - auto with small content-length routes to full-buffer
+ * - auto without content-length routes to streaming
+ * - complex-value failure routes to full-buffer
+ * - invalid engine value routes to full-buffer
+ * Covers: ngx_http_markdown_select_processing_path
+ */
 static void
 test_select_processing_path(void)
 {
@@ -938,6 +1293,14 @@ test_select_processing_path(void)
     TEST_PASS("path-selection branches covered");
 }
 
+/*
+ * Test streaming_update_headers success and failure branches.  Verifies:
+ * - successful header update sets markdown content-type, clears
+ *   content-length, and removes content-encoding when decompression needed
+ * - vary-accept add failure returns NGX_ERROR
+ * - etag clear failure returns NGX_ERROR
+ * Covers: ngx_http_markdown_streaming_update_headers
+ */
 static void
 test_update_headers_paths(void)
 {
@@ -976,6 +1339,17 @@ test_update_headers_paths(void)
     TEST_PASS("update_headers branches covered");
 }
 
+/*
+ * Test send_output and resume_pending backpressure branches.  Verifies:
+ * - successful send increments flush counter and records TTFB on first send
+ * - NGX_AGAIN from downstream stores pending output and sets buffered flag
+ * - resume_pending drains pending chain and clears buffered flag
+ * - resume with terminal metrics latch does not fail
+ * - resume downstream error propagates and records post-commit failure
+ * - deferred last_buf is sent on resume
+ * Covers: ngx_http_markdown_streaming_send_output,
+ *         ngx_http_markdown_streaming_resume_pending
+ */
 static void
 test_send_output_and_resume_paths(void)
 {
@@ -1063,6 +1437,18 @@ test_send_output_and_resume_paths(void)
     TEST_PASS("send_output/resume_pending branches covered");
 }
 
+/*
+ * Test send_output allocation errors and deferred-lastbuf branches.  Verifies:
+ * - buffer allocation failure returns NGX_ERROR
+ * - payload copy allocation failure returns NGX_ERROR
+ * - chain-link allocation failure returns NGX_ERROR
+ * - backpressure helper returns NGX_AGAIN and sets buffered flag
+ * - deferred last_buf propagates backpressure and latches terminal metrics
+ * - deferred last_buf propagates hard downstream errors and records failure
+ * Covers: ngx_http_markdown_streaming_send_output,
+ *         ngx_http_markdown_streaming_handle_backpressure,
+ *         ngx_http_markdown_streaming_send_deferred_lastbuf
+ */
 static void
 test_send_output_error_and_deferred_paths(void)
 {
@@ -1130,6 +1516,14 @@ test_send_output_error_and_deferred_paths(void)
     TEST_PASS("send_output error/deferred branches covered");
 }
 
+/*
+ * Test fallback_to_fullbuffer success and error branches.  Verifies:
+ * - fallback returns NGX_DECLINED, switches to full-buffer path,
+ *   clears conversion_attempted, initialises main buffer, and marks
+ *   decompression done
+ * - buffer_init failure propagates NGX_ERROR
+ * Covers: ngx_http_markdown_streaming_fallback_to_fullbuffer
+ */
 static void
 test_fallback_to_fullbuffer_paths(void)
 {
@@ -1180,6 +1574,17 @@ test_fallback_to_fullbuffer_paths(void)
     TEST_PASS("fallback branches covered");
 }
 
+/*
+ * Test postcommit and precommit error policy branches.  Verifies:
+ * - postcommit error sends terminal chunk and records failure once;
+ *   memory-limit errors are classified as budget-exceeded
+ * - precommit reject policy returns NGX_ERROR (fail-closed)
+ * - precommit pass policy returns NGX_DECLINED (fail-open) and marks
+ *   request ineligible
+ * - streaming fallback error routes through fallback path
+ * Covers: ngx_http_markdown_streaming_handle_postcommit_error,
+ *         ngx_http_markdown_streaming_precommit_error
+ */
 static void
 test_postcommit_and_precommit_error_paths(void)
 {
@@ -1235,6 +1640,20 @@ test_postcommit_and_precommit_error_paths(void)
     TEST_PASS("postcommit/precommit branches covered");
 }
 
+/*
+ * Test abort, passthrough, and reentry helper branches.  Verifies:
+ * - no connection error continues (returns 0)
+ * - connection error aborts request and clears streaming handle
+ * - passthrough forwards headers then body on first call
+ * - passthrough fails when header forwarding fails
+ * - passthrough calls next body filter when headers already forwarded
+ * - reentry passes cl->next to full-buffer body filter
+ * - reentry fails on terminal buffer or chain allocation failure
+ * - reentry synthesises terminal buffer when needed
+ * Covers: ngx_http_markdown_streaming_check_client_abort,
+ *         ngx_http_markdown_streaming_passthrough,
+ *         ngx_http_markdown_streaming_reenter_fullbuffer_after_fallback
+ */
 static void
 test_abort_passthrough_and_reentry_helpers(void)
 {
@@ -1317,6 +1736,26 @@ test_abort_passthrough_and_reentry_helpers(void)
     TEST_PASS("abort/passthrough/reentry helpers covered");
 }
 
+/*
+ * Test null-input handling, failopen tracking, and body_filter entry
+ * branches.  Verifies:
+ * - count_chain_bufs counts only non-NULL buffers
+ * - post-commit failopen tracking short-circuits
+ * - tracking allocation failure returns NGX_ERROR
+ * - tracking grows storage and copies prior consumed slots
+ * - null-input handler propagates resume backpressure
+ * - null-input handler finalizes when pending drain completes
+ * - process_chain skips NULL buffers safely
+ * - body_filter passthrough when ctx or conf is missing
+ * - body_filter stops on client abort
+ * - ineligible ctx passthroughs body filter
+ * - body_filter surfaces failopen tracking allocation errors
+ * Covers: ngx_http_markdown_streaming_count_chain_bufs,
+ *         ngx_http_markdown_streaming_prepare_failopen_tracking,
+ *         ngx_http_markdown_streaming_handle_null_input,
+ *         ngx_http_markdown_streaming_process_chain,
+ *         ngx_http_markdown_streaming_body_filter
+ */
 static void
 test_null_input_tracking_and_body_filter_entry(void)
 {
@@ -1460,6 +1899,22 @@ test_null_input_tracking_and_body_filter_entry(void)
     TEST_PASS("null-input/tracking/body-filter entry branches covered");
 }
 
+/*
+ * Test init_handle and chunk_result helper branches.  Verifies:
+ * - init_handle succeeds on happy path, sets handle, enters pre-commit
+ *   state, and marks conversion attempted
+ * - prepare-options failure routes through precommit_error
+ * - handle-create failure routes through precommit_error
+ * - NULL handle on success code still fails
+ * - cleanup registration failure returns NGX_ERROR
+ * - decompressor init failure routes through precommit_error
+ * - chunk_result propagates NGX_AGAIN and NGX_OK
+ * - chunk_result returns NGX_DONE after fallback switch
+ * - chunk_result fail-open surfaces header-forward errors
+ * - chunk_result propagates non-special errors
+ * Covers: ngx_http_markdown_streaming_init_handle,
+ *         ngx_http_markdown_streaming_handle_chunk_result
+ */
 static void
 test_init_handle_and_chunk_result_helpers(void)
 {
@@ -1563,6 +2018,29 @@ test_init_handle_and_chunk_result_helpers(void)
     TEST_PASS("init_handle/chunk_result branches covered");
 }
 
+/*
+ * Test commit, feed-result, and finalize core branches.  Verifies:
+ * - commit fails when header update or next header filter fails
+ * - commit propagates positive next header filter rc
+ * - commit succeeds on happy path, switches to post-commit, marks
+ *   headers forwarded
+ * - fallback feed result switches to full-buffer
+ * - post-commit feed errors terminate with downstream rc and record failure
+ * - pre-commit feed errors honor pass policy and mark ineligible
+ * - output byte counter saturates on overflow
+ * - successful feed surfaces backpressure (NGX_AGAIN)
+ * - empty successful feed output is a no-op
+ * - finalize emits terminal buffer when handle is null
+ * - pre-commit finalize errors honor pass policy
+ * - post-commit finalize errors terminate downstream
+ * - successful finalize increments success metrics and stores peak memory
+ * - finalize defers terminal last_buf on NGX_AGAIN and latches it
+ * - terminal last_buf backpressure latches pending terminal metrics
+ * - terminal last_buf hard errors propagate and record failure
+ * Covers: ngx_http_markdown_streaming_commit,
+ *         ngx_http_markdown_streaming_handle_feed_result,
+ *         ngx_http_markdown_streaming_finalize_request
+ */
 static void
 test_commit_feed_and_finalize_core_paths(void)
 {
@@ -1781,6 +2259,20 @@ test_commit_feed_and_finalize_core_paths(void)
     TEST_PASS("commit/feed-result/finalize core branches covered");
 }
 
+/*
+ * Test process-chain, failopen passthrough, and body_filter deep branches.
+ * Verifies:
+ * - failopen passthrough passes current chain for first invocation
+ * - failopen passthrough fails on prefix chain allocation errors
+ * - failopen passthrough rebuilds prefix chain on reentry
+ * - process_chain fails when failopen tracking capacity is exhausted
+ * - process_chain returns NGX_DONE when fallback switches path
+ * - body_filter reenters full-buffer path after fallback
+ * - body_filter fail-open passthrough when finalize declines
+ * Covers: ngx_http_markdown_streaming_failopen_passthrough,
+ *         ngx_http_markdown_streaming_process_chain,
+ *         ngx_http_markdown_streaming_body_filter
+ */
 static void
 test_process_chain_and_body_filter_deep_paths(void)
 {
@@ -1930,6 +2422,41 @@ test_process_chain_and_body_filter_deep_paths(void)
     TEST_PASS("process-chain/failopen/body-filter deep branches covered");
 }
 
+/*
+ * Test streaming helper gap branches — edge cases not covered by the
+ * focused tests above.  Verifies:
+ * - selector uses full-buffer when conf is NULL
+ * - resume_pending sends deferred last_buf branch
+ * - resume_pending sends deferred last_buf after pending drain
+ * - fallback fails when prebuffer append fails
+ * - feed errors with output fail-open in pre-commit pass mode and free
+ *   the output buffer
+ * - feed success propagates commit failure and still frees feed output
+ * - finalize propagates markdown send errors, preserves saturated output
+ *   counter, and records failure
+ * - finalize pre-commit surfaces commit errors
+ * - process_chunk short-circuits on NULL buffer, empty buffers, and
+ *   invalid pointer ordering
+ * - ensure_handle fails when fail-open header forwarding fails
+ * - ensure_handle passthrough when init declines
+ * - ensure_handle propagates hard init failures
+ * - ensure_handle returns NGX_OK when init succeeds
+ * - body_filter NULL input uses null-input helper success path
+ * - body_filter returns non-OK ensure_handle result
+ * - body_filter returns NGX_OK for non-terminal successful chunks
+ * - body_filter returns finalize rc on terminal buffer
+ * - finalize handles empty markdown result path
+ * - null-input helper returns NGX_OK when nothing is pending
+ * Covers: ngx_http_markdown_select_processing_path,
+ *         ngx_http_markdown_streaming_resume_pending,
+ *         ngx_http_markdown_streaming_fallback_to_fullbuffer,
+ *         ngx_http_markdown_streaming_handle_feed_result,
+ *         ngx_http_markdown_streaming_finalize_request,
+ *         ngx_http_markdown_streaming_process_chunk,
+ *         ngx_http_markdown_streaming_ensure_handle,
+ *         ngx_http_markdown_streaming_body_filter,
+ *         ngx_http_markdown_streaming_handle_null_input
+ */
 static void
 test_streaming_gap_branches(void)
 {
@@ -2187,6 +2714,11 @@ test_streaming_gap_branches(void)
     TEST_PASS("streaming helper gap branches covered");
 }
 
+/*
+ * Test entry point.  Runs all streaming_impl unit test functions in
+ * sequence.  Prints a banner before and after the test run.  Returns 0
+ * on success; individual test assertions abort via TEST_ASSERT on failure.
+ */
 int
 main(void)
 {

--- a/tools/ci/verify_real_nginx_ims.sh
+++ b/tools/ci/verify_real_nginx_ims.sh
@@ -194,11 +194,11 @@ else
   echo "==> Configuring NGINX"
   (
     cd "${BUILDROOT}"
+    # Enable streaming at compile time so the C module includes streaming
+    # code paths; this must match the Rust --features streaming flag above.
     ./configure \
       --without-http_rewrite_module \
       --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
-      # ^ Enable streaming at compile time so the C module includes streaming
-      #   code paths; must match the Rust --features streaming flag above.
       --prefix="${RUNTIME}" \
       --add-module="${WORKSPACE_ROOT}/components/nginx-module"
   )

--- a/tools/ci/verify_real_nginx_ims.sh
+++ b/tools/ci/verify_real_nginx_ims.sh
@@ -196,6 +196,7 @@ else
     cd "${BUILDROOT}"
     ./configure \
       --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
       --prefix="${RUNTIME}" \
       --add-module="${WORKSPACE_ROOT}/components/nginx-module"
   )

--- a/tools/ci/verify_real_nginx_ims.sh
+++ b/tools/ci/verify_real_nginx_ims.sh
@@ -182,7 +182,10 @@ if [[ -n "${NGINX_BIN}" ]]; then
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
   echo "==> Building Rust converter (${RUST_TARGET})"
-  markdown_prepare_rust_converter_release "${WORKSPACE_ROOT}" "${RUST_TARGET}"
+  # Keep streaming feature enabled so this retained binary can be safely
+  # reused by downstream streaming E2E checks in CI.
+  markdown_prepare_rust_converter_release "${WORKSPACE_ROOT}" "${RUST_TARGET}" \
+    --features streaming
 
   echo "==> Downloading NGINX ${NGINX_VERSION}"
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"

--- a/tools/ci/verify_real_nginx_ims.sh
+++ b/tools/ci/verify_real_nginx_ims.sh
@@ -197,6 +197,8 @@ else
     ./configure \
       --without-http_rewrite_module \
       --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      # ^ Enable streaming at compile time so the C module includes streaming
+      #   code paths; must match the Rust --features streaming flag above.
       --prefix="${RUNTIME}" \
       --add-module="${WORKSPACE_ROOT}/components/nginx-module"
   )

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -449,7 +449,8 @@ if [[ -n "${NGINX_BIN}" ]]; then
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
   echo "==> Building Rust converter (${RUST_TARGET})"
-  markdown_prepare_rust_converter_release "${WORKSPACE_ROOT}" "${RUST_TARGET}" >/dev/null
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
 
   echo "==> Downloading/building NGINX ${NGINX_VERSION}"
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
@@ -457,7 +458,11 @@ else
   tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
   (
     cd "${BUILDROOT}/src"
-    ./configure --without-http_rewrite_module --prefix="${RUNTIME}" --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
     make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
     make install >/dev/null
   )
@@ -649,14 +654,16 @@ grep -q 'response size exceeds limit' "${RUNTIME}/logs/error.log" || {
 # Verify that the truncated compressed streams produced the expected
 # internal diagnostics: a decompression finalize failure and a
 # STREAMING_FAIL_POSTCOMMIT decision log entry.
-grep -q 'decomp_finish failed in finalize' "${RUNTIME}/logs/error.log" || {
-  echo "missing decomp finalize failure log for truncated compressed cases" >&2
+decomp_finalize_count="$(grep -Fc 'decomp_finish failed in finalize' "${RUNTIME}/logs/error.log" || true)"
+postcommit_count="$(grep -Fc 'reason=STREAMING_FAIL_POSTCOMMIT' "${RUNTIME}/logs/error.log" || true)"
+if [[ "${decomp_finalize_count}" -lt 2 ]]; then
+  echo "missing decomp finalize failure logs for truncated gzip/deflate cases: ${decomp_finalize_count}" >&2
   exit 1
-}
-grep -q 'reason=STREAMING_FAIL_POSTCOMMIT' "${RUNTIME}/logs/error.log" || {
-  echo "missing STREAMING_FAIL_POSTCOMMIT decision log for truncated cases" >&2
+fi
+if [[ "${postcommit_count}" -lt 2 ]]; then
+  echo "missing STREAMING_FAIL_POSTCOMMIT decision logs for truncated gzip/deflate cases: ${postcommit_count}" >&2
   exit 1
-}
+fi
 
 if [[ "${PROFILE}" == "stress" ]]; then
   echo "==> Stress profile: ApacheBench for chunked conversion and fail-open paths"

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -3,9 +3,15 @@ set -euo pipefail
 
 # Native-only E2E validation for chunked/streaming upstream responses.
 #
-# Validates two critical paths:
+# Validates six critical paths:
 #  1) Chunked body below markdown_max_size converts successfully to Markdown.
 #  2) Chunked body above markdown_max_size triggers fail-open without truncation.
+#  3) Streaming + gzip decompression converts to Markdown and strips
+#     Content-Encoding.
+#  4) Streaming + deflate decompression converts to Markdown and strips
+#     Content-Encoding.
+#  5) Truncated gzip stream triggers decomp finalize failure and fail-open.
+#  6) Truncated deflate stream triggers decomp finalize failure and fail-open.
 
 NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
 PORT="${PORT:-18094}"
@@ -24,6 +30,13 @@ LOAD_MODULE_LINE=""
 UPSTREAM_PID=""
 ORIG_ARGS=("$@")
 ACCEPT_MARKDOWN_HEADER='Accept: text/markdown'
+readonly CURL_METRICS_FMT='http=%{http_code} size=%{size_download} total=%{time_total}\n'
+readonly PATTERN_HTTP_200='http=200 '
+readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown; charset=utf-8'
+readonly PATTERN_CT_HTML='^Content-Type: text/html'
+readonly PATTERN_TRANSFER_CHUNKED='^Transfer-Encoding:.*chunked'
+readonly PATTERN_CONTENT_LENGTH='^Content-Length:'
+readonly PATTERN_CONTENT_ENCODING='^Content-Encoding:'
 # shellcheck disable=SC1090
 source "${NATIVE_BUILD_HELPER}"
 
@@ -52,6 +65,41 @@ require_flag_value() {
   fi
 
   return 0
+}
+
+assert_streaming_markdown_response() {
+  local case_name="$1"
+  local hdr_file="$2"
+  local body_file="$3"
+  local heading="$4"
+  local end_token="${5:-}"
+
+  grep -qi "${PATTERN_CT_MARKDOWN}" "${hdr_file}" || {
+    echo "${case_name} expected markdown Content-Type" >&2
+    exit 1
+  }
+  grep -qi "${PATTERN_TRANSFER_CHUNKED}" "${hdr_file}" || {
+    echo "${case_name} missing chunked transfer encoding header" >&2
+    exit 1
+  }
+  grep -qi "${PATTERN_CONTENT_LENGTH}" "${hdr_file}" && {
+    echo "${case_name} unexpected Content-Length in streaming response" >&2
+    exit 1
+  }
+  grep -qi "${PATTERN_CONTENT_ENCODING}" "${hdr_file}" && {
+    echo "${case_name} response leaked Content-Encoding header" >&2
+    exit 1
+  }
+  grep -q "${heading}" "${body_file}" || {
+    echo "${case_name} missing converted heading marker" >&2
+    exit 1
+  }
+  if [[ -n "${end_token}" ]]; then
+    grep -q "${end_token}" "${body_file}" || {
+      echo "${case_name} missing tail marker after conversion" >&2
+      exit 1
+    }
+  fi
 }
 
 cleanup() {
@@ -158,12 +206,16 @@ mkdir -p "${RAW_DIR}"
 cat > "${UPSTREAM_SCRIPT}" <<'PY'
 #!/usr/bin/env python3
 import argparse
+import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 
 SMALL_END_TOKEN = "SMALL_STREAM_END_TOKEN"
 OVERSIZE_END_TOKEN = "OVERSIZE_STREAM_END_TOKEN"
+GZIP_END_TOKEN = "GZIP_STREAM_END_TOKEN"
+DEFLATE_END_TOKEN = "DEFLATE_STREAM_END_TOKEN"
 SMALL_TARGET = 2 * 1024 * 1024
+COMPRESSED_TARGET = 64 * 1024
 OVERSIZE_TARGET = 12 * 1024 * 1024
 CHUNK_SIZE = 16 * 1024
 
@@ -186,8 +238,32 @@ def build_payload(title: str, target_size: int, end_token: str) -> bytes:
     return bytes(out)
 
 
+def compress_payload(body: bytes, mode: str) -> bytes:
+    if mode == "gzip":
+        wbits = zlib.MAX_WBITS | 16
+    elif mode == "deflate":
+        wbits = -zlib.MAX_WBITS
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+
+    compressor = zlib.compressobj(level=6, wbits=wbits)
+    return compressor.compress(body) + compressor.flush()
+
+
 SMALL_BODY = build_payload("Chunked Small", SMALL_TARGET, SMALL_END_TOKEN)
 OVERSIZE_BODY = build_payload("Chunked Oversize", OVERSIZE_TARGET, OVERSIZE_END_TOKEN)
+GZIP_SOURCE_BODY = build_payload(
+    "Chunked Gzip", COMPRESSED_TARGET, GZIP_END_TOKEN
+)
+DEFLATE_SOURCE_BODY = build_payload(
+    "Chunked Deflate", COMPRESSED_TARGET, DEFLATE_END_TOKEN
+)
+GZIP_BODY = compress_payload(GZIP_SOURCE_BODY, "gzip")
+DEFLATE_BODY = compress_payload(DEFLATE_SOURCE_BODY, "deflate")
+TRUNCATED_GZIP_BODY = GZIP_BODY[:-8] if len(GZIP_BODY) > 8 else GZIP_BODY
+TRUNCATED_DEFLATE_BODY = (
+    DEFLATE_BODY[:-4] if len(DEFLATE_BODY) > 4 else DEFLATE_BODY
+)
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -196,11 +272,13 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt: str, *args):
         return
 
-    def _write_chunked(self, body: bytes):
+    def _write_chunked(self, body: bytes, content_encoding=None):
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=UTF-8")
         self.send_header("Transfer-Encoding", "chunked")
         self.send_header("Connection", "close")
+        if content_encoding:
+            self.send_header("Content-Encoding", content_encoding)
         self.end_headers()
 
         for i in range(0, len(body), CHUNK_SIZE):
@@ -227,6 +305,20 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/oversize":
             self._write_chunked(OVERSIZE_BODY)
             return
+        if path == "/small-gzip":
+            self._write_chunked(GZIP_BODY, content_encoding="gzip")
+            return
+        if path == "/small-deflate":
+            self._write_chunked(DEFLATE_BODY, content_encoding="deflate")
+            return
+        if path == "/truncated-gzip":
+            self._write_chunked(TRUNCATED_GZIP_BODY, content_encoding="gzip")
+            return
+        if path == "/truncated-deflate":
+            self._write_chunked(
+                TRUNCATED_DEFLATE_BODY, content_encoding="deflate"
+            )
+            return
         self.send_response(404)
         self.send_header("Content-Length", "0")
         self.end_headers()
@@ -242,6 +334,34 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=UTF-8")
             self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            return
+        if path == "/small-gzip":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Content-Encoding", "gzip")
+            self.end_headers()
+            return
+        if path == "/small-deflate":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Content-Encoding", "deflate")
+            self.end_headers()
+            return
+        if path == "/truncated-gzip":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Content-Encoding", "gzip")
+            self.end_headers()
+            return
+        if path == "/truncated-deflate":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.send_header("Content-Encoding", "deflate")
             self.end_headers()
             return
         self.send_response(404)
@@ -260,8 +380,19 @@ def main():
     if args.print_metrics:
         print(f"SMALL_LEN={len(SMALL_BODY)}")
         print(f"OVERSIZE_LEN={len(OVERSIZE_BODY)}")
+        print(f"GZIP_SOURCE_LEN={len(GZIP_SOURCE_BODY)}")
+        print(f"GZIP_COMPRESSED_LEN={len(GZIP_BODY)}")
+        print(f"DEFLATE_SOURCE_LEN={len(DEFLATE_SOURCE_BODY)}")
+        print(f"DEFLATE_COMPRESSED_LEN={len(DEFLATE_BODY)}")
+        print(f"TRUNCATED_GZIP_COMPRESSED_LEN={len(TRUNCATED_GZIP_BODY)}")
+        print(
+            f"TRUNCATED_DEFLATE_COMPRESSED_LEN="
+            f"{len(TRUNCATED_DEFLATE_BODY)}"
+        )
         print(f"SMALL_END_TOKEN={SMALL_END_TOKEN}")
         print(f"OVERSIZE_END_TOKEN={OVERSIZE_END_TOKEN}")
+        print(f"GZIP_END_TOKEN={GZIP_END_TOKEN}")
+        print(f"DEFLATE_END_TOKEN={DEFLATE_END_TOKEN}")
         return
 
     if args.serve:
@@ -343,6 +474,25 @@ http {
             proxy_set_header Connection "";
             proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
         }
+
+        location /streaming/ {
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_etag on;
+            markdown_streaming_engine on;
+            markdown_streaming_on_error pass;
+            markdown_conditional_requests if_modified_since_only;
+            markdown_max_size ${MARKDOWN_MAX_SIZE};
+            markdown_streaming_budget 64m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            markdown_log_verbosity info;
+
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
     }
 }
 EOF
@@ -355,10 +505,10 @@ echo "==> Case 1: chunked below max_size should convert to Markdown"
 small_line="$(curl -sS -D "${RAW_DIR}/small.hdr" -o "${RAW_DIR}/small.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
   "http://127.0.0.1:${PORT}/stream/small-valid" \
-  -w 'http=%{http_code} size=%{size_download} total=%{time_total}\n')"
+  -w "${CURL_METRICS_FMT}")"
 echo "${small_line}" | tee "${RAW_DIR}/small.metrics" >/dev/null
-echo "${small_line}" | grep -q 'http=200 ' || { echo "small-valid failed: ${small_line}" >&2; exit 1; }
-grep -qi '^Content-Type: text/markdown; charset=utf-8' "${RAW_DIR}/small.hdr" || {
+echo "${small_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "small-valid failed: ${small_line}" >&2; exit 1; }
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/small.hdr" || {
   echo "small-valid expected markdown Content-Type" >&2
   exit 1
 }
@@ -375,10 +525,10 @@ echo "==> Case 2: chunked above max_size should fail-open without truncation"
 oversize_line="$(curl -sS -D "${RAW_DIR}/oversize.hdr" -o "${RAW_DIR}/oversize.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 240 \
   "http://127.0.0.1:${PORT}/stream/oversize" \
-  -w 'http=%{http_code} size=%{size_download} total=%{time_total}\n')"
+  -w "${CURL_METRICS_FMT}")"
 echo "${oversize_line}" | tee "${RAW_DIR}/oversize.metrics" >/dev/null
-echo "${oversize_line}" | grep -q 'http=200 ' || { echo "oversize failed: ${oversize_line}" >&2; exit 1; }
-grep -qi '^Content-Type: text/html' "${RAW_DIR}/oversize.hdr" || {
+echo "${oversize_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "oversize failed: ${oversize_line}" >&2; exit 1; }
+grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/oversize.hdr" || {
   echo "oversize expected fail-open pass-through Content-Type text/html" >&2
   exit 1
 }
@@ -393,9 +543,71 @@ grep -q "${OVERSIZE_END_TOKEN}" "${RAW_DIR}/oversize.body" || {
   exit 1
 }
 
+echo "==> Case 3: streaming gzip decompression should convert to Markdown"
+gzip_line="$(curl -sS -D "${RAW_DIR}/gzip.hdr" -o "${RAW_DIR}/gzip.body" \
+  -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
+  "http://127.0.0.1:${PORT}/streaming/small-gzip" \
+  -w "${CURL_METRICS_FMT}")"
+echo "${gzip_line}" | tee "${RAW_DIR}/gzip.metrics" >/dev/null
+echo "${gzip_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "small-gzip failed: ${gzip_line}" >&2; exit 1; }
+assert_streaming_markdown_response \
+  "small-gzip" "${RAW_DIR}/gzip.hdr" "${RAW_DIR}/gzip.body" \
+  "# Chunked Gzip" "${GZIP_END_TOKEN}"
+
+echo "==> Case 4: streaming deflate decompression should convert to Markdown"
+deflate_line="$(curl -sS -D "${RAW_DIR}/deflate.hdr" -o "${RAW_DIR}/deflate.body" \
+  -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
+  "http://127.0.0.1:${PORT}/streaming/small-deflate" \
+  -w "${CURL_METRICS_FMT}")"
+echo "${deflate_line}" | tee "${RAW_DIR}/deflate.metrics" >/dev/null
+echo "${deflate_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "small-deflate failed: ${deflate_line}" >&2; exit 1; }
+assert_streaming_markdown_response \
+  "small-deflate" "${RAW_DIR}/deflate.hdr" "${RAW_DIR}/deflate.body" \
+  "# Chunked Deflate" "${DEFLATE_END_TOKEN}"
+
+echo "==> Case 5: truncated gzip should trigger post-commit failure"
+trunc_gzip_line="$(curl -sS -D "${RAW_DIR}/trunc_gzip.hdr" -o "${RAW_DIR}/trunc_gzip.body" \
+  -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
+  "http://127.0.0.1:${PORT}/streaming/truncated-gzip" \
+  -w "${CURL_METRICS_FMT}")"
+echo "${trunc_gzip_line}" | tee "${RAW_DIR}/trunc_gzip.metrics" >/dev/null
+echo "${trunc_gzip_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-gzip failed: ${trunc_gzip_line}" >&2; exit 1; }
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_gzip.hdr" || {
+  echo "truncated-gzip expected markdown Content-Type (post-commit path)" >&2
+  exit 1
+}
+grep -q '# Chunked Gzip' "${RAW_DIR}/trunc_gzip.body" || {
+  echo "truncated-gzip missing converted heading marker" >&2
+  exit 1
+}
+
+echo "==> Case 6: truncated deflate should trigger post-commit failure"
+trunc_deflate_line="$(curl -sS -D "${RAW_DIR}/trunc_deflate.hdr" -o "${RAW_DIR}/trunc_deflate.body" \
+  -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
+  "http://127.0.0.1:${PORT}/streaming/truncated-deflate" \
+  -w "${CURL_METRICS_FMT}")"
+echo "${trunc_deflate_line}" | tee "${RAW_DIR}/trunc_deflate.metrics" >/dev/null
+echo "${trunc_deflate_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-deflate failed: ${trunc_deflate_line}" >&2; exit 1; }
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_deflate.hdr" || {
+  echo "truncated-deflate expected markdown Content-Type (post-commit path)" >&2
+  exit 1
+}
+grep -q '# Chunked Deflate' "${RAW_DIR}/trunc_deflate.body" || {
+  echo "truncated-deflate missing converted heading marker" >&2
+  exit 1
+}
+
 echo "==> Log sanity checks"
 grep -q 'response size exceeds limit' "${RUNTIME}/logs/error.log" || {
   echo "missing size-limit log for chunked oversize case" >&2
+  exit 1
+}
+grep -q 'decomp_finish failed in finalize' "${RUNTIME}/logs/error.log" || {
+  echo "missing decomp finalize failure log for truncated compressed cases" >&2
+  exit 1
+}
+grep -q 'reason=STREAMING_FAIL_POSTCOMMIT' "${RUNTIME}/logs/error.log" || {
+  echo "missing STREAMING_FAIL_POSTCOMMIT decision log for truncated cases" >&2
   exit 1
 }
 
@@ -435,6 +647,16 @@ echo "  small_expected_html_bytes=${SMALL_LEN}"
 echo "  small_result=$(cat "${RAW_DIR}/small.metrics")"
 echo "  oversize_expected_html_bytes=${OVERSIZE_LEN}"
 echo "  oversize_result=$(cat "${RAW_DIR}/oversize.metrics")"
+echo "  gzip_source_html_bytes=${GZIP_SOURCE_LEN}"
+echo "  gzip_compressed_bytes=${GZIP_COMPRESSED_LEN}"
+echo "  gzip_result=$(cat "${RAW_DIR}/gzip.metrics")"
+echo "  deflate_source_html_bytes=${DEFLATE_SOURCE_LEN}"
+echo "  deflate_compressed_bytes=${DEFLATE_COMPRESSED_LEN}"
+echo "  deflate_result=$(cat "${RAW_DIR}/deflate.metrics")"
+echo "  truncated_gzip_compressed_bytes=${TRUNCATED_GZIP_COMPRESSED_LEN}"
+echo "  truncated_gzip_result=$(cat "${RAW_DIR}/trunc_gzip.metrics")"
+echo "  truncated_deflate_compressed_bytes=${TRUNCATED_DEFLATE_COMPRESSED_LEN}"
+echo "  truncated_deflate_result=$(cat "${RAW_DIR}/trunc_deflate.metrics")"
 if [[ "${PROFILE}" == "stress" ]]; then
   echo "  stress_small_ab_rps=${small_rps:-unknown}"
   echo "  stress_oversize_ab_rps=${oversize_rps:-unknown}"

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -30,12 +30,19 @@ LOAD_MODULE_LINE=""
 UPSTREAM_PID=""
 ORIG_ARGS=("$@")
 ACCEPT_MARKDOWN_HEADER='Accept: text/markdown'
+# curl -w format string for capturing HTTP status, download size, and total
+# time from each request; used to populate .metrics artifact files.
 readonly CURL_METRICS_FMT='http=%{http_code} size=%{size_download} total=%{time_total}\n'
+# Grep patterns for validating response headers and status codes.
 readonly PATTERN_HTTP_200='http=200 '
 readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown; charset=utf-8'
 readonly PATTERN_CT_HTML='^Content-Type: text/html'
 readonly PATTERN_TRANSFER_CHUNKED='^Transfer-Encoding:.*chunked'
+# Pattern matching Content-Length header; streaming responses must not
+# include this header (they use chunked transfer instead).
 readonly PATTERN_CONTENT_LENGTH='^Content-Length:'
+# Pattern matching Content-Encoding header; used to verify that streaming
+# decompression strips the header from the downstream response.
 readonly PATTERN_CONTENT_ENCODING='^Content-Encoding:'
 # shellcheck disable=SC1090
 source "${NATIVE_BUILD_HELPER}"
@@ -55,6 +62,14 @@ EOF
   return 0
 }
 
+#
+# Validate that a flag requiring a value has one.
+# Arguments:
+#   $1: flag name (for diagnostics)
+#   $2: flag value (must be non-empty)
+# Output: prints usage to stderr on failure
+# Exit: exits with code 2 if value is missing
+#
 require_flag_value() {
   local flag_name="$1"
 
@@ -116,6 +131,12 @@ assert_streaming_markdown_response() {
   return 0
 }
 
+#
+# Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+# Arguments: none (reads global UPSTREAM_PID, RUNTIME, NGINX_EXECUTABLE, etc.)
+# Output: diagnostic message to stderr on failure with artifact path
+# Exit: returns the original trap exit code
+#
 cleanup() {
   local rc=$?
 
@@ -580,10 +601,16 @@ assert_streaming_markdown_response \
   "# Chunked Deflate" "${DEFLATE_END_TOKEN}"
 
 echo "==> Case 5: truncated gzip should trigger post-commit failure"
+# The upstream sends a gzip stream with the final 8 bytes removed, so
+# decompression succeeds incrementally but fails at finalize.  Because
+# headers were already committed, the module must emit partial Markdown
+# (post-commit fail-open) rather than switching to HTML pass-through.
 trunc_gzip_line="$(curl -sS -D "${RAW_DIR}/trunc_gzip.hdr" -o "${RAW_DIR}/trunc_gzip.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
   "http://127.0.0.1:${PORT}/streaming/truncated-gzip" \
   -w "${CURL_METRICS_FMT}" || true)"
+# || true: under set -e, curl may return non-zero when the server closes
+# the connection after a truncated stream; suppress so assertions can run.
 echo "${trunc_gzip_line}" | tee "${RAW_DIR}/trunc_gzip.metrics" >/dev/null
 echo "${trunc_gzip_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-gzip failed: ${trunc_gzip_line}" >&2; exit 1; }
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_gzip.hdr" || {
@@ -596,10 +623,13 @@ grep -q '# Chunked Gzip' "${RAW_DIR}/trunc_gzip.body" || {
 }
 
 echo "==> Case 6: truncated deflate should trigger post-commit failure"
+# Same rationale as case 5 but for deflate: the final 4 bytes are
+# stripped so the deflate finalizer fails after the commit boundary.
 trunc_deflate_line="$(curl -sS -D "${RAW_DIR}/trunc_deflate.hdr" -o "${RAW_DIR}/trunc_deflate.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
   "http://127.0.0.1:${PORT}/streaming/truncated-deflate" \
   -w "${CURL_METRICS_FMT}" || true)"
+# || true: same rationale as truncated-gzip case above.
 echo "${trunc_deflate_line}" | tee "${RAW_DIR}/trunc_deflate.metrics" >/dev/null
 echo "${trunc_deflate_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-deflate failed: ${trunc_deflate_line}" >&2; exit 1; }
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_deflate.hdr" || {
@@ -616,6 +646,9 @@ grep -q 'response size exceeds limit' "${RUNTIME}/logs/error.log" || {
   echo "missing size-limit log for chunked oversize case" >&2
   exit 1
 }
+# Verify that the truncated compressed streams produced the expected
+# internal diagnostics: a decompression finalize failure and a
+# STREAMING_FAIL_POSTCOMMIT decision log entry.
 grep -q 'decomp_finish failed in finalize' "${RUNTIME}/logs/error.log" || {
   echo "missing decomp finalize failure log for truncated compressed cases" >&2
   exit 1

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -67,6 +67,18 @@ require_flag_value() {
   return 0
 }
 
+#
+# Validate a streaming markdown HTTP response contract.
+# Args:
+#   case_name: logical case label used in diagnostics
+#   hdr_file: response header artifact path
+#   body_file: response body artifact path
+#   heading: required markdown heading token in body
+#   end_token: optional tail token expected in body
+# Output/exit:
+#   emits diagnostics to stderr and exits non-zero on assertion failure;
+#   returns 0 when all assertions pass.
+#
 assert_streaming_markdown_response() {
   local case_name="$1"
   local hdr_file="$2"
@@ -100,6 +112,8 @@ assert_streaming_markdown_response() {
       exit 1
     }
   fi
+
+  return 0
 }
 
 cleanup() {
@@ -569,7 +583,7 @@ echo "==> Case 5: truncated gzip should trigger post-commit failure"
 trunc_gzip_line="$(curl -sS -D "${RAW_DIR}/trunc_gzip.hdr" -o "${RAW_DIR}/trunc_gzip.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
   "http://127.0.0.1:${PORT}/streaming/truncated-gzip" \
-  -w "${CURL_METRICS_FMT}")"
+  -w "${CURL_METRICS_FMT}" || true)"
 echo "${trunc_gzip_line}" | tee "${RAW_DIR}/trunc_gzip.metrics" >/dev/null
 echo "${trunc_gzip_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-gzip failed: ${trunc_gzip_line}" >&2; exit 1; }
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_gzip.hdr" || {
@@ -585,7 +599,7 @@ echo "==> Case 6: truncated deflate should trigger post-commit failure"
 trunc_deflate_line="$(curl -sS -D "${RAW_DIR}/trunc_deflate.hdr" -o "${RAW_DIR}/trunc_deflate.body" \
   -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 180 \
   "http://127.0.0.1:${PORT}/streaming/truncated-deflate" \
-  -w "${CURL_METRICS_FMT}")"
+  -w "${CURL_METRICS_FMT}" || true)"
 echo "${trunc_deflate_line}" | tee "${RAW_DIR}/trunc_deflate.metrics" >/dev/null
 echo "${trunc_deflate_line}" | grep -q "${PATTERN_HTTP_200}" || { echo "truncated-deflate failed: ${trunc_deflate_line}" >&2; exit 1; }
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/trunc_deflate.hdr" || {

--- a/tools/e2e/verify_streaming_failure_cache_e2e.sh
+++ b/tools/e2e/verify_streaming_failure_cache_e2e.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 #   10.7  Streaming response headers: no Content-Length, chunked transfer
 #   10.8  streaming_engine off + streaming_on_error config: 0.4.0 behavior
 #   10.9  markdown_on_error vs markdown_streaming_on_error independence
+#   10.10 HEAD request does not enter streaming path
+#   10.11 304 response does not enter streaming path
 #
 # When NGINX_BIN is not set, exits with code 1 unless --plan is specified.
 
@@ -45,6 +47,7 @@ readonly PATTERN_CT_HTML='^Content-Type: text/html'
 readonly PATTERN_CL='^Content-Length:'
 readonly PATTERN_ETAG='^ETag:'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
+readonly PATTERN_HTTP_304='HTTP/1.1 304'
 readonly PATTERN_TRANSFER_CHUNKED='^Transfer-Encoding:.*chunked'
 readonly PATTERN_VARY_ACCEPT='^Vary:.*Accept'
 readonly PATTERN_MARKDOWN_HEADING='^# '
@@ -88,6 +91,8 @@ Test cases:
   10.7  Streaming response headers
   10.8  streaming_engine off + streaming_on_error
   10.9  Directive independence
+  10.10 HEAD request does not enter streaming path
+  10.11 304 response does not enter streaming path
 EOF
     return 0
 }
@@ -342,6 +347,14 @@ echo "  - Cross-config: on_error pass + streaming_on_error reject"
 echo "  - Cross-config: on_error reject + streaming_on_error pass"
 echo "  - Verify: each directive controls only its own path"
 echo ""
+echo "10.10 HEAD request does not enter streaming path"
+echo "  - streaming_engine on + HEAD request"
+echo "  - Verify: HTTP 200 and empty response body"
+echo ""
+echo "10.11 304 response does not enter streaming path"
+echo "  - Capture ETag from full-buffer location"
+echo "  - Re-request with If-None-Match and verify HTTP 304 + empty body"
+echo ""
 
 if [[ "${PLAN_ONLY}" -eq 1 ]]; then
     echo "Plan-only mode. All test cases documented. Exiting."
@@ -418,9 +431,9 @@ Test upstream server for streaming failure/cache E2E tests.
 Endpoints:
   /health              Health check
   /simple              Small valid HTML (streaming-friendly)
+  /simple-with-etag    Small HTML with upstream ETag header
   /oversize            HTML exceeding typical max_size (triggers pre-commit error)
   /partial-abort       Sends partial HTML then aborts (triggers post-commit error)
-  /simple-with-etag    Small HTML with upstream ETag header
 """
 import argparse
 import time
@@ -545,6 +558,21 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/health":
             self.send_response(200)
             self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if path == "/simple":
+            body = SIMPLE_HTML.encode('utf-8')
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            return
+        if path == "/simple-with-etag":
+            body = SIMPLE_HTML.encode('utf-8')
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("ETag", '"upstream-etag-v1"')
             self.end_headers()
             return
         self.send_response(404)
@@ -803,6 +831,42 @@ http {
             markdown_conditional_requests if_modified_since_only;
             markdown_max_size 20m;
             markdown_streaming_budget 1k;
+            markdown_timeout 120000;
+            markdown_log_verbosity info;
+
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # 10.10: HEAD request should bypass streaming body processing
+        location /t10/ {
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_etag on;
+            markdown_streaming_engine on;
+            markdown_conditional_requests if_modified_since_only;
+            markdown_max_size ${MARKDOWN_MAX_SIZE};
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            markdown_log_verbosity info;
+
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # 10.11: 304 should bypass streaming path selection
+        location /t11/ {
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_etag on;
+            markdown_streaming_engine on;
+            markdown_conditional_requests full_support;
+            markdown_max_size ${MARKDOWN_MAX_SIZE};
+            markdown_on_error pass;
             markdown_timeout 120000;
             markdown_log_verbosity info;
 
@@ -1142,6 +1206,70 @@ if [[ ${t09_pass} -eq 1 ]]; then
     report_case "10.9" "PASS" "Directive independence verified"
 else
     report_case "10.9" "FAIL" "Directive independence verified"
+fi
+
+# ---------------------------------------------------------------------------
+# 10.10 HEAD request does not enter streaming path
+# ---------------------------------------------------------------------------
+echo "==> 10.10 HEAD request does not enter streaming path"
+curl -sS -D "${RAW_DIR}/t10.hdr" -o "${RAW_DIR}/t10.body" \
+    -X HEAD -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
+    "http://127.0.0.1:${PORT}/t10/simple"
+
+t10_pass=1
+
+assert_http_200 "${RAW_DIR}/t10.hdr" "10.10" t10_pass \
+    "${MSG_EXPECTED_HTTP_200}"
+assert_content_type_markdown "${RAW_DIR}/t10.hdr" "10.10" t10_pass \
+    "${MSG_EXPECTED_CT_MARKDOWN}"
+if [[ -s "${RAW_DIR}/t10.body" ]]; then
+    mark_case_fail "10.10" "HEAD response should not include a body" t10_pass
+fi
+
+if [[ ${t10_pass} -eq 1 ]]; then
+    report_case "10.10" "PASS" "HEAD bypasses streaming body processing"
+else
+    report_case "10.10" "FAIL" "HEAD bypasses streaming body processing"
+fi
+
+# ---------------------------------------------------------------------------
+# 10.11 304 response does not enter streaming path
+# ---------------------------------------------------------------------------
+echo "==> 10.11 304 response does not enter streaming path"
+curl -sS -D "${RAW_DIR}/t11_first.hdr" -o "${RAW_DIR}/t11_first.body" \
+    -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
+    "http://127.0.0.1:${PORT}/t11/simple-with-etag"
+
+t11_pass=1
+t11_etag="$(awk '{
+    line = $0
+    if (tolower(line) ~ /^etag:/) {
+        sub(/^[^:]+:[[:space:]]*/, "", line)
+        gsub(/\r/, "", line)
+        print line
+        exit
+    }
+}' "${RAW_DIR}/t11_first.hdr")"
+if [[ -z "${t11_etag}" ]]; then
+    mark_case_fail "10.11" "first request did not return ETag for conditional revalidation" t11_pass
+else
+    curl -sS -D "${RAW_DIR}/t11_304.hdr" -o "${RAW_DIR}/t11_304.body" \
+        -H "${ACCEPT_MARKDOWN_HEADER}" \
+        -H "If-None-Match: ${t11_etag}" --max-time 30 \
+        "http://127.0.0.1:${PORT}/t11/simple-with-etag"
+
+    if ! grep -q "${PATTERN_HTTP_304}" "${RAW_DIR}/t11_304.hdr"; then
+        mark_case_fail "10.11" "expected HTTP 304 for matching If-None-Match" t11_pass
+    fi
+    if [[ -s "${RAW_DIR}/t11_304.body" ]]; then
+        mark_case_fail "10.11" "304 response should not include a body" t11_pass
+    fi
+fi
+
+if [[ ${t11_pass} -eq 1 ]]; then
+    report_case "10.11" "PASS" "304 bypasses streaming conversion path"
+else
+    report_case "10.11" "FAIL" "304 bypasses streaming conversion path"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tools/e2e/verify_streaming_failure_cache_e2e.sh
+++ b/tools/e2e/verify_streaming_failure_cache_e2e.sh
@@ -47,6 +47,8 @@ readonly PATTERN_CT_HTML='^Content-Type: text/html'
 readonly PATTERN_CL='^Content-Length:'
 readonly PATTERN_ETAG='^ETag:'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
+# Pattern for detecting HTTP 304 Not Modified in response headers;
+# used by case 10.11 to verify conditional revalidation bypasses streaming.
 readonly PATTERN_HTTP_304='HTTP/1.1 304'
 readonly PATTERN_TRANSFER_CHUNKED='^Transfer-Encoding:.*chunked'
 readonly PATTERN_VARY_ACCEPT='^Vary:.*Accept'
@@ -841,6 +843,8 @@ http {
         }
 
         # 10.10: HEAD request should bypass streaming body processing
+        # Uses if_modified_since_only so streaming is eligible for GET,
+        # but HEAD must still skip the streaming body path entirely.
         location /t10/ {
             markdown_filter on;
             markdown_on_wildcard on;
@@ -859,6 +863,8 @@ http {
         }
 
         # 10.11: 304 should bypass streaming path selection
+        # Uses full_support so ETag is generated, enabling If-None-Match
+        # revalidation that must produce 304 without entering streaming.
         location /t11/ {
             markdown_filter on;
             markdown_on_wildcard on;
@@ -1212,6 +1218,8 @@ fi
 # 10.10 HEAD request does not enter streaming path
 # ---------------------------------------------------------------------------
 echo "==> 10.10 HEAD request does not enter streaming path"
+# Create an empty body file before curl --head, which writes headers but
+# not a body file; downstream -s test needs the file to exist.
 : > "${RAW_DIR}/t10.body"
 curl -sS --head -D "${RAW_DIR}/t10.hdr" \
     -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
@@ -1237,11 +1245,16 @@ fi
 # 10.11 304 response does not enter streaming path
 # ---------------------------------------------------------------------------
 echo "==> 10.11 304 response does not enter streaming path"
+# First request: capture the ETag from a full-support conditional location
+# so we can send a conditional revalidation request next.
 curl -sS -D "${RAW_DIR}/t11_first.hdr" -o "${RAW_DIR}/t11_first.body" \
     -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
     "http://127.0.0.1:${PORT}/t11/simple-with-etag"
 
 t11_pass=1
+# Extract the ETag value from response headers using awk.
+# tolower + regex match handles case-insensitive header names;
+# sub/gsub strips the header name prefix and trailing CR.
 t11_etag="$(awk '{
     line = $0
     if (tolower(line) ~ /^etag:/) {

--- a/tools/e2e/verify_streaming_failure_cache_e2e.sh
+++ b/tools/e2e/verify_streaming_failure_cache_e2e.sh
@@ -1212,8 +1212,9 @@ fi
 # 10.10 HEAD request does not enter streaming path
 # ---------------------------------------------------------------------------
 echo "==> 10.10 HEAD request does not enter streaming path"
-curl -sS -D "${RAW_DIR}/t10.hdr" -o "${RAW_DIR}/t10.body" \
-    -X HEAD -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
+: > "${RAW_DIR}/t10.body"
+curl -sS --head -D "${RAW_DIR}/t10.hdr" \
+    -H "${ACCEPT_MARKDOWN_HEADER}" --max-time 30 \
     "http://127.0.0.1:${PORT}/t10/simple"
 
 t10_pass=1

--- a/tools/sonar/collect_nginx_coverage.sh
+++ b/tools/sonar/collect_nginx_coverage.sh
@@ -318,6 +318,13 @@ http {
             markdown_conditional_requests disabled;
         }
 
+        location /no-etag {
+            root html;
+            markdown_filter on;
+            markdown_etag off;
+            markdown_conditional_requests full_support;
+        }
+
         location /no-wildcard {
             root html;
             markdown_filter on;
@@ -405,6 +412,36 @@ http {
             markdown_log_verbosity debug;
             markdown_on_error pass;
             markdown_max_size 1m;
+        }
+
+        # Proxy to backend that advertises gzip without valid gzip payload
+        # (exercises decompression error + fail-open handling)
+        location /proxy-fake-gzip {
+            proxy_pass http://127.0.0.1:${BACKEND_PORT}/fake-gzip/;
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_log_verbosity debug;
+            markdown_on_error pass;
+        }
+
+        # Proxy to backend that advertises brotli without valid brotli payload
+        # (exercises unsupported/invalid compressed-stream handling)
+        location /proxy-fake-br {
+            proxy_pass http://127.0.0.1:${BACKEND_PORT}/fake-br/;
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_log_verbosity debug;
+            markdown_on_error pass;
+        }
+
+        # Proxy to backend that advertises deflate without valid deflate payload
+        # (exercises deflate decompression error handling)
+        location /proxy-fake-deflate {
+            proxy_pass http://127.0.0.1:${BACKEND_PORT}/fake-deflate/;
+            markdown_filter on;
+            markdown_on_wildcard on;
+            markdown_log_verbosity debug;
+            markdown_on_error pass;
         }
 
         # Proxy to backend with Cache-Control: public (exercises strip-public CC path)
@@ -626,6 +663,22 @@ http {
             alias html/;
             add_header Cache-Control "no-store";
         }
+
+        # Deliberately mislabeled encodings for decompression negative-path coverage.
+        location /fake-gzip/ {
+            alias html/;
+            add_header Content-Encoding "gzip" always;
+        }
+
+        location /fake-br/ {
+            alias html/;
+            add_header Content-Encoding "br" always;
+        }
+
+        location /fake-deflate/ {
+            alias html/;
+            add_header Content-Encoding "deflate" always;
+        }
     }
 }
 EOF
@@ -633,7 +686,7 @@ EOF
 # ── Create test HTML fixtures ───────────────────────────────────────
 
 # Create subdirectories for location blocks that use root html
-for subdir in auth auth-public-cc auth-allow reject-error ims-only no-conditional \
+for subdir in auth auth-public-cc auth-allow reject-error ims-only no-conditional no-etag \
               no-wildcard disabled gfm commonmark small-limit log-error \
               streaming streaming-auto streaming-tiny-budget \
               streaming-variable streaming-fullsupport streaming-ims-only \
@@ -661,7 +714,7 @@ HTML
 # Copy index.html to all subdirectories so location blocks serve 200.
 # Note: small-limit is intentionally excluded — it only receives large.html
 # (below) so the size-limit rejection test exercises the over-limit path.
-for subdir in auth auth-public-cc auth-allow reject-error ims-only no-conditional \
+for subdir in auth auth-public-cc auth-allow reject-error ims-only no-conditional no-etag \
               no-wildcard disabled gfm commonmark log-error \
               streaming streaming-auto streaming-tiny-budget \
               streaming-variable streaming-fullsupport streaming-ims-only \
@@ -823,6 +876,22 @@ curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: "etag"' \
 curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: "etag"' \
   "http://127.0.0.1:${PORT}/no-conditional/index.html" -o /dev/null -w "  INM disabled bypass: HTTP %{http_code}\n"
 
+# If-None-Match with ETag disabled (branch: cannot compare)
+curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: "etag-disabled"' \
+  "http://127.0.0.1:${PORT}/no-etag/index.html" -o /dev/null -w "  INM etag-off bypass: HTTP %{http_code}\n"
+
+# Malformed If-None-Match (unterminated quote)
+curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: "unterminated' \
+  "http://127.0.0.1:${PORT}/index.html" -o /dev/null -w "  INM malformed quote: HTTP %{http_code}\n"
+
+# Weak/quoted ETag token handling
+curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: W/"some-etag-value"' \
+  "http://127.0.0.1:${PORT}/index.html" -o /dev/null -w "  INM weak validator: HTTP %{http_code}\n"
+
+# Unquoted multi-token ETag parsing
+curl -sS -H "${ACCEPT_MARKDOWN}" -H 'If-None-Match: etagA, etagB' \
+  "http://127.0.0.1:${PORT}/index.html" -o /dev/null -w "  INM unquoted multi: HTTP %{http_code}\n"
+
 # ── Error path scenarios (Req 4) ────────────────────────────────────
 
 # Non-existent page (404 passthrough)
@@ -896,6 +965,17 @@ curl -sS -H "${ACCEPT_MARKDOWN}" \
 curl -sS -H "${ACCEPT_MARKDOWN}" \
   "http://127.0.0.1:${PORT}/streaming-proxy-gzip-reject/large.html" \
   -o /dev/null -w "  streaming gzip reject: HTTP %{http_code}\n" || true
+
+# Proxy with invalid/mislabeled compressed payloads
+curl -sS -H "${ACCEPT_MARKDOWN}" \
+  "http://127.0.0.1:${PORT}/proxy-fake-gzip/index.html" \
+  -o /dev/null -w "  fake gzip payload: HTTP %{http_code}\n" || true
+curl -sS -H "${ACCEPT_MARKDOWN}" \
+  "http://127.0.0.1:${PORT}/proxy-fake-br/index.html" \
+  -o /dev/null -w "  fake br payload: HTTP %{http_code}\n" || true
+curl -sS -H "${ACCEPT_MARKDOWN}" \
+  "http://127.0.0.1:${PORT}/proxy-fake-deflate/index.html" \
+  -o /dev/null -w "  fake deflate payload: HTTP %{http_code}\n" || true
 
 # ── X-Forwarded header scenarios (exercises conversion_impl.h header iteration) ──
 
@@ -1080,8 +1160,11 @@ echo "==> Stopping NGINX (flush gcov data)"
 "${RUNTIME}/sbin/nginx" -p "${RUNTIME}" -c conf/nginx.conf -s stop
 sleep 2
 
+REUSE_NGINX_BIN="${RUNTIME}/sbin/nginx"
+
 echo "==> Running extended streaming failure/cache e2e coverage"
-if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_streaming_failure_cache_e2e.sh" \
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
+  bash "${WORKSPACE_ROOT}/tools/e2e/verify_streaming_failure_cache_e2e.sh" \
   --nginx-bin "${RUNTIME}/sbin/nginx" \
   --port 18296 \
   --upstream-port 19296 \
@@ -1090,34 +1173,54 @@ if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_streaming_failure_cache_e2e.sh" \
 fi
 
 echo "==> Running streaming e2e coverage"
-if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_streaming_e2e.sh" \
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
+  bash "${WORKSPACE_ROOT}/tools/e2e/verify_streaming_e2e.sh" \
   --nginx-bin "${RUNTIME}/sbin/nginx"; then
     echo "  WARNING: streaming e2e coverage run failed; continuing" >&2
 fi
 
 echo "==> Running chunked streaming e2e coverage (smoke)"
-if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_chunked_streaming_native_e2e.sh" \
-    --nginx-bin "${RUNTIME}/sbin/nginx" \
+# Keep 10m so streaming gzip/deflate fixtures can validate decompression
+# behavior instead of tripping full-buffer size fail-open at 1m.
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
+    bash "${WORKSPACE_ROOT}/tools/e2e/verify_chunked_streaming_native_e2e.sh" \
     --profile smoke \
     --port 18294 \
     --upstream-port 19294 \
-    --markdown-max-size 1m; then
+    --markdown-max-size 10m; then
     echo "  WARNING: chunked streaming e2e coverage run failed; continuing" >&2
 fi
 
 echo "==> Running large markdown response e2e coverage"
-if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_large_markdown_response_e2e.sh" \
-    --nginx-bin "${RUNTIME}/sbin/nginx" \
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
+    bash "${WORKSPACE_ROOT}/tools/e2e/verify_large_markdown_response_e2e.sh" \
     --port 18291; then
     echo "  WARNING: large markdown e2e coverage run failed; continuing" >&2
 fi
 
 echo "==> Running proxy TLS backend e2e coverage"
-if ! bash "${WORKSPACE_ROOT}/tools/e2e/verify_proxy_tls_backend_e2e.sh" \
-    --nginx-bin "${RUNTIME}/sbin/nginx" \
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
+    bash "${WORKSPACE_ROOT}/tools/e2e/verify_proxy_tls_backend_e2e.sh" \
     --port 18289 \
     --backend-port 19289; then
     echo "  WARNING: proxy TLS backend e2e coverage run failed; continuing" >&2
+fi
+
+echo "==> Running huge-body native e2e coverage (skip 1GB GET)"
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" RUN_1G_GET=0 \
+    bash "${WORKSPACE_ROOT}/tools/e2e/verify_huge_body_native_e2e.sh" \
+    --port 18292 \
+    --skip-1g-get; then
+    echo "  WARNING: huge-body native e2e coverage run failed; continuing" >&2
+fi
+
+echo "==> Running huge-body allowed native e2e coverage (skip 1GB GET)"
+if ! env NGINX_BIN="${REUSE_NGINX_BIN}" RUN_1G_GET=0 \
+    bash "${WORKSPACE_ROOT}/tools/e2e/verify_huge_body_allowed_native_e2e.sh" \
+    --port 18293 \
+    --skip-1g-get \
+    --markdown-max-size 1536m; then
+    echo "  WARNING: huge-body allowed native e2e coverage run failed; continuing" >&2
 fi
 
 # ── Collect gcov/lcov coverage ──────────────────────────────────────

--- a/tools/sonar/collect_nginx_coverage.sh
+++ b/tools/sonar/collect_nginx_coverage.sh
@@ -318,6 +318,9 @@ http {
             markdown_conditional_requests disabled;
         }
 
+        # ETag disabled with full_support conditional requests; exercises the
+        # branch where If-None-Match is present but ETag comparison cannot
+        # proceed because markdown_etag is off.
         location /no-etag {
             root html;
             markdown_filter on;
@@ -665,16 +668,20 @@ http {
         }
 
         # Deliberately mislabeled encodings for decompression negative-path coverage.
+        # Each serves plain HTML with a Content-Encoding header that does not
+        # match the actual body, triggering decompression error handling.
         location /fake-gzip/ {
             alias html/;
             add_header Content-Encoding "gzip" always;
         }
 
+        # Brotli encoding advertised but unsupported/mismatched payload.
         location /fake-br/ {
             alias html/;
             add_header Content-Encoding "br" always;
         }
 
+        # Deflate encoding advertised but body is not deflate-compressed.
         location /fake-deflate/ {
             alias html/;
             add_header Content-Encoding "deflate" always;
@@ -967,6 +974,9 @@ curl -sS -H "${ACCEPT_MARKDOWN}" \
   -o /dev/null -w "  streaming gzip reject: HTTP %{http_code}\n" || true
 
 # Proxy with invalid/mislabeled compressed payloads
+# These exercise the decompression error/fail-open paths: the backend
+# advertises Content-Encoding but serves plain HTML, so the decompressor
+# must detect the mismatch and fall back to pass-through or error.
 curl -sS -H "${ACCEPT_MARKDOWN}" \
   "http://127.0.0.1:${PORT}/proxy-fake-gzip/index.html" \
   -o /dev/null -w "  fake gzip payload: HTTP %{http_code}\n" || true
@@ -1160,6 +1170,9 @@ echo "==> Stopping NGINX (flush gcov data)"
 "${RUNTIME}/sbin/nginx" -p "${RUNTIME}" -c conf/nginx.conf -s stop
 sleep 2
 
+# Capture the NGINX binary path before e2e sub-scripts so each can
+# reuse the same streaming-enabled binary via NGINX_BIN env var,
+# avoiding redundant rebuilds inside each sub-script.
 REUSE_NGINX_BIN="${RUNTIME}/sbin/nginx"
 
 echo "==> Running extended streaming failure/cache e2e coverage"
@@ -1207,6 +1220,8 @@ if ! env NGINX_BIN="${REUSE_NGINX_BIN}" \
 fi
 
 echo "==> Running huge-body native e2e coverage (skip 1GB GET)"
+# RUN_1G_GET=0 and --skip-1g-get avoid the slow 1GB GET test in CI;
+# the remaining huge-body sub-tests still cover oversize and fail-open.
 if ! env NGINX_BIN="${REUSE_NGINX_BIN}" RUN_1G_GET=0 \
     bash "${WORKSPACE_ROOT}/tools/e2e/verify_huge_body_native_e2e.sh" \
     --port 18292 \
@@ -1215,6 +1230,8 @@ if ! env NGINX_BIN="${REUSE_NGINX_BIN}" RUN_1G_GET=0 \
 fi
 
 echo "==> Running huge-body allowed native e2e coverage (skip 1GB GET)"
+# --markdown-max-size 1536m allows bodies up to 1.5 GiB, exercising the
+# allowed-huge-body path where conversion proceeds instead of fail-open.
 if ! env NGINX_BIN="${REUSE_NGINX_BIN}" RUN_1G_GET=0 \
     bash "${WORKSPACE_ROOT}/tools/e2e/verify_huge_body_allowed_native_e2e.sh" \
     --port 18293 \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive new unit tests for config, directive handlers, conversion, streaming, decompression, and related helper/error branches.
* **Chores**
  * Expanded end-to-end cases for gzip/deflate and truncated streams; enabled streaming builds in test scripts; added reusable validation/assertion helpers.
* **Documentation**
  * Updated testing guidelines for C FFI stubs, ABI-free helpers, and e2e script robustness (tolerating intentional failures and HEAD/empty-body checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->