### PR TITLE
fix(ci): repair install-verify workflow

### DIFF
--- a/.github/workflows/install-verify.yml
+++ b/.github/workflows/install-verify.yml
@@ -250,7 +250,7 @@ jobs:
         if: matrix.target.pkg_manager == 'apk'
         run: |
           apk update
-          apk add --no-cache bash curl python3 tar coreutils
+          apk add --no-cache bash curl python3 tar coreutils git ca-certificates
 
       - name: Install prerequisites (apt — container)
         if: matrix.target.pkg_manager == 'apt' && matrix.target.container != ''
@@ -344,9 +344,21 @@ jobs:
           fi
 
       - name: Checkout repository
+        if: ${{ !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Checkout repository (Alpine arm64 fallback)
+        if: ${{ matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64' }}
+        env:
+          REPO_URL: https://github.com/${{ github.repository }}.git
+          CHECKOUT_REF: ${{ github.event.inputs.ref || github.ref }}
+        run: |
+          git init .
+          git remote add origin "${REPO_URL}"
+          git fetch --depth=1 origin "${CHECKOUT_REF}"
+          git checkout --force FETCH_HEAD
 
       - name: Prepare results directory
         run: |
@@ -389,6 +401,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version || '' }}
           IS_CONTAINER: ${{ matrix.target.container != '' && 'true' || 'false' }}
+        shell: bash
         run: |
           RESULTS_DIR="${{ runner.temp }}/install-verify"
           # The installer writes to root-owned paths (/usr/lib/nginx/modules,
@@ -664,6 +677,7 @@ jobs:
           EXPECTED_INSTALL_SUCCESS: ${{ matrix.target.expected_install_success && 'true' || 'false' }}
         run: |
           RESULTS_DIR="${{ runner.temp }}/install-verify"
+          mkdir -p "${RESULTS_DIR}"
           INSTALL_EXIT="${{ steps.install.outputs.install_exit }}"
           VALIDATE_OUTCOME="${{ steps.validate_outcome.conclusion }}"
           NGINX_TEST_EXIT="${{ steps.nginx_test.outputs.nginx_test_exit }}"
@@ -716,7 +730,7 @@ jobs:
           fi
 
       - name: Upload verification artifacts
-        if: always()
+        if: ${{ always() && !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ matrix.target.artifact_name }}

--- a/.github/workflows/install-verify.yml
+++ b/.github/workflows/install-verify.yml
@@ -239,6 +239,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      JS_ACTIONS_SUPPORTED: ${{ !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}
     strategy:
       fail-fast: false
       matrix:
@@ -344,13 +346,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        if: ${{ !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}
+        if: ${{ env.JS_ACTIONS_SUPPORTED == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Checkout repository (Alpine arm64 fallback)
-        if: ${{ matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64' }}
+        if: ${{ env.JS_ACTIONS_SUPPORTED != 'true' }}
         env:
           REPO_URL: https://github.com/${{ github.repository }}.git
           CHECKOUT_REF: ${{ github.event.inputs.ref || github.ref }}
@@ -730,7 +732,7 @@ jobs:
           fi
 
       - name: Upload verification artifacts
-        if: ${{ always() && !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}
+        if: ${{ always() && env.JS_ACTIONS_SUPPORTED == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ matrix.target.artifact_name }}

--- a/tools/release/matrix/tests/test_workflow_regressions.py
+++ b/tools/release/matrix/tests/test_workflow_regressions.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 def _workflow_text(name: str) -> str:
-    repo_root = Path(__file__).resolve().parents[3]
+    repo_root = Path(__file__).resolve().parents[4]
     path = repo_root / ".github" / "workflows" / name
     return path.read_text(encoding="utf-8")
 
@@ -22,3 +22,16 @@ def test_update_matrix_pr_creation_is_non_blocking_when_repo_disallows_actions_p
     text = _workflow_text("update-matrix.yml")
     assert "continue-on-error: true" in text
     assert "Matrix update branch pushed, but automatic PR creation is blocked." in text
+
+
+def test_install_verify_workflow_avoids_js_actions_on_alpine_arm64_and_uses_bash() -> None:
+    """Install verification must stay runnable on Alpine arm64 GitHub containers."""
+    text = _workflow_text("install-verify.yml")
+    assert "workflow_dispatch:" in text
+    assert "ref:" in text
+    assert "version:" in text
+    assert "Checkout repository (Alpine arm64 fallback)" in text
+    assert "git fetch --depth=1 origin" in text
+    assert "shell: bash" in text
+    assert "Upload verification artifacts" in text
+    assert "pkg_manager == 'apk' && matrix.target.arch == 'aarch64'" in text

--- a/tools/release/matrix/tests/test_workflow_regressions.py
+++ b/tools/release/matrix/tests/test_workflow_regressions.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
+
+def _workflow_data(name: str) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[4]
+    path = repo_root / ".github" / "workflows" / name
+    with path.open(encoding="utf-8") as f:
+        return yaml.load(f, Loader=yaml.BaseLoader)
+
 
 def _workflow_text(name: str) -> str:
     repo_root = Path(__file__).resolve().parents[4]
@@ -26,12 +35,21 @@ def test_update_matrix_pr_creation_is_non_blocking_when_repo_disallows_actions_p
 
 def test_install_verify_workflow_avoids_js_actions_on_alpine_arm64_and_uses_bash() -> None:
     """Install verification must stay runnable on Alpine arm64 GitHub containers."""
-    text = _workflow_text("install-verify.yml")
-    assert "workflow_dispatch:" in text
-    assert "ref:" in text
-    assert "version:" in text
-    assert "Checkout repository (Alpine arm64 fallback)" in text
-    assert "git fetch --depth=1 origin" in text
-    assert "shell: bash" in text
-    assert "Upload verification artifacts" in text
-    assert "pkg_manager == 'apk' && matrix.target.arch == 'aarch64'" in text
+    workflow = _workflow_data("install-verify.yml")
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["ref"]["default"] == ""
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["version"]["default"] == ""
+
+    job = workflow["jobs"]["install-verify"]
+    assert job["env"]["JS_ACTIONS_SUPPORTED"] == (
+        "${{ !(matrix.target.pkg_manager == 'apk' && matrix.target.arch == 'aarch64') }}"
+    )
+
+    steps = {step["name"]: step for step in job["steps"]}
+    assert steps["Checkout repository"]["if"] == "${{ env.JS_ACTIONS_SUPPORTED == 'true' }}"
+    assert steps["Checkout repository (Alpine arm64 fallback)"]["if"] == (
+        "${{ env.JS_ACTIONS_SUPPORTED != 'true' }}"
+    )
+    assert steps["Run install script"]["shell"] == "bash"
+    assert steps["Upload verification artifacts"]["if"] == (
+        "${{ always() && env.JS_ACTIONS_SUPPORTED == 'true' }}"
+    )


### PR DESCRIPTION
This PR fixes the `install-verify` workflow failure seen in Actions run 24621937638.

Root cause
- The workflow ran the install step under `sh`, but the script used Bash-specific `PIPESTATUS[0]`, which caused `Bad substitution` on the Debian aarch64 job.
- Alpine arm64 jobs were using job-level container + GitHub JS actions, which is not supported by GitHub Actions, so checkout/artifact steps failed before the actual verification could finish.

What changed
- Forced the install step to run under Bash.
- Added an Alpine arm64 checkout fallback that uses plain `git` instead of `actions/checkout`.
- Guarded artifact upload on Alpine arm64 to avoid unsupported JS action execution.
- Ensured the summary step creates the results directory before writing.
- Added regression coverage for the workflow behavior and fixed the workflow regression test helper path.

Validation
- `python3 -m pytest tools/release/matrix/tests/test_workflow_regressions.py`
- YAML load check for `.github/workflows/install-verify.yml`
- CodeRabbit review: 0 findings

Manual trigger
- `workflow_dispatch` remains available with `ref` and `version` inputs.

## Summary by Sourcery

Fix the install-verify GitHub Actions workflow to run reliably on Alpine arm64 and ensure regression coverage for its behavior.

Bug Fixes:
- Ensure the install step in the install-verify workflow runs under Bash to avoid shell incompatibilities.
- Provide a git-based checkout fallback for Alpine arm64 jobs to avoid unsupported JavaScript actions.
- Guard artifact upload on Alpine arm64 to prevent use of unsupported upload-artifact JS actions.
- Ensure the workflow summary step creates the results directory before writing files.
- Correct the workflow regression test helper path so it can locate workflow YAML files.

CI:
- Extend the install-verify workflow prerequisites to install git and CA certificates for apk-based environments.

Tests:
- Add a regression test asserting that the install-verify workflow remains runnable on Alpine arm64 containers and uses Bash and non-JS actions appropriately.