### PR TITLE
Add and update end-to-end tests and build configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,6 @@ Desktop.ini
 # Vim swap
 *.swp
 *.swo
+
 KIRO.md
+.codex-venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,9 +446,10 @@ SonarCloud rules: `shelldre:S131`, `shelldre:S7677`, `shelldre:S1066`, `shelldre
 
 Required:
 - Every `case` statement must include a default `*)` clause, even if it only logs an error to stderr.
-- Shell functions that may intentionally emit no output must still end with an
-  explicit `return 0` when success is intended, so static analysis and callers
-  do not inherit an accidental status from the last command.
+- Every shell function must end with an explicit `return` statement
+  (`return 0` on success, or the appropriate status on failure), so static
+  analysis and callers do not inherit an accidental exit status from the last
+  command. This applies to all functions, not only those that emit no output.
 - Diagnostic and informational messages (INFO, WARN, DEBUG) must be redirected to stderr (`>&2`) so they do not pollute stdout when scripts are piped or their output is captured.
 - Merge nested `if` statements that have no `else` branch into a single compound condition (`if [[ cond1 ]] && cmd; then`).
 - Extract string literals used 4+ times into `readonly` constants defined near the top of the script. Grep patterns, expected header values, and expected body tokens are common candidates.
@@ -874,8 +875,9 @@ For each code change you are about to produce, mentally (or explicitly in a thin
 7. Required checks must fail the case/run when missing (not INFO-only). (Rule 18)
 8. `--plan`/dry-run modes short-circuit before runtime prerequisites. (Rule 18)
 9. `usage()` text matches parsed flags/defaults exactly. (Rule 18)
-10. Shell functions end with an explicit success `return 0` when they may emit
-    no output intentionally. (Rule 18)
+10. Every shell function ends with an explicit `return` statement (`return 0`
+    on success, or the appropriate status on failure). This applies to all
+    functions, not only those that emit no output. (Rule 18)
 11. Every function has a comment block stating purpose, arguments, output, and exit behaviour. Repeated string constants use `readonly` variables with descriptive names. (Rule 26)
 
 #### Python test/tooling scripts (`tests/e2e/`, `tools/`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Nothing yet.
 
+## [0.5.6] - 2026-04-28
+
+This release adds end-to-end validation coverage for metrics, conditional
+requests, config merge, auth/cache, and status-code passthrough paths, and
+hardens the shared E2E helper library with portability and assertion fixes.
+
+### Added
+- New E2E validation scripts: `verify_metrics_endpoint_e2e.sh`,
+  `verify_conditional_requests_e2e.sh`, `verify_config_merge_e2e.sh`,
+  `verify_auth_cache_e2e.sh`, `verify_status_codes_e2e.sh`.
+- Shared helper functions in `nginx_markdown_native_build.sh`:
+  `markdown_wait_for_http` (HTTP readiness polling),
+  `markdown_require_flag_value` (CLI flag validation),
+  `markdown_expect_status` (HTTP status assertion),
+  `markdown_expect_header` (header pattern assertion),
+  `markdown_extract_header` (header value extraction).
+- Makefile targets for all new E2E scripts.
+
+### Changed
+- `markdown_require_flag_value` now returns 2 instead of calling
+  `usage` and exiting, allowing callers to handle the error under
+  `set -e` without coupling to a `usage` function.
+- `markdown_extract_header` now uses POSIX awk instead of GNU sed
+  `/I` for macOS portability.
+- `PATTERN_CT_PROMETHEUS` now escapes dots (`0\.0\.4`) for
+  correct grep matching.
+- Deduplicated local `wait_for_http` and `assert_http_200_header`
+  definitions across E2E scripts in favor of shared helpers.
+- Hardened auth/cache E2E assertions: Case 5 compares exact
+  upstream Cache-Control, Case 6 fails on empty ETag, Case 7
+  requires `Vary:.*Cookie` (not just `Vary:`).
+- Synced `verify_config_merge_e2e.sh` top docstring to actual
+  checks; fixed `verify_proxy_tls_backend_e2e.sh` source ordering.
+
+### Fixed
+- SonarCloud finding: missing `return 0` in
+  `check_status_passthrough` (`verify_status_codes_e2e.sh`).
+- SonarCloud finding: repeated `'Cookie: session=abc123'` literal
+  extracted to `readonly HEADER_COOKIE_AUTH`.
+- CodeRabbit findings: SC2015 anti-patterns, readiness URL
+  mismatches, inline Python string interpolation, missing
+  `.PHONY` targets, `wait_for_http` docstring drift.
+- Orphaned doc blocks and stale local helper definitions removed
+  from `verify_accept_negotiation_e2e.sh`,
+  `verify_chunked_streaming_native_e2e.sh`,
+  `verify_error_handling_e2e.sh`.
+
 ## [0.5.5] - 2026-04-26
 
 This release consolidates all post-0.5.0 work into one stabilization release,

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ NGINX_HEADER := $(NGINX_MODULE_DIR)/src/markdown_converter.h
         verify-chunked-native-e2e verify-chunked-native-e2e-smoke verify-chunked-native-e2e-stress \
         verify-streaming-failure-cache-e2e \
         verify-streaming-failure-cache-e2e-plan \
+        verify-metrics-endpoint-e2e verify-conditional-requests-e2e verify-config-merge-e2e \
+        verify-auth-cache-e2e verify-status-codes-e2e \
         test-rust-streaming \
         coverage-c coverage-rust coverage-sonar-xml coverage-all \
         clean help

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,21 @@ verify-streaming-failure-cache-e2e:
 verify-streaming-failure-cache-e2e-plan:
 	./tools/e2e/verify_streaming_failure_cache_e2e.sh --plan
 
+verify-metrics-endpoint-e2e:
+	./tools/e2e/verify_metrics_endpoint_e2e.sh
+
+verify-conditional-requests-e2e:
+	./tools/e2e/verify_conditional_requests_e2e.sh
+
+verify-config-merge-e2e:
+	./tools/e2e/verify_config_merge_e2e.sh
+
+verify-auth-cache-e2e:
+	./tools/e2e/verify_auth_cache_e2e.sh
+
+verify-status-codes-e2e:
+	./tools/e2e/verify_status_codes_e2e.sh
+
 # ── Coverage targets ────────────────────────────────────────────────
 # Generate lcov reports consumed by SonarCloud.  Output lands in
 # coverage/ at the repo root so sonar.coverageReportPaths can find it.
@@ -291,6 +306,11 @@ help:
 	@echo "  test-e2e                 - Run end-to-end tests"
 	@echo "  verify-streaming-failure-cache-e2e - Run streaming failure/cache e2e tests"
 	@echo "  verify-streaming-failure-cache-e2e-plan - Print test plan only (no NGINX_BIN required)"
+	@echo "  verify-metrics-endpoint-e2e  - Run metrics endpoint e2e tests (JSON/text/Prometheus)"
+	@echo "  verify-conditional-requests-e2e - Run conditional-request e2e tests (ETag/304)"
+	@echo "  verify-config-merge-e2e     - Run config-merge e2e tests (http/server/location)"
+	@echo "  verify-auth-cache-e2e       - Run auth/cache interaction e2e tests"
+	@echo "  verify-status-codes-e2e     - Run upstream status-code passthrough e2e tests"
 	@echo "  test-all                 - Run build + rust + unit tests"
 	@echo "  sonar-compile-db         - Generate compile_commands.json for SonarQube for VS Code C/C++ analysis"
 	@echo "  test-benchmark           - Run corpus benchmark and produce Unified Report"

--- a/components/rust-converter/Cargo.lock
+++ b/components/rust-converter/Cargo.lock
@@ -564,7 +564,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "blake3",
  "brotli",

--- a/components/rust-converter/Cargo.toml
+++ b/components/rust-converter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nginx-markdown-converter"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 rust-version = "1.91"
 authors = ["NGINX Markdown for Agents Contributors"]

--- a/docs/architecture/REPOSITORY_STRUCTURE.md
+++ b/docs/architecture/REPOSITORY_STRUCTURE.md
@@ -168,8 +168,8 @@ Scripts are grouped by domain rather than scattered at repo root.
 |------|---------|
 | `tools/docs/` | Documentation validation and duplicate-doc checks |
 | `tools/ci/` | CI-specific helpers such as license and environment checks |
-| `tools/e2e/` | Canonical native E2E verification scripts, including the proxy/TLS backend suite and shared runtime orchestration |
-| `tools/lib/` | Shared shell helpers for native build/test orchestration |
+| `tools/e2e/` | Canonical native E2E verification scripts covering proxy/TLS, streaming, metrics, conditional requests, config merge, auth/cache, status codes, Accept negotiation, error handling, and security paths |
+| `tools/lib/` | Shared shell helpers for native build/test orchestration (`markdown_wait_for_http`, `markdown_require_flag_value`, `markdown_expect_status`, `markdown_expect_header`, `markdown_extract_header`) |
 | `tools/corpus/` | Corpus validation and conversion tooling |
 | `tools/build_release/` | Release packaging support and packaging Dockerfiles |
 | `tools/c-extract/` | Small developer utility for extracting C functions |

--- a/docs/testing/E2E_TESTS.md
+++ b/docs/testing/E2E_TESTS.md
@@ -24,13 +24,24 @@ Use this page to answer three questions:
 tools/e2e/run_e2e_suite.sh
 ```
 
-That suite currently runs three focused checks:
+That suite currently runs focused checks across all E2E scenarios:
 
 | Script | Purpose |
 |--------|---------|
 | `tools/e2e/verify_proxy_tls_backend_e2e.sh` | Real proxy-chain validation against a local TLS backend |
 | `tools/e2e/verify_chunked_streaming_native_e2e.sh --profile smoke` | Chunked buffering and oversized fail-open smoke coverage |
 | `tools/e2e/verify_large_markdown_response_e2e.sh` | Large-response buffering and conversion validation |
+| `tools/e2e/verify_metrics_endpoint_e2e.sh` | Metrics endpoint format negotiation (JSON, text, Prometheus) |
+| `tools/e2e/verify_conditional_requests_e2e.sh` | ETag, If-None-Match, If-Modified-Since, 304, HEAD parity |
+| `tools/e2e/verify_config_merge_e2e.sh` | Directive merge precedence and override behavior |
+| `tools/e2e/verify_auth_cache_e2e.sh` | Auth cookie detection, Cache-Control, ETag replacement, Vary |
+| `tools/e2e/verify_status_codes_e2e.sh` | Non-2xx passthrough and redirect handling |
+| `tools/e2e/verify_accept_negotiation_e2e.sh` | Accept header content negotiation and wildcard behavior |
+| `tools/e2e/verify_error_handling_e2e.sh` | Error passthrough, fail-open, 206 skip, max-size boundary |
+| `tools/e2e/verify_security_e2e.sh` | Security header and sanitizer behavior |
+| `tools/e2e/verify_huge_body_allowed_native_e2e.sh` | Huge body within max-size converts successfully |
+| `tools/e2e/verify_huge_body_native_e2e.sh` | Huge body exceeding max-size fail-opens |
+| `tools/e2e/verify_streaming_failure_cache_e2e.sh` | Streaming failure cache and retry behavior |
 
 The suite keeps the public command stable:
 
@@ -50,6 +61,13 @@ The canonical E2E suite is intentionally focused on runtime paths that benefit f
 - `HEAD` requests through a proxy path
 - chunked buffering behavior
 - large-response handling and fail-open size protection
+- metrics endpoint format negotiation (JSON, plain-text, Prometheus exposition)
+- conditional request semantics (ETag, If-None-Match, If-Modified-Since, 304, HEAD parity)
+- directive merge precedence and override behavior
+- auth cookie detection, Cache-Control/ETag/Vary header handling
+- non-2xx status code passthrough and redirect handling
+- Accept header content negotiation and wildcard behavior
+- error passthrough, fail-open, 206 skip, max-size boundary
 
 ### Coverage E2E Scenarios
 
@@ -175,6 +193,11 @@ That helper owns:
 - header sync for native verification builds
 - macOS deployment-target alignment
 - reusable runtime layout checks
+- HTTP readiness polling (`markdown_wait_for_http`)
+- CLI flag validation (`markdown_require_flag_value`)
+- HTTP status assertion (`markdown_expect_status`)
+- header pattern assertion (`markdown_expect_header`)
+- header value extraction (`markdown_extract_header`)
 
 ## Notes
 
@@ -187,4 +210,5 @@ That helper owns:
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 0.5.6 | 2026-04-28 | release-prep | Added new E2E scripts (metrics, conditional requests, config merge, auth/cache, status codes); listed shared helpers |
 | 0.5.0 | 2026-04-21 | docs-standardization | Standardized formatting, added mermaid diagrams where applicable, verified directive accuracy against code, added update tracking section |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -87,7 +87,7 @@ make test-rust-fuzz-smoke
 - Performance references are guidance for regression detection, not hard SLAs.
 - The CI workflow records non-blocking performance artifacts for `perf_baseline`, including a front-matter-enabled medium sample, and runs a runtime-regression job that self-builds a module-enabled NGINX runtime for delegated `If-Modified-Since`, then reuses that retained binary for the chunked native smoke and large-response checks.
 - Nightly fuzzing runs parser, FFI, and security-validator targets from `components/rust-converter/fuzz/`.
-- The native NGINX verification scripts share `tools/lib/nginx_markdown_native_build.sh`, which centralizes Rust target detection, header sync, and macOS deployment-target alignment for Rust and NGINX builds.
+- The native NGINX verification scripts share `tools/lib/nginx_markdown_native_build.sh`, which centralizes Rust target detection, header sync, macOS deployment-target alignment, HTTP readiness polling, CLI flag validation, and HTTP status/header assertion helpers for E2E scripts.
 - A separate non-blocking Darwin/macOS smoke workflow exercises native Rust build, real-nginx IMS validation, and chunked native smoke on GitHub-hosted macOS runners.
 
 As a working rule:
@@ -101,4 +101,5 @@ As a working rule:
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 0.5.6 | 2026-04-28 | release-prep | Updated shared helper description to include new E2E helpers |
 | 0.5.0 | 2026-04-21 | docs-standardization | Added update tracking section |

--- a/tools/e2e/run_e2e_suite.sh
+++ b/tools/e2e/run_e2e_suite.sh
@@ -10,6 +10,11 @@ STREAMING_FAILURE_CACHE_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_streaming_fai
 ACCEPT_NEGOTIATION_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_accept_negotiation_e2e.sh"
 SECURITY_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_security_e2e.sh"
 ERROR_HANDLING_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_error_handling_e2e.sh"
+METRICS_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_metrics_endpoint_e2e.sh"
+CONDITIONAL_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_conditional_requests_e2e.sh"
+CONFIG_MERGE_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_config_merge_e2e.sh"
+AUTH_CACHE_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_auth_cache_e2e.sh"
+STATUS_CODES_SCRIPT="${WORKSPACE_ROOT}/tools/e2e/verify_status_codes_e2e.sh"
 SUITE_BUILDROOT=""
 SUITE_NGINX_BIN=""
 NGINX_BIN_OUTPUT_FILE=""
@@ -20,13 +25,18 @@ usage() {
 Usage: $(basename "$0") [--keep-artifacts]
 
 Run the canonical E2E suite:
-  1. proxy/TLS backend verification
-  2. chunked native smoke verification
-  3. large-response native verification
-  4. streaming failure/cache semantics verification
-  5. Accept-header content-negotiation verification
-  6. security behavior verification
-  7. error-handling and fail-open verification
+   1. proxy/TLS backend verification
+   2. chunked native smoke verification
+   3. large-response native verification
+   4. streaming failure/cache semantics verification
+   5. Accept-header content-negotiation verification
+   6. security behavior verification
+   7. error-handling and fail-open verification
+   8. metrics endpoint verification
+   9. conditional-request (ETag/If-None-Match/If-Modified-Since) verification
+  10. config-merge (http/server/location) verification
+  11. auth/cache interaction verification
+  12. upstream status-code passthrough verification
 
 Environment variables:
   NGINX_BIN       Optional reusable module-enabled nginx binary
@@ -109,14 +119,29 @@ env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${STREAMING_FAILURE_CACHE_SCRIPT}" "${s
 accept_args=()
 security_args=()
 error_args=()
+metrics_args=()
+conditional_args=()
+config_merge_args=()
+auth_cache_args=()
+status_codes_args=()
 if [[ "${KEEP_ARTIFACTS}" -eq 1 ]]; then
   accept_args=(--keep-artifacts)
   security_args=(--keep-artifacts)
   error_args=(--keep-artifacts)
+  metrics_args=(--keep-artifacts)
+  conditional_args=(--keep-artifacts)
+  config_merge_args=(--keep-artifacts)
+  auth_cache_args=(--keep-artifacts)
+  status_codes_args=(--keep-artifacts)
 fi
 env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${ACCEPT_NEGOTIATION_SCRIPT}" "${accept_args[@]}"
 env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${SECURITY_SCRIPT}" "${security_args[@]}"
 env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${ERROR_HANDLING_SCRIPT}" "${error_args[@]}"
+env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${METRICS_SCRIPT}" "${metrics_args[@]}"
+env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${CONDITIONAL_SCRIPT}" "${conditional_args[@]}"
+env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${CONFIG_MERGE_SCRIPT}" "${config_merge_args[@]}"
+env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${AUTH_CACHE_SCRIPT}" "${auth_cache_args[@]}"
+env NGINX_BIN="${SUITE_NGINX_BIN}" bash "${STATUS_CODES_SCRIPT}" "${status_codes_args[@]}"
 
 echo "Canonical E2E suite summary:"
 echo "  proxy_tls_backend=passed"
@@ -126,4 +151,9 @@ echo "  streaming_failure_cache=passed"
 echo "  accept_negotiation=passed"
 echo "  security=passed"
 echo "  error_handling=passed"
+echo "  metrics_endpoint=passed"
+echo "  conditional_requests=passed"
+echo "  config_merge=passed"
+echo "  auth_cache=passed"
+echo "  status_codes=passed"
 echo "  reusable_nginx_bin=${SUITE_NGINX_BIN}"

--- a/tools/e2e/verify_accept_negotiation_e2e.sh
+++ b/tools/e2e/verify_accept_negotiation_e2e.sh
@@ -56,15 +56,6 @@ EOF
 # Output: prints usage to stderr on failure
 # Exit: exits with code 2 if value is missing
 #
-require_flag_value() {
-  local flag_name="$1"
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-  return 0
-}
 
 #
 # Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
@@ -131,17 +122,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
@@ -196,7 +187,6 @@ JSON_BODY = b'{"status":"ok","message":"not html"}'
 
 PLAIN_BODY = b'This is plain text, not HTML.'
 
-
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -244,7 +234,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -254,7 +243,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()

--- a/tools/e2e/verify_accept_negotiation_e2e.sh
+++ b/tools/e2e/verify_accept_negotiation_e2e.sh
@@ -49,15 +49,6 @@ EOF
 }
 
 #
-# Validate a flag requiring a value has one.
-# Arguments:
-#   $1: flag name (for diagnostics)
-#   $2: flag value (must be non-empty)
-# Output: prints usage to stderr on failure
-# Exit: exits with code 2 if value is missing
-#
-
-#
 # Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
 #
 cleanup() {
@@ -78,42 +69,6 @@ cleanup() {
   return 0
 }
 trap cleanup EXIT
-
-#
-# Poll an HTTP endpoint until it becomes reachable.
-# Arguments:
-#   $1: URL to poll for readiness.
-#   $2: label for failure diagnostics.
-# Output: writes timeout diagnostics and curl output to stderr on failure.
-# Exit: returns 0 when the endpoint responds; returns 1 after timeout.
-#
-wait_for_http() {
-  local url="$1"
-  local label="$2"
-  local curl_output=""
-  for _ in $(seq 1 50); do
-    if curl -sS --max-time 1 "$url" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 0.1
-  done
-  curl_output=$(curl -sS --max-time 2 "$url" 2>&1 || true)
-  echo "${label} failed to become ready after 5s" >&2
-  if [[ -n "${curl_output}" ]]; then
-    echo "curl output: ${curl_output}" >&2
-  fi
-  return 1
-}
-
-assert_http_200_header() {
-  local header_file="$1"
-  local case_name="$2"
-  grep -qi "${PATTERN_HTTP_200}" "${header_file}" || {
-    echo "FAIL: ${case_name} - expected HTTP 200 response" >&2
-    exit 1
-  }
-  return 0
-}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -284,8 +239,8 @@ mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 echo "==> Starting accept-negotiation upstream on 127.0.0.1:${UPSTREAM_PORT}"
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
-wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" \
-  "Upstream on ${UPSTREAM_PORT}"
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" \
+  "Upstream on ${UPSTREAM_PORT}" || exit 1
 
 # --- NGINX config with wildcard on ---
 cat > "${RUNTIME}/conf/nginx.conf" <<EOF
@@ -334,15 +289,15 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-wait_for_http "http://127.0.0.1:${PORT}/md/html" \
-  "NGINX on ${PORT}"
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" \
+  "NGINX on ${PORT}" || exit 1
 
 # --- Case 1: Accept: text/markdown triggers conversion ---
 echo "==> Case 1: Accept: text/markdown triggers conversion"
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-assert_http_200_header "${RAW_DIR}/case1.hdr" "Case 1"
+markdown_expect_status "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1.hdr" || {
   echo "FAIL: Case 1 - expected text/markdown Content-Type" >&2
   exit 1
@@ -358,7 +313,7 @@ echo "==> Case 2: Accept: text/html returns original HTML"
 curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
   -H "${ACCEPT_HTML}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-assert_http_200_header "${RAW_DIR}/case2.hdr" "Case 2"
+markdown_expect_status "Case 2" "${RAW_DIR}/case2.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case2.hdr" || {
   echo "FAIL: Case 2 - expected text/html Content-Type" >&2
   exit 1
@@ -375,7 +330,7 @@ curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H 'Accept:' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-assert_http_200_header "${RAW_DIR}/case3.hdr" "Case 3"
+markdown_expect_status "Case 3" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case3.hdr" || {
   echo "FAIL: Case 3 - expected text/html Content-Type (no conversion without Accept)" >&2
   exit 1
@@ -387,7 +342,7 @@ echo "==> Case 4: Accept: */* with markdown_on_wildcard on triggers conversion"
 curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
   -H "${ACCEPT_WILDCARD}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-assert_http_200_header "${RAW_DIR}/case4.hdr" "Case 4"
+markdown_expect_status "Case 4" "${RAW_DIR}/case4.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case4.hdr" || {
   echo "FAIL: Case 4 - expected text/markdown with wildcard Accept and on_wildcard on" >&2
   exit 1
@@ -399,7 +354,7 @@ echo "==> Case 5: Accept: */* with markdown_on_wildcard off does NOT convert"
 curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H "${ACCEPT_WILDCARD}" --max-time 30 \
   "http://127.0.0.1:${PORT}/no-wildcard/html" >/dev/null
-assert_http_200_header "${RAW_DIR}/case5.hdr" "Case 5"
+markdown_expect_status "Case 5" "${RAW_DIR}/case5.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case5.hdr" || {
   echo "FAIL: Case 5 - expected text/html with wildcard Accept and on_wildcard off" >&2
   exit 1
@@ -419,7 +374,7 @@ echo "==> Case 7: Non-HTML Content-Type (application/json) is not converted"
 curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/json" >/dev/null
-assert_http_200_header "${RAW_DIR}/case7.hdr" "Case 7"
+markdown_expect_status "Case 7" "${RAW_DIR}/case7.hdr" "${PATTERN_HTTP_200}"
 grep -qi "application/json" "${RAW_DIR}/case7.hdr" || {
   echo "FAIL: Case 7 - expected application/json Content-Type to be preserved" >&2
   exit 1
@@ -431,7 +386,7 @@ echo "==> Case 8: text/plain Content-Type is not converted"
 curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/plain" >/dev/null
-assert_http_200_header "${RAW_DIR}/case8.hdr" "Case 8"
+markdown_expect_status "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_HTTP_200}"
 grep -qi "text/plain" "${RAW_DIR}/case8.hdr" || {
   echo "FAIL: Case 8 - expected text/plain Content-Type to be preserved" >&2
   exit 1

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -359,31 +359,42 @@ echo "  PASS: Non-matching cookie does not trigger auth logic"
 # --- Case 5: Auth fail-open preserves Cache-Control ---
 echo "==> Case 5: Auth fail-open preserves upstream Cache-Control"
 # With on_error pass and auth request, if conversion fails, upstream headers preserved
+# Capture upstream Cache-Control value for comparison
+curl -sS -D "${RAW_DIR}/case5up.hdr" -o /dev/null \
+  --max-time 30 \
+  "http://127.0.0.1:${UPSTREAM_PORT}/html" >/dev/null
+UPSTREAM_CC="$(markdown_extract_header "${RAW_DIR}/case5up.hdr" "Cache-Control")"
 curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-if ! grep -qi "^Cache-Control:" "${RAW_DIR}/case5.hdr"; then
+AUTH_CC="$(markdown_extract_header "${RAW_DIR}/case5.hdr" "Cache-Control")"
+if [[ -z "${AUTH_CC}" ]]; then
   echo "FAIL: Case 5 - expected Cache-Control header in auth request response" >&2
   exit 1
 fi
-echo "  PASS: Auth request response has Cache-Control header"
+if [[ "${AUTH_CC}" != "${UPSTREAM_CC}" ]]; then
+  echo "FAIL: Case 5 - auth Cache-Control (${AUTH_CC}) differs from upstream (${UPSTREAM_CC})" >&2
+  exit 1
+fi
+echo "  PASS: Auth response preserves upstream Cache-Control (${AUTH_CC})"
 
 # --- Case 6: Non-auth ETag replacement ---
 echo "==> Case 6: Non-auth conversion replaces upstream ETag with markdown ETag"
 curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-MD_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case6.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
-if [[ -n "${MD_ETAG}" && "${MD_ETAG}" != '"upstream-auth-etag-001"' ]]; then
-  echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-auth-etag-001, got=${MD_ETAG})"
-elif [[ -z "${MD_ETAG}" ]]; then
-  echo "  PASS (soft): No ETag in response (etag may be off by default)"
-else
+MD_ETAG="$(markdown_extract_header "${RAW_DIR}/case6.hdr" "ETag")"
+if [[ -z "${MD_ETAG}" ]]; then
+  echo "FAIL: Case 6 - expected ETag header in non-auth conversion response" >&2
+  exit 1
+fi
+if [[ "${MD_ETAG}" == '"upstream-auth-etag-001"' ]]; then
   echo "FAIL: Case 6 - ETag should differ from upstream for markdown content" >&2
   exit 1
 fi
+echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-auth-etag-001, got=${MD_ETAG})"
 
 # --- Case 7: Vary: Cookie in auth response ---
 echo "==> Case 7: Vary header in auth response"
@@ -393,11 +404,11 @@ curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-if ! grep -qi '^Vary:' "${RAW_DIR}/case7.hdr"; then
-  echo "FAIL: Case 7 - expected Vary header in auth response" >&2
+if ! grep -qi '^Vary:.*Cookie' "${RAW_DIR}/case7.hdr"; then
+  echo "FAIL: Case 7 - expected Vary header containing Cookie in auth response" >&2
   exit 1
 fi
-echo "  PASS: Auth response has Vary header"
+echo "  PASS: Vary header contains Cookie in auth response"
 
 echo ""
 echo "========================================="

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -31,7 +31,7 @@ readonly ACCEPT_MARKDOWN='Accept: text/markdown'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
 readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown'
 readonly PATTERN_CT_HTML='^Content-Type: text/html'
-readonly HEADER_COOKIE_AUTH='Cookie: session=abc123'
+readonly HEADER_COOKIE_AUTH='Cookie: session_user=abc123'
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
@@ -367,6 +367,7 @@ echo "==> Case 5: Auth fail-open preserves upstream Cache-Control"
 # With on_error pass and auth request, if conversion fails, upstream headers preserved
 # Capture upstream Cache-Control value for comparison
 curl -sS -D "${RAW_DIR}/case5up.hdr" -o /dev/null \
+  -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${UPSTREAM_PORT}/html" >/dev/null
 UPSTREAM_CC="$(markdown_extract_header "${RAW_DIR}/case5up.hdr" "Cache-Control")"

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E validation for auth/cache interaction with markdown conversion.
+#
+# Validates critical auth/cache paths:
+#  1) Auth request with Cookie: session=abc gets Cache-Control: private
+#  2) Non-auth request retains upstream Cache-Control: public
+#  3) markdown_auth_policy deny rejects conversion for auth requests
+#  4) markdown_auth_cookies pattern matching (session_* regex)
+#  5) Auth request fail-open preserves Cache-Control from upstream
+#  6) Non-auth conversion removes upstream ETag, generates markdown ETag
+#  7) Auth request with Vary: Cookie in response
+
+NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
+PORT="${PORT:-18103}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-19103}"
+KEEP_ARTIFACTS=0
+NGINX_BIN="${NGINX_BIN:-}"
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NATIVE_BUILD_HELPER="${WORKSPACE_ROOT}/tools/lib/nginx_markdown_native_build.sh"
+BUILDROOT=""
+RUNTIME=""
+RUST_TARGET=""
+NGINX_EXECUTABLE=""
+LOAD_MODULE_LINE=""
+UPSTREAM_PID=""
+ORIG_ARGS=("$@")
+
+readonly ACCEPT_MARKDOWN='Accept: text/markdown'
+readonly PATTERN_HTTP_200='HTTP/1.1 200'
+readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown'
+readonly PATTERN_CT_HTML='^Content-Type: text/html'
+
+# shellcheck source=tools/lib/nginx_markdown_native_build.sh
+source "${NATIVE_BUILD_HELPER}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+
+Build local NGINX with the markdown module and run auth/cache E2E checks.
+
+Checks:
+  1) Auth request Cache-Control: private
+  2) Non-auth request retains Cache-Control: public
+  3) auth_policy deny rejects conversion
+  4) auth_cookies pattern matching
+  5) Auth fail-open preserves Cache-Control
+  6) Non-auth ETag replacement
+  7) Vary: Cookie in auth response
+
+Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
+EOF
+  return 0
+}
+
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${RUNTIME}" && -n "${NGINX_EXECUTABLE}" && -x "${NGINX_EXECUTABLE}" ]]; then
+    "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf -s stop >/dev/null 2>&1 || true
+  fi
+
+  if [[ $rc -eq 0 && "${KEEP_ARTIFACTS}" -eq 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    rm -rf "${BUILDROOT}" || true
+  fi
+
+  if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    echo "Auth/cache E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
+  elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
+    echo "Auth/cache E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --nginx-version)
+      require_flag_value "$1" "${2:-}"
+      NGINX_VERSION="$2"
+      shift 2
+      ;;
+    --port)
+      require_flag_value "$1" "${2:-}"
+      PORT="$2"
+      shift 2
+      ;;
+    --upstream-port)
+      require_flag_value "$1" "${2:-}"
+      UPSTREAM_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#ORIG_ARGS[@]} )); then
+  markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"
+else
+  markdown_ensure_native_apple_silicon "$0"
+fi
+
+for cmd in curl python3 grep; do
+  markdown_need_cmd "$cmd"
+done
+if [[ -z "${NGINX_BIN}" ]]; then
+  for cmd in tar make cargo; do
+    markdown_need_cmd "$cmd"
+  done
+fi
+
+RUST_TARGET="$(markdown_detect_rust_target)"
+BUILDROOT="$(mktemp -d /tmp/nginx-auth-cache-e2e.XXXXXX)"
+RUNTIME="${BUILDROOT}/runtime"
+RAW_DIR="${BUILDROOT}/raw"
+UPSTREAM_SCRIPT="${BUILDROOT}/auth_cache_upstream.py"
+mkdir -p "${RAW_DIR}"
+
+# --- Upstream server that responds to auth and non-auth requests ---
+cat > "${UPSTREAM_SCRIPT}" <<'PY'
+#!/usr/bin/env python3
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+HTML_BODY = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>Auth Cache Test</title></head>
+<body><h1>Auth Cache Test</h1><p>Content for auth/cache validation.</p></body></html>
+"""
+
+UPSTREAM_ETAG = '"upstream-auth-etag-001"'
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args):
+        return
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            body = b"ok\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/html":
+            has_cookie = "Cookie" in self.headers
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_BODY)))
+            self.send_header("ETag", UPSTREAM_ETAG)
+            if has_cookie:
+                self.send_header("Cache-Control", "private, max-age=0")
+                self.send_header("Vary", "Cookie")
+            else:
+                self.send_header("Cache-Control", "public, max-age=3600")
+            self.end_headers()
+            self.wfile.write(HTML_BODY)
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19103)
+    args = parser.parse_args()
+    if args.serve:
+        server = ThreadingHTTPServer((args.host, args.port), Handler)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+chmod +x "${UPSTREAM_SCRIPT}"
+
+# --- Build or reuse NGINX ---
+echo "==> Host architecture: $(uname -m)"
+if [[ -n "${NGINX_BIN}" ]]; then
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
+  NGINX_EXECUTABLE="${NGINX_BIN}"
+else
+  echo "==> Building Rust converter (${RUST_TARGET})"
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
+
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
+  mkdir -p "${BUILDROOT}/src"
+  tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
+  (
+    cd "${BUILDROOT}/src"
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+    make install >/dev/null
+  )
+  NGINX_EXECUTABLE="${RUNTIME}/sbin/nginx"
+fi
+
+mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
+
+# --- Start upstream ---
+echo "==> Starting auth/cache upstream on 127.0.0.1:${UPSTREAM_PORT}"
+python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
+
+# --- NGINX config with auth policy ---
+cat > "${RUNTIME}/conf/nginx.conf" <<EOF
+${LOAD_MODULE_LINE}worker_processes 1;
+error_log logs/error.log info;
+pid logs/nginx.pid;
+
+events { worker_connections 512; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 5;
+
+    server {
+        listen 127.0.0.1:${PORT};
+        server_name localhost;
+
+        # Auth-aware conversion location
+        location /md/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            markdown_auth_policy allow;
+            markdown_auth_cookies "session_*";
+            markdown_etag on;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Auth deny location
+        location /md-deny/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            markdown_auth_policy deny;
+            markdown_auth_cookies "session_*";
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+    }
+}
+EOF
+
+echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+"${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" "NGINX on ${PORT}" || exit 1
+
+# --- Case 1: Auth request with Cookie gets Cache-Control: private ---
+echo "==> Case 1: Auth request with Cookie gets Cache-Control: private"
+curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'Cookie: session=abc123' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected HTTP 200" >&2
+  exit 1
+}
+grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr" || {
+  echo "INFO: Case 1 - Cache-Control: private not found; module may not rewrite CC for auth requests" >&2
+  echo "  PASS (soft): Auth request conversion completed"
+}
+grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr" && {
+  echo "  PASS: Cache-Control contains private for auth request"
+}
+
+# --- Case 2: Non-auth request retains Cache-Control: public ---
+echo "==> Case 2: Non-auth request retains upstream Cache-Control: public"
+curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case2.hdr" || {
+  echo "FAIL: Case 2 - expected HTTP 200" >&2
+  exit 1
+}
+grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr" || {
+  echo "INFO: Case 2 - Cache-Control: public not found in response" >&2
+  echo "  PASS (soft): Non-auth request conversion completed"
+}
+grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr" && {
+  echo "  PASS: Cache-Control contains public for non-auth request"
+}
+
+# --- Case 3: auth_policy deny rejects conversion for auth requests ---
+echo "==> Case 3: auth_policy deny rejects conversion for auth requests"
+curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'Cookie: session=abc123' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md-deny/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected HTTP 200 (passthrough)" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected text/html when auth_policy deny blocks conversion" >&2
+  exit 1
+}
+echo "  PASS: auth_policy deny returns HTML passthrough"
+
+# --- Case 4: auth_cookies pattern matching ---
+echo "==> Case 4: auth_cookies pattern matching"
+# A cookie that does NOT match session_* should not trigger auth logic
+curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'Cookie: preferences=dark' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
+  echo "FAIL: Case 4 - expected HTTP 200" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case4.hdr" || {
+  echo "FAIL: Case 4 - expected text/markdown for non-auth cookie" >&2
+  exit 1
+}
+echo "  PASS: Non-matching cookie does not trigger auth logic"
+
+# --- Case 5: Auth fail-open preserves Cache-Control ---
+echo "==> Case 5: Auth fail-open preserves upstream Cache-Control"
+# With on_error pass and auth request, if conversion fails, upstream headers preserved
+curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'Cookie: session=abc123' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "^Cache-Control:" "${RAW_DIR}/case5.hdr" || {
+  echo "INFO: Case 5 - No Cache-Control header in response" >&2
+}
+echo "  PASS: Auth request response has Cache-Control header"
+
+# --- Case 6: Non-auth ETag replacement ---
+echo "==> Case 6: Non-auth conversion replaces upstream ETag with markdown ETag"
+curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+MD_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case6.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
+if [[ -n "${MD_ETAG}" && "${MD_ETAG}" != '"upstream-auth-etag-001"' ]]; then
+  echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-auth-etag-001, got=${MD_ETAG})"
+elif [[ -z "${MD_ETAG}" ]]; then
+  echo "  PASS (soft): No ETag in response (etag may be off by default)"
+else
+  echo "FAIL: Case 6 - ETag should differ from upstream for markdown content" >&2
+  exit 1
+fi
+
+# --- Case 7: Vary: Cookie in auth response ---
+echo "==> Case 7: Vary header in auth response"
+# The upstream sends Vary: Cookie for auth requests; check if forwarded
+curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'Cookie: session=abc123' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi '^Vary:' "${RAW_DIR}/case7.hdr" || {
+  echo "INFO: Case 7 - No Vary header in auth response" >&2
+}
+echo "  PASS: Auth response has Vary header"
+
+echo ""
+echo "========================================="
+echo "All auth/cache E2E tests passed!"
+echo "========================================="

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -55,6 +55,7 @@ assert_header_contains() {
     echo "FAIL: ${label} - expected header matching ${pattern}" >&2
     exit 1
   }
+  return 0
 }
 
 #
@@ -76,6 +77,7 @@ assert_header_not_contains() {
     echo "FAIL: ${label} - unexpected header matching ${pattern}" >&2
     exit 1
   fi
+  return 0
 }
 
 #

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -36,6 +36,9 @@ readonly HEADER_COOKIE_AUTH='Cookie: session=abc123'
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+#
+# Print command-line usage for this E2E script.
+#
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
@@ -56,6 +59,9 @@ EOF
   return 0
 }
 
+#
+# Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
 cleanup() {
   local rc=$?
 

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -37,13 +37,67 @@ readonly HEADER_COOKIE_AUTH='Cookie: session_user=abc123'
 source "${NATIVE_BUILD_HELPER}"
 
 #
+# Assert that a headers file contains a line matching a pattern.
+#
+# Arguments:
+#   $1 - case label (for diagnostic messages)
+#   $2 - headers file path
+#   $3 - grep pattern to match
+# Output: FAIL diagnostic to stderr on failure
+# Exit behavior: exits 1 if pattern not found
+#
+assert_header_contains() {
+  local label="$1"
+  local hdr_file="$2"
+  local pattern="$3"
+
+  grep -qi "${pattern}" "${hdr_file}" || {
+    echo "FAIL: ${label} - expected header matching ${pattern}" >&2
+    exit 1
+  }
+}
+
+#
+# Assert that a headers file does NOT contain a line matching a pattern.
+#
+# Arguments:
+#   $1 - case label (for diagnostic messages)
+#   $2 - headers file path
+#   $3 - grep pattern that must not match
+# Output: FAIL diagnostic to stderr on failure
+# Exit behavior: exits 1 if pattern is found
+#
+assert_header_not_contains() {
+  local label="$1"
+  local hdr_file="$2"
+  local pattern="$3"
+
+  if grep -qi "${pattern}" "${hdr_file}"; then
+    echo "FAIL: ${label} - unexpected header matching ${pattern}" >&2
+    exit 1
+  fi
+}
+
+#
 # Print command-line usage for this E2E script.
+#
+# Arguments: none
+# Output: usage text to stdout
+# Exit behavior: returns 0
 #
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT] [-h|--help]
 
 Build local NGINX with the markdown module and run auth/cache E2E checks.
+
+Options:
+  --keep-artifacts       Keep build artifacts after run (default: remove on success)
+  --nginx-version VERSION
+                         NGINX version to build (default: ${NGINX_VERSION})
+  --port PORT            Main NGINX listen port (default: ${PORT})
+  --upstream-port PORT   Upstream server listen port (default: ${UPSTREAM_PORT})
+  -h, --help             Show this help message
 
 Checks:
   1) Auth request Cache-Control: private
@@ -61,6 +115,10 @@ EOF
 
 #
 # Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
+# Arguments: none (reads global state)
+# Output: diagnostic messages to stderr
+# Exit behavior: returns 0
 #
 cleanup() {
   local rc=$?
@@ -80,7 +138,7 @@ cleanup() {
   if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
     echo "Auth/cache E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
   elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
-    echo "Auth/cache E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+    echo "Auth/cache E2E succeeded. Artifacts kept at: ${BUILDROOT}" >&2
   fi
   return 0
 }
@@ -206,17 +264,17 @@ PY
 chmod +x "${UPSTREAM_SCRIPT}"
 
 # --- Build or reuse NGINX ---
-echo "==> Host architecture: $(uname -m)"
+echo "==> Host architecture: $(uname -m)" >&2
 if [[ -n "${NGINX_BIN}" ]]; then
-  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})" >&2
   LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
-  echo "==> Building Rust converter (${RUST_TARGET})"
+  echo "==> Building Rust converter (${RUST_TARGET})" >&2
   markdown_prepare_rust_converter_release \
     "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
 
-  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}" >&2
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
   mkdir -p "${BUILDROOT}/src"
   tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
@@ -236,7 +294,7 @@ fi
 mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 
 # --- Start upstream ---
-echo "==> Starting auth/cache upstream on 127.0.0.1:${UPSTREAM_PORT}"
+echo "==> Starting auth/cache upstream on 127.0.0.1:${UPSTREAM_PORT}" >&2
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
 markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
@@ -291,79 +349,55 @@ http {
 }
 EOF
 
-echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+echo "==> Starting NGINX on 127.0.0.1:${PORT}" >&2
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
 markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" "NGINX on ${PORT}" || exit 1
 
 # --- Case 1: Auth request with Cookie gets Cache-Control: private ---
-echo "==> Case 1: Auth request with Cookie gets Cache-Control: private"
+echo "==> Case 1: Auth request with Cookie gets Cache-Control: private" >&2
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected HTTP 200" >&2
-  exit 1
-}
-if ! grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr"; then
-  echo "FAIL: Case 1 - expected Cache-Control: private for auth request" >&2
-  exit 1
-fi
-echo "  PASS: Cache-Control contains private for auth request"
+assert_header_contains "Case 1 status" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 1 cache-control" "${RAW_DIR}/case1.hdr" '^Cache-Control:.*private'
+echo "  PASS: Cache-Control contains private for auth request" >&2
 
 # --- Case 2: Non-auth request retains Cache-Control: public ---
-echo "==> Case 2: Non-auth request retains upstream Cache-Control: public"
+echo "==> Case 2: Non-auth request retains upstream Cache-Control: public" >&2
 curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case2.hdr" || {
-  echo "FAIL: Case 2 - expected HTTP 200" >&2
-  exit 1
-}
-if ! grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr"; then
-  echo "FAIL: Case 2 - expected Cache-Control: public for non-auth request" >&2
-  exit 1
-fi
-echo "  PASS: Cache-Control contains public for non-auth request"
+assert_header_contains "Case 2 status" "${RAW_DIR}/case2.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 2 cache-control" "${RAW_DIR}/case2.hdr" '^Cache-Control:.*public'
+echo "  PASS: Cache-Control contains public for non-auth request" >&2
 
 # --- Case 3: auth_policy deny rejects conversion for auth requests ---
-echo "==> Case 3: auth_policy deny rejects conversion for auth requests"
+echo "==> Case 3: auth_policy deny rejects conversion for auth requests" >&2
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md-deny/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected HTTP 200 (passthrough)" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected text/html when auth_policy deny blocks conversion" >&2
-  exit 1
-}
-echo "  PASS: auth_policy deny returns HTML passthrough"
+assert_header_contains "Case 3 status" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 3 content-type" "${RAW_DIR}/case3.hdr" "${PATTERN_CT_HTML}"
+echo "  PASS: auth_policy deny returns HTML passthrough" >&2
 
 # --- Case 4: auth_cookies pattern matching ---
-echo "==> Case 4: auth_cookies pattern matching"
+echo "==> Case 4: auth_cookies pattern matching" >&2
 # A cookie that does NOT match session_* should not trigger auth logic
 curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'Cookie: preferences=dark' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
-  echo "FAIL: Case 4 - expected HTTP 200" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case4.hdr" || {
-  echo "FAIL: Case 4 - expected text/markdown for non-auth cookie" >&2
-  exit 1
-}
-echo "  PASS: Non-matching cookie does not trigger auth logic"
+assert_header_contains "Case 4 status" "${RAW_DIR}/case4.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 4 content-type" "${RAW_DIR}/case4.hdr" "${PATTERN_CT_MARKDOWN}"
+echo "  PASS: Non-matching cookie does not trigger auth logic" >&2
 
 # --- Case 5: Auth fail-open preserves Cache-Control ---
-echo "==> Case 5: Auth fail-open preserves upstream Cache-Control"
+echo "==> Case 5: Auth fail-open preserves upstream Cache-Control" >&2
 # With on_error pass and auth request, if conversion fails, upstream headers preserved
 # Capture upstream Cache-Control value for comparison
 curl -sS -D "${RAW_DIR}/case5up.hdr" -o /dev/null \
@@ -385,10 +419,10 @@ if [[ "${AUTH_CC}" != "${UPSTREAM_CC}" ]]; then
   echo "FAIL: Case 5 - auth Cache-Control (${AUTH_CC}) differs from upstream (${UPSTREAM_CC})" >&2
   exit 1
 fi
-echo "  PASS: Auth response preserves upstream Cache-Control (${AUTH_CC})"
+echo "  PASS: Auth response preserves upstream Cache-Control (${AUTH_CC})" >&2
 
 # --- Case 6: Non-auth ETag replacement ---
-echo "==> Case 6: Non-auth conversion replaces upstream ETag with markdown ETag"
+echo "==> Case 6: Non-auth conversion replaces upstream ETag with markdown ETag" >&2
 curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
@@ -401,23 +435,20 @@ if [[ "${MD_ETAG}" == '"upstream-auth-etag-001"' ]]; then
   echo "FAIL: Case 6 - ETag should differ from upstream for markdown content" >&2
   exit 1
 fi
-echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-auth-etag-001, got=${MD_ETAG})"
+echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-auth-etag-001, got=${MD_ETAG})" >&2
 
 # --- Case 7: Vary: Cookie in auth response ---
-echo "==> Case 7: Vary header in auth response"
+echo "==> Case 7: Vary header in auth response" >&2
 # The upstream sends Vary: Cookie for auth requests; check if forwarded
 curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-if ! grep -qi '^Vary:.*Cookie' "${RAW_DIR}/case7.hdr"; then
-  echo "FAIL: Case 7 - expected Vary header containing Cookie in auth response" >&2
-  exit 1
-fi
-echo "  PASS: Vary header contains Cookie in auth response"
+assert_header_contains "Case 7 vary" "${RAW_DIR}/case7.hdr" '^Vary:.*Cookie'
+echo "  PASS: Vary header contains Cookie in auth response" >&2
 
-echo ""
-echo "========================================="
-echo "All auth/cache E2E tests passed!"
-echo "========================================="
+echo "" >&2
+echo "=========================================" >&2
+echo "All auth/cache E2E tests passed!" >&2
+echo "=========================================" >&2

--- a/tools/e2e/verify_auth_cache_e2e.sh
+++ b/tools/e2e/verify_auth_cache_e2e.sh
@@ -31,6 +31,7 @@ readonly ACCEPT_MARKDOWN='Accept: text/markdown'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
 readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown'
 readonly PATTERN_CT_HTML='^Content-Type: text/html'
+readonly HEADER_COOKIE_AUTH='Cookie: session=abc123'
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
@@ -52,18 +53,6 @@ Checks:
 
 Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
 EOF
-  return 0
-}
-
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
   return 0
 }
 
@@ -98,17 +87,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
@@ -160,7 +149,6 @@ HTML_BODY = b"""<!doctype html>
 
 UPSTREAM_ETAG = '"upstream-auth-etag-001"'
 
-
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -195,7 +183,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -205,7 +192,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()
@@ -307,20 +293,18 @@ markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" "NGINX on ${PORT}" || 
 echo "==> Case 1: Auth request with Cookie gets Cache-Control: private"
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" \
-  -H 'Cookie: session=abc123' \
+  -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
 grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
   echo "FAIL: Case 1 - expected HTTP 200" >&2
   exit 1
 }
-grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr" || {
-  echo "INFO: Case 1 - Cache-Control: private not found; module may not rewrite CC for auth requests" >&2
-  echo "  PASS (soft): Auth request conversion completed"
-}
-grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr" && {
-  echo "  PASS: Cache-Control contains private for auth request"
-}
+if ! grep -qi '^Cache-Control:.*private' "${RAW_DIR}/case1.hdr"; then
+  echo "FAIL: Case 1 - expected Cache-Control: private for auth request" >&2
+  exit 1
+fi
+echo "  PASS: Cache-Control contains private for auth request"
 
 # --- Case 2: Non-auth request retains Cache-Control: public ---
 echo "==> Case 2: Non-auth request retains upstream Cache-Control: public"
@@ -331,19 +315,17 @@ grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case2.hdr" || {
   echo "FAIL: Case 2 - expected HTTP 200" >&2
   exit 1
 }
-grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr" || {
-  echo "INFO: Case 2 - Cache-Control: public not found in response" >&2
-  echo "  PASS (soft): Non-auth request conversion completed"
-}
-grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr" && {
-  echo "  PASS: Cache-Control contains public for non-auth request"
-}
+if ! grep -qi '^Cache-Control:.*public' "${RAW_DIR}/case2.hdr"; then
+  echo "FAIL: Case 2 - expected Cache-Control: public for non-auth request" >&2
+  exit 1
+fi
+echo "  PASS: Cache-Control contains public for non-auth request"
 
 # --- Case 3: auth_policy deny rejects conversion for auth requests ---
 echo "==> Case 3: auth_policy deny rejects conversion for auth requests"
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_MARKDOWN}" \
-  -H 'Cookie: session=abc123' \
+  -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md-deny/html" >/dev/null
 grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
@@ -379,12 +361,13 @@ echo "==> Case 5: Auth fail-open preserves upstream Cache-Control"
 # With on_error pass and auth request, if conversion fails, upstream headers preserved
 curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H "${ACCEPT_MARKDOWN}" \
-  -H 'Cookie: session=abc123' \
+  -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "^Cache-Control:" "${RAW_DIR}/case5.hdr" || {
-  echo "INFO: Case 5 - No Cache-Control header in response" >&2
-}
+if ! grep -qi "^Cache-Control:" "${RAW_DIR}/case5.hdr"; then
+  echo "FAIL: Case 5 - expected Cache-Control header in auth request response" >&2
+  exit 1
+fi
 echo "  PASS: Auth request response has Cache-Control header"
 
 # --- Case 6: Non-auth ETag replacement ---
@@ -407,12 +390,13 @@ echo "==> Case 7: Vary header in auth response"
 # The upstream sends Vary: Cookie for auth requests; check if forwarded
 curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_MARKDOWN}" \
-  -H 'Cookie: session=abc123' \
+  -H "${HEADER_COOKIE_AUTH}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi '^Vary:' "${RAW_DIR}/case7.hdr" || {
-  echo "INFO: Case 7 - No Vary header in auth response" >&2
-}
+if ! grep -qi '^Vary:' "${RAW_DIR}/case7.hdr"; then
+  echo "FAIL: Case 7 - expected Vary header in auth response" >&2
+  exit 1
+fi
 echo "  PASS: Auth response has Vary header"
 
 echo ""

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -63,15 +63,6 @@ EOF
 }
 
 #
-# Validate that a flag requiring a value has one.
-# Arguments:
-#   $1: flag name (for diagnostics)
-#   $2: flag value (must be non-empty)
-# Output: prints usage to stderr on failure
-# Exit: exits with code 2 if value is missing
-#
-
-#
 # Validate a streaming markdown HTTP response contract.
 # Args:
 #   case_name: logical case label used in diagnostics
@@ -457,13 +448,7 @@ mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 echo "==> Starting chunked upstream on 127.0.0.1:${UPSTREAM_PORT}"
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
-for _ in $(seq 1 50); do
-  if curl -sS "http://127.0.0.1:${UPSTREAM_PORT}/health" >/dev/null 2>&1; then
-    break
-  fi
-  sleep 0.1
-done
-curl -sS "http://127.0.0.1:${UPSTREAM_PORT}/health" >/dev/null
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
 
 cat > "${RUNTIME}/conf/nginx.conf" <<EOF
 ${LOAD_MODULE_LINE}worker_processes 1;

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -539,7 +539,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/stream/small-valid" "NGINX" || exit 1
 
 echo "==> Case 1: chunked below max_size should convert to Markdown"
 small_line="$(curl -sS -D "${RAW_DIR}/small.hdr" -o "${RAW_DIR}/small.body" \

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -70,17 +70,6 @@ EOF
 # Output: prints usage to stderr on failure
 # Exit: exits with code 2 if value is missing
 #
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
 
 #
 # Validate a streaming markdown HTTP response contract.
@@ -169,27 +158,27 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
     --markdown-max-size)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       MARKDOWN_MAX_SIZE="$2"
       shift 2
       ;;
     --profile)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       PROFILE="$2"
       shift 2
       ;;
@@ -254,7 +243,6 @@ COMPRESSED_TARGET = 64 * 1024
 OVERSIZE_TARGET = 12 * 1024 * 1024
 CHUNK_SIZE = 16 * 1024
 
-
 def build_payload(title: str, target_size: int, end_token: str) -> bytes:
     prefix = (
         f'<!doctype html><html><head><meta charset="UTF-8"><title>{title}</title></head>'
@@ -272,7 +260,6 @@ def build_payload(title: str, target_size: int, end_token: str) -> bytes:
     out.extend(suffix)
     return bytes(out)
 
-
 def compress_payload(body: bytes, mode: str) -> bytes:
     if mode == "gzip":
         wbits = zlib.MAX_WBITS | 16
@@ -283,7 +270,6 @@ def compress_payload(body: bytes, mode: str) -> bytes:
 
     compressor = zlib.compressobj(level=6, wbits=wbits)
     return compressor.compress(body) + compressor.flush()
-
 
 SMALL_BODY = build_payload("Chunked Small", SMALL_TARGET, SMALL_END_TOKEN)
 OVERSIZE_BODY = build_payload("Chunked Oversize", OVERSIZE_TARGET, OVERSIZE_END_TOKEN)
@@ -299,7 +285,6 @@ TRUNCATED_GZIP_BODY = GZIP_BODY[:-8] if len(GZIP_BODY) > 8 else GZIP_BODY
 TRUNCATED_DEFLATE_BODY = (
     DEFLATE_BODY[:-4] if len(DEFLATE_BODY) > 4 else DEFLATE_BODY
 )
-
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -403,7 +388,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -433,7 +417,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()

--- a/tools/e2e/verify_conditional_requests_e2e.sh
+++ b/tools/e2e/verify_conditional_requests_e2e.sh
@@ -33,6 +33,7 @@ ORIG_ARGS=("$@")
 readonly ACCEPT_MARKDOWN='Accept: text/markdown'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
 readonly PATTERN_HTTP_304='HTTP/1.1 304'
+readonly MD_HTML_URL="http://127.0.0.1:${PORT}/md/html"
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
@@ -40,11 +41,23 @@ source "${NATIVE_BUILD_HELPER}"
 #
 # Print command-line usage for this E2E script.
 #
+# Arguments: none
+# Output: usage text to stdout
+# Exit behavior: returns 0
+#
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT] [-h|--help]
 
 Build local NGINX with the markdown module and run conditional-request E2E checks.
+
+Options:
+  --keep-artifacts       Keep build artifacts after run (default: remove on success)
+  --nginx-version VERSION
+                         NGINX version to build (default: ${NGINX_VERSION})
+  --port PORT            Main NGINX listen port (default: ${PORT})
+  --upstream-port PORT   Upstream server listen port (default: ${UPSTREAM_PORT})
+  -h, --help             Show this help message
 
 Checks:
   1) Converted response includes ETag
@@ -66,6 +79,10 @@ EOF
 #
 # Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
 #
+# Arguments: none (reads global state)
+# Output: diagnostic messages to stderr
+# Exit behavior: returns 0
+#
 cleanup() {
   local rc=$?
 
@@ -84,7 +101,7 @@ cleanup() {
   if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
     echo "Conditional-request E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
   elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
-    echo "Conditional-request E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+    echo "Conditional-request E2E succeeded. Artifacts kept at: ${BUILDROOT}" >&2
   fi
   return 0
 }
@@ -199,7 +216,7 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/health":
             self.send_response(200)
             self.send_header("Content-Type", "text/plain")
-            self.send_header("Content-Length", "2")
+            self.send_header("Content-Length", "3")
             self.end_headers()
             return
         if path == "/html":
@@ -232,17 +249,17 @@ PY
 chmod +x "${UPSTREAM_SCRIPT}"
 
 # --- Build or reuse NGINX ---
-echo "==> Host architecture: $(uname -m)"
+echo "==> Host architecture: $(uname -m)" >&2
 if [[ -n "${NGINX_BIN}" ]]; then
-  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})" >&2
   LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
-  echo "==> Building Rust converter (${RUST_TARGET})"
+  echo "==> Building Rust converter (${RUST_TARGET})" >&2
   markdown_prepare_rust_converter_release \
     "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
 
-  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}" >&2
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
   mkdir -p "${BUILDROOT}/src"
   tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
@@ -262,7 +279,7 @@ fi
 mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 
 # --- Start upstream ---
-echo "==> Starting conditional-request upstream on 127.0.0.1:${UPSTREAM_PORT}"
+echo "==> Starting conditional-request upstream on 127.0.0.1:${UPSTREAM_PORT}" >&2
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
 markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
@@ -301,110 +318,110 @@ http {
 }
 EOF
 
-echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+echo "==> Starting NGINX on 127.0.0.1:${PORT}" >&2
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" "NGINX on ${PORT}" || exit 1
+markdown_wait_for_http "${MD_HTML_URL}" "NGINX on ${PORT}" || exit 1
 
 # --- Case 1: Converted response includes ETag header ---
-echo "==> Case 1: Converted response includes ETag header"
+echo "==> Case 1: Converted response includes ETag header" >&2
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
 markdown_expect_header "Case 1" "${RAW_DIR}/case1.hdr" '^ETag:'
-echo "  PASS: Converted response includes ETag header"
+echo "  PASS: Converted response includes ETag header" >&2
 
 # Extract the ETag value for subsequent tests
 RESPONSE_ETAG="$(markdown_extract_header "${RAW_DIR}/case1.hdr" "ETag")"
 
 # --- Case 2: ETag differs from upstream's original ETag ---
-echo "==> Case 2: ETag differs from upstream original"
+echo "==> Case 2: ETag differs from upstream original" >&2
 [[ "${RESPONSE_ETAG}" != '"upstream-original-etag-12345"' ]] || {
   echo "FAIL: Case 2 - markdown ETag should differ from upstream ETag, got: ${RESPONSE_ETAG}" >&2
   exit 1
 }
-echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-original-etag-12345, got=${RESPONSE_ETAG})"
+echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-original-etag-12345, got=${RESPONSE_ETAG})" >&2
 
 # --- Case 3: If-None-Match with matching ETag returns 304 ---
-echo "==> Case 3: If-None-Match matching ETag returns 304"
+echo "==> Case 3: If-None-Match matching ETag returns 304" >&2
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "If-None-Match: ${RESPONSE_ETAG}" \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 3" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_304}"
-echo "  PASS: If-None-Match with matching ETag returns 304"
+echo "  PASS: If-None-Match with matching ETag returns 304" >&2
 
 # --- Case 4: If-None-Match with non-matching ETag returns 200 ---
-echo "==> Case 4: If-None-Match non-matching ETag returns 200"
+echo "==> Case 4: If-None-Match non-matching ETag returns 200" >&2
 curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'If-None-Match: "non-matching-etag-99999"' \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 4" "${RAW_DIR}/case4.hdr" "${PATTERN_HTTP_200}"
-echo "  PASS: If-None-Match with non-matching ETag returns 200"
+echo "  PASS: If-None-Match with non-matching ETag returns 200" >&2
 
 # --- Case 5: If-Modified-Since with future date returns 304 ---
-echo "==> Case 5: If-Modified-Since with future date returns 304"
+echo "==> Case 5: If-Modified-Since with future date returns 304" >&2
 curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 5" "${RAW_DIR}/case5.hdr" "${PATTERN_HTTP_304}"
-echo "  PASS: If-Modified-Since with future date returns 304"
+echo "  PASS: If-Modified-Since with future date returns 304" >&2
 
 # --- Case 6: If-Modified-Since with past date returns 200 ---
-echo "==> Case 6: If-Modified-Since with past date returns 200"
+echo "==> Case 6: If-Modified-Since with past date returns 200" >&2
 curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'If-Modified-Since: Mon, 01 Jan 2020 00:00:00 GMT' \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 6" "${RAW_DIR}/case6.hdr" "${PATTERN_HTTP_200}"
-echo "  PASS: If-Modified-Since with past date returns 200"
+echo "  PASS: If-Modified-Since with past date returns 200" >&2
 
 # --- Case 7: Weak ETag matching returns 304 ---
-echo "==> Case 7: Weak ETag matching returns 304"
+echo "==> Case 7: Weak ETag matching returns 304" >&2
 WEAK_ETAG="W/${RESPONSE_ETAG}"
 curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H "If-None-Match: ${WEAK_ETAG}" \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 7" "${RAW_DIR}/case7.hdr" "${PATTERN_HTTP_304}"
-echo "  PASS: Weak ETag matching returns 304"
+echo "  PASS: Weak ETag matching returns 304" >&2
 
 # --- Case 8: Wildcard If-None-Match: * returns 304 ---
-echo "==> Case 8: Wildcard If-None-Match: * returns 304"
+echo "==> Case 8: Wildcard If-None-Match: * returns 304" >&2
 curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'If-None-Match: *' \
   --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_HTTP_304}"
-echo "  PASS: Wildcard If-None-Match returns 304"
+echo "  PASS: Wildcard If-None-Match returns 304" >&2
 
 # --- Case 9: Vary: Accept present in 304 response ---
-echo "==> Case 9: Vary: Accept present in 304 response"
+echo "==> Case 9: Vary: Accept present in 304 response" >&2
 markdown_expect_header "Case 9" "${RAW_DIR}/case3.hdr" '^Vary:.*Accept'
-echo "  PASS: Vary: Accept present in 304 response"
+echo "  PASS: Vary: Accept present in 304 response" >&2
 
 # --- Case 10: HEAD returns same ETag as GET ---
-echo "==> Case 10: HEAD returns same ETag as GET"
+echo "==> Case 10: HEAD returns same ETag as GET" >&2
 curl -sS -D "${RAW_DIR}/case10.hdr" -o "${RAW_DIR}/case10.body" \
   --head -H "${ACCEPT_MARKDOWN}" --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+  "${MD_HTML_URL}" >/dev/null
 markdown_expect_status "Case 10" "${RAW_DIR}/case10.hdr" "${PATTERN_HTTP_200}"
 HEAD_ETAG="$(markdown_extract_header "${RAW_DIR}/case10.hdr" "ETag")"
 [[ "${HEAD_ETAG}" == "${RESPONSE_ETAG}" ]] || {
   echo "FAIL: Case 10 - HEAD ETag (${HEAD_ETAG}) != GET ETag (${RESPONSE_ETAG})" >&2
   exit 1
 }
-echo "  PASS: HEAD and GET return identical ETag"
+echo "  PASS: HEAD and GET return identical ETag" >&2
 
-echo ""
-echo "=============================================="
-echo "All conditional-request E2E tests passed!"
-echo "=============================================="
+echo "" >&2
+echo "==============================================" >&2
+echo "All conditional-request E2E tests passed!" >&2
+echo "==============================================" >&2

--- a/tools/e2e/verify_conditional_requests_e2e.sh
+++ b/tools/e2e/verify_conditional_requests_e2e.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E validation for conditional requests (ETag + If-None-Match + If-Modified-Since).
+#
+# Validates critical conditional-request paths:
+#  1) Converted response includes ETag header
+#  2) ETag differs from upstream's original ETag
+#  3) If-None-Match with matching ETag returns 304 Not Modified
+#  4) If-None-Match with non-matching ETag returns 200 with body
+#  5) If-Modified-Since with future date returns 304
+#  6) If-Modified-Since with past date returns 200 with body
+#  7) Weak ETag matching (W/"...") returns 304
+#  8) Wildcard If-None-Match: * returns 304
+#  9) Vary: Accept present in 304 response
+#  10) HEAD request returns same ETag as GET
+
+NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
+PORT="${PORT:-18099}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-19099}"
+KEEP_ARTIFACTS=0
+NGINX_BIN="${NGINX_BIN:-}"
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NATIVE_BUILD_HELPER="${WORKSPACE_ROOT}/tools/lib/nginx_markdown_native_build.sh"
+BUILDROOT=""
+RUNTIME=""
+RUST_TARGET=""
+NGINX_EXECUTABLE=""
+LOAD_MODULE_LINE=""
+UPSTREAM_PID=""
+ORIG_ARGS=("$@")
+
+readonly ACCEPT_MARKDOWN='Accept: text/markdown'
+readonly PATTERN_HTTP_200='HTTP/1.1 200'
+readonly PATTERN_HTTP_304='HTTP/1.1 304'
+
+# shellcheck source=tools/lib/nginx_markdown_native_build.sh
+source "${NATIVE_BUILD_HELPER}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+
+Build local NGINX with the markdown module and run conditional-request E2E checks.
+
+Checks:
+  1) Converted response includes ETag
+  2) ETag differs from upstream ETag
+  3) If-None-Match matching ETag returns 304
+  4) If-None-Match non-matching ETag returns 200
+  5) If-Modified-Since future returns 304
+  6) If-Modified-Since past returns 200
+  7) Weak ETag matching returns 304
+  8) Wildcard If-None-Match returns 304
+  9) Vary: Accept in 304 response
+  10) HEAD returns same ETag as GET
+
+Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
+EOF
+  return 0
+}
+
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${RUNTIME}" && -n "${NGINX_EXECUTABLE}" && -x "${NGINX_EXECUTABLE}" ]]; then
+    "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf -s stop >/dev/null 2>&1 || true
+  fi
+
+  if [[ $rc -eq 0 && "${KEEP_ARTIFACTS}" -eq 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    rm -rf "${BUILDROOT}" || true
+  fi
+
+  if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    echo "Conditional-request E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
+  elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
+    echo "Conditional-request E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --nginx-version)
+      require_flag_value "$1" "${2:-}"
+      NGINX_VERSION="$2"
+      shift 2
+      ;;
+    --port)
+      require_flag_value "$1" "${2:-}"
+      PORT="$2"
+      shift 2
+      ;;
+    --upstream-port)
+      require_flag_value "$1" "${2:-}"
+      UPSTREAM_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#ORIG_ARGS[@]} )); then
+  markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"
+else
+  markdown_ensure_native_apple_silicon "$0"
+fi
+
+for cmd in curl python3 grep; do
+  markdown_need_cmd "$cmd"
+done
+if [[ -z "${NGINX_BIN}" ]]; then
+  for cmd in tar make cargo; do
+    markdown_need_cmd "$cmd"
+  done
+fi
+
+RUST_TARGET="$(markdown_detect_rust_target)"
+BUILDROOT="$(mktemp -d /tmp/nginx-conditional-e2e.XXXXXX)"
+RUNTIME="${BUILDROOT}/runtime"
+RAW_DIR="${BUILDROOT}/raw"
+UPSTREAM_SCRIPT="${BUILDROOT}/conditional_upstream.py"
+mkdir -p "${RAW_DIR}"
+
+# --- Upstream server with ETag and Last-Modified ---
+cat > "${UPSTREAM_SCRIPT}" <<'PY'
+#!/usr/bin/env python3
+import argparse
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+from email.utils import formatdate
+from time import time
+
+HTML_BODY = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>Conditional Test</title></head>
+<body><h1>Conditional Request Test</h1><p>Content for ETag validation.</p>
+<a href="/link">Click here</a></body></html>
+"""
+
+UPSTREAM_ETAG = '"upstream-original-etag-12345"'
+LAST_MODIFIED = "Mon, 01 Jan 2024 00:00:00 GMT"
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args):
+        return
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            body = b"ok\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_BODY)))
+            self.send_header("ETag", UPSTREAM_ETAG)
+            self.send_header("Last-Modified", LAST_MODIFIED)
+            self.send_header("Cache-Control", "public, max-age=3600")
+            self.end_headers()
+            self.wfile.write(HTML_BODY)
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19099)
+    args = parser.parse_args()
+    if args.serve:
+        server = ThreadingHTTPServer((args.host, args.port), Handler)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+chmod +x "${UPSTREAM_SCRIPT}"
+
+# --- Build or reuse NGINX ---
+echo "==> Host architecture: $(uname -m)"
+if [[ -n "${NGINX_BIN}" ]]; then
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
+  NGINX_EXECUTABLE="${NGINX_BIN}"
+else
+  echo "==> Building Rust converter (${RUST_TARGET})"
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
+
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
+  mkdir -p "${BUILDROOT}/src"
+  tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
+  (
+    cd "${BUILDROOT}/src"
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+    make install >/dev/null
+  )
+  NGINX_EXECUTABLE="${RUNTIME}/sbin/nginx"
+fi
+
+mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
+
+# --- Start upstream ---
+echo "==> Starting conditional-request upstream on 127.0.0.1:${UPSTREAM_PORT}"
+python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
+
+# --- NGINX config with conditional requests enabled ---
+cat > "${RUNTIME}/conf/nginx.conf" <<EOF
+${LOAD_MODULE_LINE}worker_processes 1;
+error_log logs/error.log info;
+pid logs/nginx.pid;
+
+events { worker_connections 512; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 5;
+
+    server {
+        listen 127.0.0.1:${PORT};
+        server_name localhost;
+
+        location /md/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            markdown_etag on;
+            markdown_conditional_requests full_support;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+    }
+}
+EOF
+
+echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+"${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/html" "NGINX on ${PORT}" || exit 1
+
+# --- Case 1: Converted response includes ETag header ---
+echo "==> Case 1: Converted response includes ETag header"
+curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected HTTP 200" >&2
+  exit 1
+}
+grep -qi '^ETag:' "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected ETag header in converted response" >&2
+  exit 1
+}
+echo "  PASS: Converted response includes ETag header"
+
+# Extract the ETag value for subsequent tests
+RESPONSE_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case1.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
+
+# --- Case 2: ETag differs from upstream's original ETag ---
+echo "==> Case 2: ETag differs from upstream original"
+[[ "${RESPONSE_ETAG}" != '"upstream-original-etag-12345"' ]] || {
+  echo "FAIL: Case 2 - markdown ETag should differ from upstream ETag, got: ${RESPONSE_ETAG}" >&2
+  exit 1
+}
+echo "  PASS: Markdown ETag differs from upstream (upstream=upstream-original-etag-12345, got=${RESPONSE_ETAG})"
+
+# --- Case 3: If-None-Match with matching ETag returns 304 ---
+echo "==> Case 3: If-None-Match matching ETag returns 304"
+curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H "If-None-Match: ${RESPONSE_ETAG}" \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected 304 for matching If-None-Match" >&2
+  exit 1
+}
+echo "  PASS: If-None-Match with matching ETag returns 304"
+
+# --- Case 4: If-None-Match with non-matching ETag returns 200 ---
+echo "==> Case 4: If-None-Match non-matching ETag returns 200"
+curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'If-None-Match: "non-matching-etag-99999"' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
+  echo "FAIL: Case 4 - expected 200 for non-matching If-None-Match" >&2
+  exit 1
+}
+echo "  PASS: If-None-Match with non-matching ETag returns 200"
+
+# --- Case 5: If-Modified-Since with future date returns 304 ---
+echo "==> Case 5: If-Modified-Since with future date returns 304"
+curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case5.hdr" || {
+  echo "FAIL: Case 5 - expected 304 for future If-Modified-Since" >&2
+  exit 1
+}
+echo "  PASS: If-Modified-Since with future date returns 304"
+
+# --- Case 6: If-Modified-Since with past date returns 200 ---
+echo "==> Case 6: If-Modified-Since with past date returns 200"
+curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'If-Modified-Since: Mon, 01 Jan 2020 00:00:00 GMT' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case6.hdr" || {
+  echo "FAIL: Case 6 - expected 200 for past If-Modified-Since" >&2
+  exit 1
+}
+echo "  PASS: If-Modified-Since with past date returns 200"
+
+# --- Case 7: Weak ETag matching returns 304 ---
+echo "==> Case 7: Weak ETag matching returns 304"
+WEAK_ETAG="W/${RESPONSE_ETAG}"
+curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H "If-None-Match: ${WEAK_ETAG}" \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case7.hdr" || {
+  echo "FAIL: Case 7 - expected 304 for weak ETag If-None-Match" >&2
+  exit 1
+}
+echo "  PASS: Weak ETag matching returns 304"
+
+# --- Case 8: Wildcard If-None-Match: * returns 304 ---
+echo "==> Case 8: Wildcard If-None-Match: * returns 304"
+curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'If-None-Match: *' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case8.hdr" || {
+  echo "FAIL: Case 8 - expected 304 for wildcard If-None-Match" >&2
+  exit 1
+}
+echo "  PASS: Wildcard If-None-Match returns 304"
+
+# --- Case 9: Vary: Accept present in 304 response ---
+echo "==> Case 9: Vary: Accept present in 304 response"
+grep -qi '^Vary:.*Accept' "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 9 - Vary: Accept not found in 304 response" >&2
+  exit 1
+}
+echo "  PASS: Vary: Accept present in 304 response"
+
+# --- Case 10: HEAD returns same ETag as GET ---
+echo "==> Case 10: HEAD returns same ETag as GET"
+curl -sS -D "${RAW_DIR}/case10.hdr" -o "${RAW_DIR}/case10.body" \
+  --head -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case10.hdr" || {
+  echo "FAIL: Case 10 - expected HTTP 200 for HEAD" >&2
+  exit 1
+}
+HEAD_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case10.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
+[[ "${HEAD_ETAG}" == "${RESPONSE_ETAG}" ]] || {
+  echo "FAIL: Case 10 - HEAD ETag (${HEAD_ETAG}) != GET ETag (${RESPONSE_ETAG})" >&2
+  exit 1
+}
+echo "  PASS: HEAD and GET return identical ETag"
+
+echo ""
+echo "=============================================="
+echo "All conditional-request E2E tests passed!"
+echo "=============================================="

--- a/tools/e2e/verify_conditional_requests_e2e.sh
+++ b/tools/e2e/verify_conditional_requests_e2e.sh
@@ -194,6 +194,27 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    def do_HEAD(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            return
+        if path == "/html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_BODY)))
+            self.send_header("ETag", UPSTREAM_ETAG)
+            self.send_header("Last-Modified", LAST_MODIFIED)
+            self.send_header("Cache-Control", "public, max-age=3600")
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")

--- a/tools/e2e/verify_conditional_requests_e2e.sh
+++ b/tools/e2e/verify_conditional_requests_e2e.sh
@@ -60,18 +60,6 @@ EOF
   return 0
 }
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 cleanup() {
   local rc=$?
 
@@ -103,17 +91,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
@@ -170,7 +158,6 @@ HTML_BODY = b"""<!doctype html>
 UPSTREAM_ETAG = '"upstream-original-etag-12345"'
 LAST_MODIFIED = "Mon, 01 Jan 2024 00:00:00 GMT"
 
-
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -201,7 +188,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -211,7 +197,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()
@@ -298,18 +283,12 @@ echo "==> Case 1: Converted response includes ETag header"
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected HTTP 200" >&2
-  exit 1
-}
-grep -qi '^ETag:' "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected ETag header in converted response" >&2
-  exit 1
-}
+markdown_expect_status "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
+markdown_expect_header "Case 1" "${RAW_DIR}/case1.hdr" '^ETag:'
 echo "  PASS: Converted response includes ETag header"
 
 # Extract the ETag value for subsequent tests
-RESPONSE_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case1.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
+RESPONSE_ETAG="$(markdown_extract_header "${RAW_DIR}/case1.hdr" "ETag")"
 
 # --- Case 2: ETag differs from upstream's original ETag ---
 echo "==> Case 2: ETag differs from upstream original"
@@ -326,10 +305,7 @@ curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "If-None-Match: ${RESPONSE_ETAG}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected 304 for matching If-None-Match" >&2
-  exit 1
-}
+markdown_expect_status "Case 3" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_304}"
 echo "  PASS: If-None-Match with matching ETag returns 304"
 
 # --- Case 4: If-None-Match with non-matching ETag returns 200 ---
@@ -339,10 +315,7 @@ curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
   -H 'If-None-Match: "non-matching-etag-99999"' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
-  echo "FAIL: Case 4 - expected 200 for non-matching If-None-Match" >&2
-  exit 1
-}
+markdown_expect_status "Case 4" "${RAW_DIR}/case4.hdr" "${PATTERN_HTTP_200}"
 echo "  PASS: If-None-Match with non-matching ETag returns 200"
 
 # --- Case 5: If-Modified-Since with future date returns 304 ---
@@ -352,10 +325,7 @@ curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case5.hdr" || {
-  echo "FAIL: Case 5 - expected 304 for future If-Modified-Since" >&2
-  exit 1
-}
+markdown_expect_status "Case 5" "${RAW_DIR}/case5.hdr" "${PATTERN_HTTP_304}"
 echo "  PASS: If-Modified-Since with future date returns 304"
 
 # --- Case 6: If-Modified-Since with past date returns 200 ---
@@ -365,10 +335,7 @@ curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H 'If-Modified-Since: Mon, 01 Jan 2020 00:00:00 GMT' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case6.hdr" || {
-  echo "FAIL: Case 6 - expected 200 for past If-Modified-Since" >&2
-  exit 1
-}
+markdown_expect_status "Case 6" "${RAW_DIR}/case6.hdr" "${PATTERN_HTTP_200}"
 echo "  PASS: If-Modified-Since with past date returns 200"
 
 # --- Case 7: Weak ETag matching returns 304 ---
@@ -379,10 +346,7 @@ curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "If-None-Match: ${WEAK_ETAG}" \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case7.hdr" || {
-  echo "FAIL: Case 7 - expected 304 for weak ETag If-None-Match" >&2
-  exit 1
-}
+markdown_expect_status "Case 7" "${RAW_DIR}/case7.hdr" "${PATTERN_HTTP_304}"
 echo "  PASS: Weak ETag matching returns 304"
 
 # --- Case 8: Wildcard If-None-Match: * returns 304 ---
@@ -392,18 +356,12 @@ curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
   -H 'If-None-Match: *' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_304}" "${RAW_DIR}/case8.hdr" || {
-  echo "FAIL: Case 8 - expected 304 for wildcard If-None-Match" >&2
-  exit 1
-}
+markdown_expect_status "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_HTTP_304}"
 echo "  PASS: Wildcard If-None-Match returns 304"
 
 # --- Case 9: Vary: Accept present in 304 response ---
 echo "==> Case 9: Vary: Accept present in 304 response"
-grep -qi '^Vary:.*Accept' "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 9 - Vary: Accept not found in 304 response" >&2
-  exit 1
-}
+markdown_expect_header "Case 9" "${RAW_DIR}/case3.hdr" '^Vary:.*Accept'
 echo "  PASS: Vary: Accept present in 304 response"
 
 # --- Case 10: HEAD returns same ETag as GET ---
@@ -411,11 +369,8 @@ echo "==> Case 10: HEAD returns same ETag as GET"
 curl -sS -D "${RAW_DIR}/case10.hdr" -o "${RAW_DIR}/case10.body" \
   --head -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case10.hdr" || {
-  echo "FAIL: Case 10 - expected HTTP 200 for HEAD" >&2
-  exit 1
-}
-HEAD_ETAG="$(grep -i '^ETag:' "${RAW_DIR}/case10.hdr" | sed 's/^ETag:[[:space:]]*//I' | tr -d '\r\n')"
+markdown_expect_status "Case 10" "${RAW_DIR}/case10.hdr" "${PATTERN_HTTP_200}"
+HEAD_ETAG="$(markdown_extract_header "${RAW_DIR}/case10.hdr" "ETag")"
 [[ "${HEAD_ETAG}" == "${RESPONSE_ETAG}" ]] || {
   echo "FAIL: Case 10 - HEAD ETag (${HEAD_ETAG}) != GET ETag (${RESPONSE_ETAG})" >&2
   exit 1

--- a/tools/e2e/verify_conditional_requests_e2e.sh
+++ b/tools/e2e/verify_conditional_requests_e2e.sh
@@ -37,6 +37,9 @@ readonly PATTERN_HTTP_304='HTTP/1.1 304'
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+#
+# Print command-line usage for this E2E script.
+#
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
@@ -60,6 +63,9 @@ EOF
   return 0
 }
 
+#
+# Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
 cleanup() {
   local rc=$?
 

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -34,6 +34,9 @@ readonly PATTERN_CT_HTML='^Content-Type: text/html'
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+#
+# Print command-line usage for this E2E script.
+#
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
@@ -53,6 +56,9 @@ EOF
   return 0
 }
 
+#
+# Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
 cleanup() {
   local rc=$?
 

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -63,6 +63,7 @@ assert_http_status() {
     echo "FAIL: ${label} - expected status ${expected}" >&2
     exit 1
   }
+  return 0
 }
 
 #
@@ -84,6 +85,7 @@ assert_header_contains() {
     echo "FAIL: ${label} - expected header matching ${pattern}" >&2
     exit 1
   }
+  return 0
 }
 
 #

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -35,13 +35,77 @@ readonly PATTERN_CT_HTML='^Content-Type: text/html'
 source "${NATIVE_BUILD_HELPER}"
 
 #
+# Fetch URL, store headers/body, assert HTTP status matches pattern.
+#
+# Arguments:
+#   $1 - case label
+#   $2 - output directory for header/body files
+#   $3 - expected status pattern (e.g. "HTTP/1.1 200")
+#   $4 - URL to fetch
+#   $5 - optional additional curl headers (space-separated)
+# Output: FAIL diagnostic to stderr on failure
+# Exit behavior: exits 1 if status does not match
+#
+assert_http_status() {
+  local label="$1"
+  local raw_dir="$2"
+  local expected="$3"
+  local url="$4"
+  local extra_headers="${5:-}"
+
+  local base="${raw_dir}/${label// /_}"
+  # shellcheck disable=SC2086
+  curl -sS -D "${base}.hdr" -o "${base}.body" \
+    -H "${ACCEPT_MARKDOWN}" ${extra_headers} \
+    --max-time 30 \
+    "${url}" >/dev/null
+  grep -qi "${expected}" "${base}.hdr" || {
+    echo "FAIL: ${label} - expected status ${expected}" >&2
+    exit 1
+  }
+}
+
+#
+# Assert a header pattern is present in a headers file.
+#
+# Arguments:
+#   $1 - case label
+#   $2 - headers file path
+#   $3 - header pattern (grep-compatible)
+# Output: FAIL diagnostic to stderr on failure
+# Exit behavior: exits 1 if pattern not found
+#
+assert_header_contains() {
+  local label="$1"
+  local hdr_file="$2"
+  local pattern="$3"
+
+  grep -qi "${pattern}" "${hdr_file}" || {
+    echo "FAIL: ${label} - expected header matching ${pattern}" >&2
+    exit 1
+  }
+}
+
+#
 # Print command-line usage for this E2E script.
+#
+# Arguments: none
+# Output: usage text to stdout
+# Exit behavior: returns 0
 #
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT] [-h|--help]
 
 Build local NGINX with the markdown module and run config-merge E2E checks.
+
+Options:
+  --keep-artifacts       Keep build artifacts after run (default: remove on success)
+  --nginx-version VERSION
+                         NGINX version to build (default: ${NGINX_VERSION})
+  --port PORT            Main NGINX listen port (default: ${PORT})
+  --upstream-port PORT   Upstream server listen port (default: ${UPSTREAM_PORT})
+  -h, --help             Show this help message
 
 Checks:
   1) http-level on_error pass + location-level reject override
@@ -58,6 +122,10 @@ EOF
 
 #
 # Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
+# Arguments: none (reads global state)
+# Output: diagnostic messages to stderr
+# Exit behavior: returns 0
 #
 cleanup() {
   local rc=$?
@@ -77,7 +145,7 @@ cleanup() {
   if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
     echo "Config-merge E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
   elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
-    echo "Config-merge E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+    echo "Config-merge E2E succeeded. Artifacts kept at: ${BUILDROOT}" >&2
   fi
   return 0
 }
@@ -224,17 +292,17 @@ PY
 chmod +x "${UPSTREAM_SCRIPT}"
 
 # --- Build or reuse NGINX ---
-echo "==> Host architecture: $(uname -m)"
+echo "==> Host architecture: $(uname -m)" >&2
 if [[ -n "${NGINX_BIN}" ]]; then
-  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})" >&2
   LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
-  echo "==> Building Rust converter (${RUST_TARGET})"
+  echo "==> Building Rust converter (${RUST_TARGET})" >&2
   markdown_prepare_rust_converter_release \
     "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
 
-  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}" >&2
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
   mkdir -p "${BUILDROOT}/src"
   tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
@@ -254,7 +322,7 @@ fi
 mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 
 # --- Start upstream ---
-echo "==> Starting config-merge upstream on 127.0.0.1:${UPSTREAM_PORT}"
+echo "==> Starting config-merge upstream on 127.0.0.1:${UPSTREAM_PORT}" >&2
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
 markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
@@ -368,114 +436,79 @@ http {
 }
 EOF
 
-echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+echo "==> Starting NGINX on 127.0.0.1:${PORT}" >&2
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
 markdown_wait_for_http "http://127.0.0.1:${PORT}/md/pass/html" "NGINX on ${PORT}" || exit 1
 
 # --- Case 1: location-level on_error reject overrides http-level pass ---
-echo "==> Case 1: location-level on_error reject overrides http-level pass"
+echo "==> Case 1: location-level on_error reject overrides http-level pass" >&2
 # With reject, a malformed response should return an error, not pass-through
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/reject/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected 200 for valid HTML with on_error reject" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected text/markdown for valid HTML" >&2
-  exit 1
-}
-echo "  PASS: Valid HTML converts with on_error reject"
+assert_header_contains "Case 1 status" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 1 content-type" "${RAW_DIR}/case1.hdr" "${PATTERN_CT_MARKDOWN}"
+echo "  PASS: Valid HTML converts with on_error reject" >&2
 
 # --- Case 1b: http-level on_error pass inherited ---
-echo "==> Case 1b: http-level on_error pass inherited at location"
+echo "==> Case 1b: http-level on_error pass inherited at location" >&2
 curl -sS -D "${RAW_DIR}/case1b.hdr" -o "${RAW_DIR}/case1b.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/pass/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1b.hdr" || {
-  echo "FAIL: Case 1b - expected 200" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1b.hdr" || {
-  echo "FAIL: Case 1b - expected text/markdown" >&2
-  exit 1
-}
-echo "  PASS: http-level on_error pass inherited correctly"
+assert_header_contains "Case 1b status" "${RAW_DIR}/case1b.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 1b content-type" "${RAW_DIR}/case1b.hdr" "${PATTERN_CT_MARKDOWN}"
+echo "  PASS: http-level on_error pass inherited correctly" >&2
 
 # --- Case 1c: on_error reject + malformed input returns error ---
-echo "==> Case 1c: on_error reject with malformed input"
+echo "==> Case 1c: on_error reject with malformed input" >&2
 curl -sS -D "${RAW_DIR}/case1c.hdr" -o "${RAW_DIR}/case1c.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/reject/malformed" >/dev/null
 REJECT_STATUS="$(head -1 "${RAW_DIR}/case1c.hdr" | awk '{print $2}')"
 if [[ "${REJECT_STATUS}" == "200" ]]; then
-  grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1c.hdr" || {
-    echo "FAIL: Case 1c - on_error reject returned 200 but not markdown (unexpected pass-through)" >&2
-    exit 1
-  }
+  echo "FAIL: Case 1c - on_error reject returned 200 for malformed input (should reject)" >&2
+  exit 1
 fi
-echo "  PASS: on_error reject handles malformed input without markdown conversion"
+echo "  PASS: on_error reject returns non-200 for malformed input (status=${REJECT_STATUS})" >&2
 
 # --- Case 1d: on_error pass + malformed input returns fail-open HTML ---
-echo "==> Case 1d: on_error pass with malformed input (fail-open)"
+echo "==> Case 1d: on_error pass with malformed input (fail-open)" >&2
 curl -sS -D "${RAW_DIR}/case1d.hdr" -o "${RAW_DIR}/case1d.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/pass/malformed" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1d.hdr" || {
-  echo "FAIL: Case 1d - expected 200 for on_error pass with malformed input" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case1d.hdr" || {
-  echo "FAIL: Case 1d - expected text/html fail-open for malformed input with on_error pass" >&2
-  exit 1
-}
-echo "  PASS: on_error pass fail-opens malformed input to HTML"
+assert_header_contains "Case 1d status" "${RAW_DIR}/case1d.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 1d content-type" "${RAW_DIR}/case1d.hdr" "${PATTERN_CT_HTML}"
+echo "  PASS: on_error pass fail-opens malformed input to HTML" >&2
 
 # --- Case 3: markdown_filter off disables conversion ---
-echo "==> Case 3: markdown_filter off disables conversion"
+echo "==> Case 3: markdown_filter off disables conversion" >&2
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/nomd/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected 200" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected text/html when markdown_filter off" >&2
-  exit 1
-}
-echo "  PASS: markdown_filter off preserves HTML"
+assert_header_contains "Case 3 status" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 3 content-type" "${RAW_DIR}/case3.hdr" "${PATTERN_CT_HTML}"
+echo "  PASS: markdown_filter off preserves HTML" >&2
 
 # --- Case 4: on_wildcard off at location overrides server on ---
-echo "==> Case 4: on_wildcard off at location overrides server on"
+echo "==> Case 4: on_wildcard off at location overrides server on" >&2
 curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
   -H 'Accept: */*' --max-time 30 \
   "http://127.0.0.1:${PORT}/no-wildcard/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
-  echo "FAIL: Case 4 - expected 200" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case4.hdr" || {
-  echo "FAIL: Case 4 - expected text/html with on_wildcard off" >&2
-  exit 1
-}
-echo "  PASS: on_wildcard off at location overrides server on"
+assert_header_contains "Case 4 status" "${RAW_DIR}/case4.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 4 content-type" "${RAW_DIR}/case4.hdr" "${PATTERN_CT_HTML}"
+echo "  PASS: on_wildcard off at location overrides server on" >&2
 
 # --- Case 5: etag on at location overrides server off ---
-echo "==> Case 5: etag on at location overrides server off"
+echo "==> Case 5: etag on at location overrides server off" >&2
 curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/etag-on/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case5.hdr" || {
-  echo "FAIL: Case 5 - expected 200" >&2
-  exit 1
-}
+assert_header_contains "Case 5 status" "${RAW_DIR}/case5.hdr" "${PATTERN_HTTP_200}"
 grep -qi '^ETag:' "${RAW_DIR}/case5.hdr" || {
   echo "FAIL: Case 5 - expected ETag header when etag on at location" >&2
   exit 1
 }
-echo "  PASS: ETag present when etag on at location overrides server off"
+echo "  PASS: ETag present when etag on at location overrides server off" >&2
 
 # Verify server-level etag off behavior: the /md/pass/ location inherits server off
 curl -sS -D "${RAW_DIR}/case5b.hdr" -o "${RAW_DIR}/case5b.body" \
@@ -485,10 +518,10 @@ if grep -qi '^ETag:' "${RAW_DIR}/case5b.hdr"; then
   echo "FAIL: Case 5b - ETag present despite server-level etag off being inherited" >&2
   exit 1
 fi
-echo "  PASS: No ETag when server-level etag off inherited"
+echo "  PASS: No ETag when server-level etag off inherited" >&2
 
 # --- Case 6: conditional_requests override at location ---
-echo "==> Case 6: conditional_requests if_modified_since_only at location"
+echo "==> Case 6: conditional_requests if_modified_since_only at location" >&2
 curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H "${ACCEPT_MARKDOWN}" \
   -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
@@ -498,24 +531,18 @@ if ! grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr"; then
   echo "FAIL: Case 6 - expected 304 from if_modified_since_only override" >&2
   exit 1
 fi
-echo "  PASS: If-Modified-Since returns 304 with if_modified_since_only"
+echo "  PASS: If-Modified-Since returns 304 with if_modified_since_only" >&2
 
 # --- Case 7: flavor override at location ---
-echo "==> Case 7: flavor override at location level"
+echo "==> Case 7: flavor override at location level" >&2
 curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/flavor/html" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case7.hdr" || {
-  echo "FAIL: Case 7 - expected 200" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case7.hdr" || {
-  echo "FAIL: Case 7 - expected text/markdown with flavor override" >&2
-  exit 1
-}
-echo "  PASS: flavor override at location level works"
+assert_header_contains "Case 7 status" "${RAW_DIR}/case7.hdr" "${PATTERN_HTTP_200}"
+assert_header_contains "Case 7 content-type" "${RAW_DIR}/case7.hdr" "${PATTERN_CT_MARKDOWN}"
+echo "  PASS: flavor override at location level works" >&2
 
-echo ""
-echo "========================================="
-echo "All config-merge E2E tests passed!"
-echo "========================================="
+echo "" >&2
+echo "=========================================" >&2
+echo "All config-merge E2E tests passed!" >&2
+echo "=========================================" >&2

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E validation for NGINX configuration merging across http/server/location levels.
+#
+# Validates critical config-merge paths:
+#  1) http-level markdown_on_error pass + location-level override reject
+#  2) server-level markdown_max_size 1m + location-level override 10m
+#  3) markdown_filter off location disables conversion despite Accept header
+#  4) markdown_on_wildcard on at server + off at location
+#  5) markdown_etag off at server + on at location (location wins)
+#  6) markdown_conditional_requests none at server + if_modified_since_only at location
+#  7) markdown_flavor override at location level
+#  8) markdown_streaming_engine off at server + on at location
+
+NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
+PORT="${PORT:-18101}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-19101}"
+KEEP_ARTIFACTS=0
+NGINX_BIN="${NGINX_BIN:-}"
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NATIVE_BUILD_HELPER="${WORKSPACE_ROOT}/tools/lib/nginx_markdown_native_build.sh"
+BUILDROOT=""
+RUNTIME=""
+RUST_TARGET=""
+NGINX_EXECUTABLE=""
+LOAD_MODULE_LINE=""
+UPSTREAM_PID=""
+ORIG_ARGS=("$@")
+
+readonly ACCEPT_MARKDOWN='Accept: text/markdown'
+readonly PATTERN_HTTP_200='HTTP/1.1 200'
+readonly PATTERN_CT_MARKDOWN='^Content-Type: text/markdown'
+readonly PATTERN_CT_HTML='^Content-Type: text/html'
+
+# shellcheck source=tools/lib/nginx_markdown_native_build.sh
+source "${NATIVE_BUILD_HELPER}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+
+Build local NGINX with the markdown module and run config-merge E2E checks.
+
+Checks:
+  1) http-level on_error pass + location-level reject override
+  2) server-level max_size 1m + location-level 10m override
+  3) markdown_filter off disables conversion
+  4) on_wildcard on at server + off at location
+  5) etag off at server + on at location
+  6) conditional_requests none + if_modified_since_only override
+  7) markdown_flavor override at location
+  8) streaming_engine off + on override
+
+Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
+EOF
+  return 0
+}
+
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${RUNTIME}" && -n "${NGINX_EXECUTABLE}" && -x "${NGINX_EXECUTABLE}" ]]; then
+    "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf -s stop >/dev/null 2>&1 || true
+  fi
+
+  if [[ $rc -eq 0 && "${KEEP_ARTIFACTS}" -eq 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    rm -rf "${BUILDROOT}" || true
+  fi
+
+  if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    echo "Config-merge E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
+  elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
+    echo "Config-merge E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --nginx-version)
+      require_flag_value "$1" "${2:-}"
+      NGINX_VERSION="$2"
+      shift 2
+      ;;
+    --port)
+      require_flag_value "$1" "${2:-}"
+      PORT="$2"
+      shift 2
+      ;;
+    --upstream-port)
+      require_flag_value "$1" "${2:-}"
+      UPSTREAM_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#ORIG_ARGS[@]} )); then
+  markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"
+else
+  markdown_ensure_native_apple_silicon "$0"
+fi
+
+for cmd in curl python3 grep; do
+  markdown_need_cmd "$cmd"
+done
+if [[ -z "${NGINX_BIN}" ]]; then
+  for cmd in tar make cargo; do
+    markdown_need_cmd "$cmd"
+  done
+fi
+
+RUST_TARGET="$(markdown_detect_rust_target)"
+BUILDROOT="$(mktemp -d /tmp/nginx-config-merge-e2e.XXXXXX)"
+RUNTIME="${BUILDROOT}/runtime"
+RAW_DIR="${BUILDROOT}/raw"
+UPSTREAM_SCRIPT="${BUILDROOT}/config_merge_upstream.py"
+mkdir -p "${RAW_DIR}"
+
+# --- Upstream server ---
+cat > "${UPSTREAM_SCRIPT}" <<'PY'
+#!/usr/bin/env python3
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+HTML_BODY = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>Config Merge Test</title></head>
+<body><h1>Config Merge Test Page</h1><p>Testing configuration merging.</p></body></html>
+"""
+
+LARGE_HTML_START = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>Large</title></head>
+<body>
+"""
+LARGE_HTML_END = b"""</body></html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args):
+        return
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            body = b"ok\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_BODY)))
+            self.end_headers()
+            self.wfile.write(HTML_BODY)
+            return
+        if path == "/large":
+            body = LARGE_HTML_START + b"<p>x</p>\n" * 100000 + LARGE_HTML_END
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19101)
+    args = parser.parse_args()
+    if args.serve:
+        server = ThreadingHTTPServer((args.host, args.port), Handler)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+chmod +x "${UPSTREAM_SCRIPT}"
+
+# --- Build or reuse NGINX ---
+echo "==> Host architecture: $(uname -m)"
+if [[ -n "${NGINX_BIN}" ]]; then
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
+  NGINX_EXECUTABLE="${NGINX_BIN}"
+else
+  echo "==> Building Rust converter (${RUST_TARGET})"
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
+
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
+  mkdir -p "${BUILDROOT}/src"
+  tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
+  (
+    cd "${BUILDROOT}/src"
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+    make install >/dev/null
+  )
+  NGINX_EXECUTABLE="${RUNTIME}/sbin/nginx"
+fi
+
+mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
+
+# --- Start upstream ---
+echo "==> Starting config-merge upstream on 127.0.0.1:${UPSTREAM_PORT}"
+python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
+
+# --- NGINX config with multiple merge scenarios ---
+cat > "${RUNTIME}/conf/nginx.conf" <<EOF
+${LOAD_MODULE_LINE}worker_processes 1;
+error_log logs/error.log info;
+pid logs/nginx.pid;
+
+events { worker_connections 512; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 5;
+
+    # http-level defaults
+    markdown_on_error pass;
+
+    server {
+        listen 127.0.0.1:${PORT};
+        server_name localhost;
+
+        # server-level settings
+        markdown_on_wildcard on;
+        markdown_etag off;
+        markdown_conditional_requests none;
+        markdown_max_size 1m;
+        markdown_streaming_engine off;
+
+        # Case 1: location overrides on_error to reject
+        location /md/reject/ {
+            markdown_filter on;
+            markdown_on_error reject;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 1b: location inherits on_error pass from http level
+        location /md/pass/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 3: markdown_filter off disables conversion
+        location /nomd/ {
+            markdown_filter off;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 4: on_wildcard off at location
+        location /no-wildcard/ {
+            markdown_filter on;
+            markdown_on_wildcard off;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 5: etag on at location overrides server off
+        location /etag-on/ {
+            markdown_filter on;
+            markdown_etag on;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 6: conditional_requests override at location
+        location /cond-ims/ {
+            markdown_filter on;
+            markdown_conditional_requests if_modified_since_only;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+
+        # Case 7: flavor override at location
+        location /flavor/ {
+            markdown_filter on;
+            markdown_flavor github;
+            markdown_max_size 10m;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+    }
+}
+EOF
+
+echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+"${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/pass/html" "NGINX on ${PORT}" || exit 1
+
+# --- Case 1: location-level on_error reject overrides http-level pass ---
+echo "==> Case 1: location-level on_error reject overrides http-level pass"
+# With reject, a malformed response should return an error, not pass-through
+curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/reject/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected 200 for valid HTML with on_error reject" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected text/markdown for valid HTML" >&2
+  exit 1
+}
+echo "  PASS: Valid HTML converts with on_error reject"
+
+# --- Case 1b: http-level on_error pass inherited ---
+echo "==> Case 1b: http-level on_error pass inherited at location"
+curl -sS -D "${RAW_DIR}/case1b.hdr" -o "${RAW_DIR}/case1b.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/pass/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1b.hdr" || {
+  echo "FAIL: Case 1b - expected 200" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1b.hdr" || {
+  echo "FAIL: Case 1b - expected text/markdown" >&2
+  exit 1
+}
+echo "  PASS: http-level on_error pass inherited correctly"
+
+# --- Case 3: markdown_filter off disables conversion ---
+echo "==> Case 3: markdown_filter off disables conversion"
+curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/nomd/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected 200" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected text/html when markdown_filter off" >&2
+  exit 1
+}
+echo "  PASS: markdown_filter off preserves HTML"
+
+# --- Case 4: on_wildcard off at location overrides server on ---
+echo "==> Case 4: on_wildcard off at location overrides server on"
+curl -sS -D "${RAW_DIR}/case4.hdr" -o "${RAW_DIR}/case4.body" \
+  -H 'Accept: */*' --max-time 30 \
+  "http://127.0.0.1:${PORT}/no-wildcard/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case4.hdr" || {
+  echo "FAIL: Case 4 - expected 200" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case4.hdr" || {
+  echo "FAIL: Case 4 - expected text/html with on_wildcard off" >&2
+  exit 1
+}
+echo "  PASS: on_wildcard off at location overrides server on"
+
+# --- Case 5: etag on at location overrides server off ---
+echo "==> Case 5: etag on at location overrides server off"
+curl -sS -D "${RAW_DIR}/case5.hdr" -o "${RAW_DIR}/case5.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/etag-on/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case5.hdr" || {
+  echo "FAIL: Case 5 - expected 200" >&2
+  exit 1
+}
+grep -qi '^ETag:' "${RAW_DIR}/case5.hdr" || {
+  echo "FAIL: Case 5 - expected ETag header when etag on at location" >&2
+  exit 1
+}
+echo "  PASS: ETag present when etag on at location overrides server off"
+
+# Verify server-level etag off behavior: the /md/pass/ location inherits server off
+curl -sS -D "${RAW_DIR}/case5b.hdr" -o "${RAW_DIR}/case5b.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/pass/html" >/dev/null
+grep -qi '^ETag:' "${RAW_DIR}/case5b.hdr" && {
+  echo "INFO: Case 5b - ETag found in server-level etag off path (may be default behavior)" >&2
+} || {
+  echo "  PASS: No ETag when server-level etag off inherited (as expected)"
+}
+
+# --- Case 6: conditional_requests override at location ---
+echo "==> Case 6: conditional_requests if_modified_since_only at location"
+curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
+  -H "${ACCEPT_MARKDOWN}" \
+  -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
+  --max-time 30 \
+  "http://127.0.0.1:${PORT}/cond-ims/html" >/dev/null
+grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr" || {
+  echo "INFO: Case 6 - 304 not returned for IMS; conditional_requests override may not be active" >&2
+  echo "  PASS (soft): conditional_requests override at location tested"
+}
+grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr" && {
+  echo "  PASS: If-Modified-Since returns 304 with if_modified_since_only"
+}
+
+# --- Case 7: flavor override at location ---
+echo "==> Case 7: flavor override at location level"
+curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/flavor/html" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case7.hdr" || {
+  echo "FAIL: Case 7 - expected 200" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case7.hdr" || {
+  echo "FAIL: Case 7 - expected text/markdown with flavor override" >&2
+  exit 1
+}
+echo "  PASS: flavor override at location level works"
+
+echo ""
+echo "========================================="
+echo "All config-merge E2E tests passed!"
+echo "========================================="

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -5,13 +5,11 @@ set -euo pipefail
 #
 # Validates critical config-merge paths:
 #  1) http-level markdown_on_error pass + location-level override reject
-#  2) server-level markdown_max_size 1m + location-level override 10m
-#  3) markdown_filter off location disables conversion despite Accept header
-#  4) markdown_on_wildcard on at server + off at location
-#  5) markdown_etag off at server + on at location (location wins)
-#  6) markdown_conditional_requests none at server + if_modified_since_only at location
-#  7) markdown_flavor override at location level
-#  8) markdown_streaming_engine off at server + on at location
+#  2) markdown_filter off location disables conversion despite Accept header
+#  3) markdown_on_wildcard on at server + off at location
+#  4) markdown_etag off at server + on at location (location wins)
+#  5) markdown_conditional_requests none at server + if_modified_since_only at location
+#  6) markdown_flavor override at location level
 
 NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
 PORT="${PORT:-18101}"

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -157,6 +157,14 @@ LARGE_HTML_START = b"""<!doctype html>
 LARGE_HTML_END = b"""</body></html>
 """
 
+MALFORMED_HTML = b"""<html><head><title>Bad
+<body><h1>Unclosed heading
+<div><div><div>nested without closing
+<p>paragraph without closing
+<a href="link without quote>text</a>
+</html>
+"""
+
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -187,6 +195,13 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+            return
+        if path == "/malformed":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(MALFORMED_HTML)))
+            self.end_headers()
+            self.wfile.write(MALFORMED_HTML)
             return
         self.send_response(404)
         self.send_header("Content-Length", "0")
@@ -387,6 +402,35 @@ grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1b.hdr" || {
   exit 1
 }
 echo "  PASS: http-level on_error pass inherited correctly"
+
+# --- Case 1c: on_error reject + malformed input returns error ---
+echo "==> Case 1c: on_error reject with malformed input"
+curl -sS -D "${RAW_DIR}/case1c.hdr" -o "${RAW_DIR}/case1c.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/reject/malformed" >/dev/null
+REJECT_STATUS="$(head -1 "${RAW_DIR}/case1c.hdr" | awk '{print $2}')"
+if [[ "${REJECT_STATUS}" == "200" ]]; then
+  grep -qi "${PATTERN_CT_MARKDOWN}" "${RAW_DIR}/case1c.hdr" || {
+    echo "FAIL: Case 1c - on_error reject returned 200 but not markdown (unexpected pass-through)" >&2
+    exit 1
+  }
+fi
+echo "  PASS: on_error reject handles malformed input without markdown conversion"
+
+# --- Case 1d: on_error pass + malformed input returns fail-open HTML ---
+echo "==> Case 1d: on_error pass with malformed input (fail-open)"
+curl -sS -D "${RAW_DIR}/case1d.hdr" -o "${RAW_DIR}/case1d.body" \
+  -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/pass/malformed" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1d.hdr" || {
+  echo "FAIL: Case 1d - expected 200 for on_error pass with malformed input" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_HTML}" "${RAW_DIR}/case1d.hdr" || {
+  echo "FAIL: Case 1d - expected text/html fail-open for malformed input with on_error pass" >&2
+  exit 1
+}
+echo "  PASS: on_error pass fail-opens malformed input to HTML"
 
 # --- Case 3: markdown_filter off disables conversion ---
 echo "==> Case 3: markdown_filter off disables conversion"

--- a/tools/e2e/verify_config_merge_e2e.sh
+++ b/tools/e2e/verify_config_merge_e2e.sh
@@ -44,28 +44,14 @@ Build local NGINX with the markdown module and run config-merge E2E checks.
 
 Checks:
   1) http-level on_error pass + location-level reject override
-  2) server-level max_size 1m + location-level 10m override
-  3) markdown_filter off disables conversion
-  4) on_wildcard on at server + off at location
-  5) etag off at server + on at location
-  6) conditional_requests none + if_modified_since_only override
-  7) markdown_flavor override at location
-  8) streaming_engine off + on override
+  2) markdown_filter off disables conversion
+  3) on_wildcard on at server + off at location
+  4) etag off at server + on at location
+  5) conditional_requests none + if_modified_since_only override
+  6) markdown_flavor override at location
 
 Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
 EOF
-  return 0
-}
-
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
   return 0
 }
 
@@ -100,17 +86,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
@@ -167,7 +153,6 @@ LARGE_HTML_START = b"""<!doctype html>
 LARGE_HTML_END = b"""</body></html>
 """
 
-
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -203,7 +188,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -213,7 +197,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()
@@ -282,8 +265,6 @@ http {
         markdown_on_wildcard on;
         markdown_etag off;
         markdown_conditional_requests none;
-        markdown_max_size 1m;
-        markdown_streaming_engine off;
 
         # Case 1: location overrides on_error to reject
         location /md/reject/ {
@@ -452,11 +433,11 @@ echo "  PASS: ETag present when etag on at location overrides server off"
 curl -sS -D "${RAW_DIR}/case5b.hdr" -o "${RAW_DIR}/case5b.body" \
   -H "${ACCEPT_MARKDOWN}" --max-time 30 \
   "http://127.0.0.1:${PORT}/md/pass/html" >/dev/null
-grep -qi '^ETag:' "${RAW_DIR}/case5b.hdr" && {
-  echo "INFO: Case 5b - ETag found in server-level etag off path (may be default behavior)" >&2
-} || {
-  echo "  PASS: No ETag when server-level etag off inherited (as expected)"
-}
+if grep -qi '^ETag:' "${RAW_DIR}/case5b.hdr"; then
+  echo "FAIL: Case 5b - ETag present despite server-level etag off being inherited" >&2
+  exit 1
+fi
+echo "  PASS: No ETag when server-level etag off inherited"
 
 # --- Case 6: conditional_requests override at location ---
 echo "==> Case 6: conditional_requests if_modified_since_only at location"
@@ -465,13 +446,11 @@ curl -sS -D "${RAW_DIR}/case6.hdr" -o "${RAW_DIR}/case6.body" \
   -H 'If-Modified-Since: Mon, 01 Jan 2030 00:00:00 GMT' \
   --max-time 30 \
   "http://127.0.0.1:${PORT}/cond-ims/html" >/dev/null
-grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr" || {
-  echo "INFO: Case 6 - 304 not returned for IMS; conditional_requests override may not be active" >&2
-  echo "  PASS (soft): conditional_requests override at location tested"
-}
-grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr" && {
-  echo "  PASS: If-Modified-Since returns 304 with if_modified_since_only"
-}
+if ! grep -qi 'HTTP/1.1 304' "${RAW_DIR}/case6.hdr"; then
+  echo "FAIL: Case 6 - expected 304 from if_modified_since_only override" >&2
+  exit 1
+fi
+echo "  PASS: If-Modified-Since returns 304 with if_modified_since_only"
 
 # --- Case 7: flavor override at location ---
 echo "==> Case 7: flavor override at location level"

--- a/tools/e2e/verify_error_handling_e2e.sh
+++ b/tools/e2e/verify_error_handling_e2e.sh
@@ -52,15 +52,6 @@ EOF
 }
 
 #
-# Require that an option flag was followed by a non-empty value.
-# Arguments:
-#   $1: flag name used in diagnostics.
-#   $2: flag value to validate.
-# Output: writes diagnostics and usage to stderr on failure.
-# Exit: exits with status 2 when the value is missing; returns 0 otherwise.
-#
-
-#
 # Stop child services and remove temporary artifacts when appropriate.
 # Arguments: none.
 # Output: writes failure artifact diagnostics to stderr.
@@ -85,32 +76,6 @@ cleanup() {
   return 0
 }
 trap cleanup EXIT
-
-#
-# Poll an HTTP endpoint until it becomes reachable.
-# Arguments:
-#   $1: URL to poll for readiness.
-#   $2: label for failure diagnostics.
-# Output: writes timeout diagnostics and curl output to stderr on failure.
-# Exit: returns 0 when the endpoint responds; returns 1 after timeout.
-#
-wait_for_http() {
-  local url="$1"
-  local label="$2"
-  local curl_output=""
-  for _ in $(seq 1 50); do
-    if curl -sS --max-time 1 "$url" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 0.1
-  done
-  curl_output=$(curl -sS --max-time 2 "$url" 2>&1 || true)
-  echo "${label} failed to become ready after 5s" >&2
-  if [[ -n "${curl_output}" ]]; then
-    echo "curl output: ${curl_output}" >&2
-  fi
-  return 1
-}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -303,8 +268,8 @@ mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
 echo "==> Starting error-handling upstream on 127.0.0.1:${UPSTREAM_PORT}" >&2
 python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
 UPSTREAM_PID=$!
-wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" \
-  "Upstream on ${UPSTREAM_PORT}"
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" \
+  "Upstream on ${UPSTREAM_PORT}" || exit 1
 
 cat > "${RUNTIME}/conf/nginx.conf" <<EOF
 ${LOAD_MODULE_LINE}worker_processes 1;
@@ -364,8 +329,8 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}" >&2
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-wait_for_http "http://127.0.0.1:${PORT}/md/valid" \
-  "NGINX on ${PORT}"
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/valid" \
+  "NGINX on ${PORT}" || exit 1
 
 # --- Case 1: Valid HTML converts successfully ---
 echo "==> Case 1: Valid HTML converts successfully" >&2

--- a/tools/e2e/verify_error_handling_e2e.sh
+++ b/tools/e2e/verify_error_handling_e2e.sh
@@ -59,15 +59,6 @@ EOF
 # Output: writes diagnostics and usage to stderr on failure.
 # Exit: exits with status 2 when the value is missing; returns 0 otherwise.
 #
-require_flag_value() {
-  local flag_name="$1"
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-  return 0
-}
 
 #
 # Stop child services and remove temporary artifacts when appropriate.
@@ -124,9 +115,9 @@ wait_for_http() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --keep-artifacts) KEEP_ARTIFACTS=1; shift ;;
-    --nginx-version)  require_flag_value "$1" "${2-}"; NGINX_VERSION="$2"; shift 2 ;;
-    --port)           require_flag_value "$1" "${2-}"; PORT="$2"; shift 2 ;;
-    --upstream-port)  require_flag_value "$1" "${2-}"; UPSTREAM_PORT="$2"; shift 2 ;;
+    --nginx-version)  markdown_require_flag_value "$1" "${2-}"; NGINX_VERSION="$2"; shift 2 ;;
+    --port)           markdown_require_flag_value "$1" "${2-}"; PORT="$2"; shift 2 ;;
+    --upstream-port)  markdown_require_flag_value "$1" "${2-}"; UPSTREAM_PORT="$2"; shift 2 ;;
     -h|--help)        usage; exit 0 ;;
     *)                echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -183,7 +174,6 @@ EMPTY_BODY = b""
 SMALL_HTML = b"""<html><head><title>Small</title></head>
 <body><h1>Small Page</h1><p>Content.</p></body></html>
 """
-
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -265,7 +255,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -275,7 +264,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()

--- a/tools/e2e/verify_huge_body_allowed_native_e2e.sh
+++ b/tools/e2e/verify_huge_body_allowed_native_e2e.sh
@@ -31,6 +31,18 @@ ORIG_ARGS=("$@")
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--skip-1g-get] [--markdown-max-size SIZE]
@@ -78,10 +90,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
+      require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
+      require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
@@ -90,6 +104,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --markdown-max-size)
+      require_flag_value "$1" "${2:-}"
       MARKDOWN_MAX_SIZE="$2"
       shift 2
       ;;
@@ -211,7 +226,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/html/full/allowed-100m.html" "NGINX" || exit 1
 
 check_head_markdown() {
   local name="$1"

--- a/tools/e2e/verify_huge_body_allowed_native_e2e.sh
+++ b/tools/e2e/verify_huge_body_allowed_native_e2e.sh
@@ -31,18 +31,6 @@ ORIG_ARGS=("$@")
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--skip-1g-get] [--markdown-max-size SIZE]
@@ -90,12 +78,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
@@ -104,7 +92,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --markdown-max-size)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       MARKDOWN_MAX_SIZE="$2"
       shift 2
       ;;
@@ -226,7 +214,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-markdown_wait_for_http "http://127.0.0.1:${PORT}/html/full/allowed-100m.html" "NGINX" || exit 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/allow/convert-100m.html" "NGINX" || exit 1
 
 check_head_markdown() {
   local name="$1"

--- a/tools/e2e/verify_huge_body_native_e2e.sh
+++ b/tools/e2e/verify_huge_body_native_e2e.sh
@@ -187,7 +187,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/html/full/huge-100m.html" "NGINX" || exit 1
 
 check_head() {
   local name="$1" expected_bytes="$2"

--- a/tools/e2e/verify_huge_body_native_e2e.sh
+++ b/tools/e2e/verify_huge_body_native_e2e.sh
@@ -41,18 +41,6 @@ EOF
   return 0
 }
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 cleanup() {
   local rc=$?
 
@@ -80,12 +68,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       PORT="$2"
       shift 2
       ;;
@@ -187,7 +175,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-markdown_wait_for_http "http://127.0.0.1:${PORT}/html/full/huge-100m.html" "NGINX" || exit 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/full/huge-100m.html" "NGINX" || exit 1
 
 check_head() {
   local name="$1" expected_bytes="$2"

--- a/tools/e2e/verify_large_markdown_response_e2e.sh
+++ b/tools/e2e/verify_large_markdown_response_e2e.sh
@@ -204,7 +204,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/passthrough/large.html" "NGINX" || exit 1
 
 echo "==> Validating large passthrough + markdown responses"
 pt_code="$(curl -sS -D "${RAW_DIR}/passthrough_large.hdr" -o "${RAW_DIR}/passthrough_large.body" \

--- a/tools/e2e/verify_large_markdown_response_e2e.sh
+++ b/tools/e2e/verify_large_markdown_response_e2e.sh
@@ -35,18 +35,6 @@ EOF
   return 0
 }
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 cleanup() {
   local rc=$?
 
@@ -74,12 +62,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2-}"
+      markdown_require_flag_value "$1" "${2-}"
       PORT="$2"
       shift 2
       ;;

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -38,6 +38,9 @@ readonly PATTERN_CT_PROMETHEUS='Content-Type: text/plain.*version=0\.0\.4'
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+#
+# Print command-line usage for this E2E script.
+#
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--metrics-port PORT]
@@ -59,6 +62,9 @@ EOF
   return 0
 }
 
+#
+# Trap handler: stop NGINX, then optionally remove build artifacts.
+#
 cleanup() {
   local rc=$?
 

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -271,9 +271,17 @@ grep -qi "${PATTERN_CT_PROMETHEUS}" "${RAW_DIR}/case3.hdr" || {
 echo "  PASS: Prometheus format returned"
 
 # --- Case 4: Non-empty metrics body ---
-echo "==> Case 4: Metrics endpoint returns non-empty body"
+echo "==> Case 4: Metrics endpoint returns non-empty body for all formats"
 [[ -s "${RAW_DIR}/case1.body" ]] || {
   echo "FAIL: Case 4 - JSON metrics body is empty" >&2
+  exit 1
+}
+[[ -s "${RAW_DIR}/case2.body" ]] || {
+  echo "FAIL: Case 4 - plain-text metrics body is empty" >&2
+  exit 1
+}
+[[ -s "${RAW_DIR}/case3.body" ]] || {
+  echo "FAIL: Case 4 - Prometheus metrics body is empty" >&2
   exit 1
 }
 echo "  PASS: All format bodies are non-empty"

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -33,7 +33,7 @@ readonly ACCEPT_PROMETHEUS='Accept: text/plain'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
 readonly PATTERN_CT_JSON='Content-Type: application/json'
 readonly PATTERN_CT_TEXT='Content-Type: text/plain'
-readonly PATTERN_CT_PROMETHEUS='Content-Type: text/plain.*version=0.0.4'
+readonly PATTERN_CT_PROMETHEUS='Content-Type: text/plain.*version=0\.0\.4'
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
@@ -225,14 +225,8 @@ echo "==> Case 1: JSON format via Accept: application/json"
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_JSON}" --max-time 30 \
   "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected HTTP 200 for JSON metrics" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_JSON}" "${RAW_DIR}/case1.hdr" || {
-  echo "FAIL: Case 1 - expected application/json Content-Type" >&2
-  exit 1
-}
+markdown_expect_status "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
+markdown_expect_header "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_CT_JSON}"
 METRICS_BODY="${RAW_DIR}/case1.body" python3 -c '
 import json, os, sys
 json.load(open(os.environ["METRICS_BODY"]))
@@ -247,14 +241,8 @@ echo "==> Case 2: Plain-text format (default)"
 curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
   --max-time 30 \
   "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case2.hdr" || {
-  echo "FAIL: Case 2 - expected HTTP 200 for plain-text metrics" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_TEXT}" "${RAW_DIR}/case2.hdr" || {
-  echo "FAIL: Case 2 - expected text/plain Content-Type" >&2
-  exit 1
-}
+markdown_expect_status "Case 2" "${RAW_DIR}/case2.hdr" "${PATTERN_HTTP_200}"
+markdown_expect_header "Case 2" "${RAW_DIR}/case2.hdr" "${PATTERN_CT_TEXT}"
 [[ -s "${RAW_DIR}/case2.body" ]] || {
   echo "FAIL: Case 2 - plain-text metrics body is empty" >&2
   exit 1
@@ -266,10 +254,7 @@ echo "==> Case 3: Prometheus exposition format"
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_PROMETHEUS}" --max-time 30 \
   "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
-  echo "FAIL: Case 3 - expected HTTP 200 for Prometheus metrics" >&2
-  exit 1
-}
+markdown_expect_status "Case 3" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_PROMETHEUS}" "${RAW_DIR}/case3.hdr" || {
   echo "INFO: Case 3 - Prometheus Content-Type variant not matched; checking body format as fallback" >&2
   grep -qi "^# HELP" "${RAW_DIR}/case3.body" || {
@@ -343,14 +328,8 @@ echo "==> Case 8: Invalid Accept header falls back to plain-text"
 curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
   -H 'Accept: application/xml' --max-time 30 \
   "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
-grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case8.hdr" || {
-  echo "FAIL: Case 8 - expected HTTP 200 for unknown Accept" >&2
-  exit 1
-}
-grep -qi "${PATTERN_CT_TEXT}" "${RAW_DIR}/case8.hdr" || {
-  echo "FAIL: Case 8 - expected text/plain fallback for unknown Accept" >&2
-  exit 1
-}
+markdown_expect_status "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_HTTP_200}"
+markdown_expect_header "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_CT_TEXT}"
 echo "  PASS: Unknown Accept returns plain-text fallback"
 
 echo ""

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -31,9 +31,9 @@ readonly ACCEPT_MARKDOWN='Accept: text/markdown'
 readonly ACCEPT_JSON='Accept: application/json'
 readonly ACCEPT_PROMETHEUS='Accept: text/plain'
 readonly PATTERN_HTTP_200='HTTP/1.1 200'
-readonly PATTERN_CT_JSON='^Content-Type: application/json'
-readonly PATTERN_CT_TEXT='^Content-Type: text/plain'
-readonly PATTERN_CT_PROMETHEUS='^Content-Type: text/plain; version=0.0.4'
+readonly PATTERN_CT_JSON='Content-Type: application/json'
+readonly PATTERN_CT_TEXT='Content-Type: text/plain'
+readonly PATTERN_CT_PROMETHEUS='Content-Type: text/plain.*version=0.0.4'
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
@@ -56,18 +56,6 @@ Checks:
 
 Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
 EOF
-  return 0
-}
-
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
   return 0
 }
 
@@ -98,17 +86,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --metrics-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       METRICS_PORT="$2"
       shift 2
       ;;
@@ -245,7 +233,10 @@ grep -qi "${PATTERN_CT_JSON}" "${RAW_DIR}/case1.hdr" || {
   echo "FAIL: Case 1 - expected application/json Content-Type" >&2
   exit 1
 }
-python3 -c "import json,sys; json.load(open('${RAW_DIR}/case1.body'))" || {
+METRICS_BODY="${RAW_DIR}/case1.body" python3 -c '
+import json, os, sys
+json.load(open(os.environ["METRICS_BODY"]))
+' || {
   echo "FAIL: Case 1 - metrics body is not valid JSON" >&2
   exit 1
 }
@@ -298,16 +289,16 @@ echo "  PASS: All format bodies are non-empty"
 
 # --- Case 5: JSON metrics contain required top-level keys ---
 echo "==> Case 5: JSON metrics contain required top-level keys"
-python3 -c "
-import json, sys
-data = json.load(open('${RAW_DIR}/case1.body'))
-required = ['total_requests', 'converted_total', 'skipped_total']
+METRICS_BODY="${RAW_DIR}/case1.body" python3 -c '
+import json, os, sys
+data = json.load(open(os.environ["METRICS_BODY"]))
+required = ["total_requests", "converted_total", "skipped_total"]
 missing = [k for k in required if k not in data]
 if missing:
-    print(f'FAIL: missing keys: {missing}', file=sys.stderr)
+    print(f"FAIL: missing keys: {missing}", file=sys.stderr)
     sys.exit(1)
-print('  PASS: JSON contains required top-level keys')
-" || exit 1
+print("  PASS: JSON contains required top-level keys")
+' || exit 1
 
 # --- Case 6: Prometheus metrics contain expected metric family prefixes ---
 echo "==> Case 6: Prometheus metrics contain expected metric family prefixes"
@@ -333,19 +324,19 @@ curl -sS -o /dev/null -H "${ACCEPT_MARKDOWN}" --max-time 30 \
 curl -sS -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_JSON}" --max-time 30 \
   "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
-python3 -c "
-import json, sys
-data = json.load(open('${RAW_DIR}/case7.body'))
-total = data.get('total_requests', 0)
-converted = data.get('converted_total', 0)
+METRICS_BODY="${RAW_DIR}/case7.body" python3 -c '
+import json, os, sys
+data = json.load(open(os.environ["METRICS_BODY"]))
+total = data.get("total_requests", 0)
+converted = data.get("converted_total", 0)
 if total < 1:
-    print(f'FAIL: total_requests is {total}, expected >= 1', file=sys.stderr)
+    print(f"FAIL: total_requests is {total}, expected >= 1", file=sys.stderr)
     sys.exit(1)
 if converted < 1:
-    print(f'FAIL: converted_total is {converted}, expected >= 1', file=sys.stderr)
+    print(f"FAIL: converted_total is {converted}, expected >= 1", file=sys.stderr)
     sys.exit(1)
-print(f'  PASS: total_requests={total}, converted_total={converted} (non-zero)')
-" || exit 1
+print(f"  PASS: total_requests={total}, converted_total={converted} (non-zero)")
+' || exit 1
 
 # --- Case 8: Invalid Accept header returns plain-text fallback ---
 echo "==> Case 8: Invalid Accept header falls back to plain-text"

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E validation for the markdown metrics endpoint.
+#
+# Validates critical metrics-endpoint paths:
+#  1) JSON format via Accept: application/json
+#  2) Plain-text format (default, no Accept override)
+#  3) Prometheus format via Accept: text/plain (Prometheus convention)
+#  4) Metrics endpoint returns 200 with non-empty body
+#  5) JSON metrics contain required top-level keys
+#  6) Prometheus metrics contain expected metric family prefixes
+#  7) After a conversion, request counters are non-zero
+#  8) Invalid Accept header returns plain-text fallback
+
+NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
+PORT="${PORT:-18097}"
+METRICS_PORT="${METRICS_PORT:-18098}"
+KEEP_ARTIFACTS=0
+NGINX_BIN="${NGINX_BIN:-}"
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NATIVE_BUILD_HELPER="${WORKSPACE_ROOT}/tools/lib/nginx_markdown_native_build.sh"
+BUILDROOT=""
+RUNTIME=""
+RUST_TARGET=""
+NGINX_EXECUTABLE=""
+LOAD_MODULE_LINE=""
+ORIG_ARGS=("$@")
+
+readonly ACCEPT_MARKDOWN='Accept: text/markdown'
+readonly ACCEPT_JSON='Accept: application/json'
+readonly ACCEPT_PROMETHEUS='Accept: text/plain'
+readonly PATTERN_HTTP_200='HTTP/1.1 200'
+readonly PATTERN_CT_JSON='^Content-Type: application/json'
+readonly PATTERN_CT_TEXT='^Content-Type: text/plain'
+readonly PATTERN_CT_PROMETHEUS='^Content-Type: text/plain; version=0.0.4'
+
+# shellcheck source=tools/lib/nginx_markdown_native_build.sh
+source "${NATIVE_BUILD_HELPER}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--metrics-port PORT]
+
+Build local NGINX with the markdown module and run metrics-endpoint E2E checks.
+
+Checks:
+  1) JSON format via Accept: application/json
+  2) Plain-text format (default)
+  3) Prometheus exposition format
+  4) Non-empty metrics body
+  5) JSON metrics contain required keys
+  6) Prometheus metrics contain expected prefixes
+  7) Counters non-zero after conversion
+  8) Invalid Accept falls back to plain-text
+
+Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
+EOF
+  return 0
+}
+
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${RUNTIME}" && -n "${NGINX_EXECUTABLE}" && -x "${NGINX_EXECUTABLE}" ]]; then
+    "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf -s stop >/dev/null 2>&1 || true
+  fi
+
+  if [[ $rc -eq 0 && "${KEEP_ARTIFACTS}" -eq 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    rm -rf "${BUILDROOT}" || true
+  fi
+
+  if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    echo "Metrics-endpoint E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
+  elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
+    echo "Metrics-endpoint E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --nginx-version)
+      require_flag_value "$1" "${2:-}"
+      NGINX_VERSION="$2"
+      shift 2
+      ;;
+    --port)
+      require_flag_value "$1" "${2:-}"
+      PORT="$2"
+      shift 2
+      ;;
+    --metrics-port)
+      require_flag_value "$1" "${2:-}"
+      METRICS_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#ORIG_ARGS[@]} )); then
+  markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"
+else
+  markdown_ensure_native_apple_silicon "$0"
+fi
+
+for cmd in curl python3 grep; do
+  markdown_need_cmd "$cmd"
+done
+if [[ -z "${NGINX_BIN}" ]]; then
+  for cmd in tar make cargo; do
+    markdown_need_cmd "$cmd"
+  done
+fi
+
+RUST_TARGET="$(markdown_detect_rust_target)"
+BUILDROOT="$(mktemp -d /tmp/nginx-metrics-e2e.XXXXXX)"
+RUNTIME="${BUILDROOT}/runtime"
+RAW_DIR="${BUILDROOT}/raw"
+mkdir -p "${RAW_DIR}"
+
+# --- Build or reuse NGINX ---
+echo "==> Host architecture: $(uname -m)"
+if [[ -n "${NGINX_BIN}" ]]; then
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
+  NGINX_EXECUTABLE="${NGINX_BIN}"
+else
+  echo "==> Building Rust converter (${RUST_TARGET})"
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
+
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
+  mkdir -p "${BUILDROOT}/src"
+  tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
+  (
+    cd "${BUILDROOT}/src"
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+    make install >/dev/null
+  )
+  NGINX_EXECUTABLE="${RUNTIME}/sbin/nginx"
+fi
+
+mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs" "${RUNTIME}/html"
+
+# --- Create a simple HTML page for conversion ---
+cat > "${RUNTIME}/html/test.html" <<'HTMLEOF'
+<!doctype html>
+<html><head><meta charset="UTF-8"><title>Metrics Test</title></head>
+<body><h1>Metrics Test Page</h1><p>Content for metrics counting.</p></body></html>
+HTMLEOF
+
+# --- NGINX config with metrics endpoint ---
+cat > "${RUNTIME}/conf/nginx.conf" <<EOF
+${LOAD_MODULE_LINE}worker_processes 1;
+error_log logs/error.log info;
+pid logs/nginx.pid;
+
+events { worker_connections 512; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 5;
+
+    markdown_metrics on;
+    markdown_metrics_format text;
+
+    server {
+        listen 127.0.0.1:${PORT};
+        server_name localhost;
+
+        location /md/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+            alias html/;
+        }
+
+        location /nomd/ {
+            alias html/;
+        }
+    }
+
+    server {
+        listen 127.0.0.1:${METRICS_PORT};
+        server_name localhost;
+
+        location /metrics {
+            markdown_metrics on;
+        }
+    }
+}
+EOF
+
+echo "==> Starting NGINX on 127.0.0.1:${PORT} (app) and 127.0.0.1:${METRICS_PORT} (metrics)"
+"${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
+markdown_wait_for_http "http://127.0.0.1:${PORT}/nomd/test.html" "NGINX app" || exit 1
+markdown_wait_for_http "http://127.0.0.1:${METRICS_PORT}/metrics" "NGINX metrics" || exit 1
+
+# --- Case 1: JSON format via Accept: application/json ---
+echo "==> Case 1: JSON format via Accept: application/json"
+curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
+  -H "${ACCEPT_JSON}" --max-time 30 \
+  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected HTTP 200 for JSON metrics" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_JSON}" "${RAW_DIR}/case1.hdr" || {
+  echo "FAIL: Case 1 - expected application/json Content-Type" >&2
+  exit 1
+}
+python3 -c "import json,sys; json.load(open('${RAW_DIR}/case1.body'))" || {
+  echo "FAIL: Case 1 - metrics body is not valid JSON" >&2
+  exit 1
+}
+echo "  PASS: JSON format returned with correct Content-Type"
+
+# --- Case 2: Plain-text format (default, no Accept override) ---
+echo "==> Case 2: Plain-text format (default)"
+curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
+  --max-time 30 \
+  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case2.hdr" || {
+  echo "FAIL: Case 2 - expected HTTP 200 for plain-text metrics" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_TEXT}" "${RAW_DIR}/case2.hdr" || {
+  echo "FAIL: Case 2 - expected text/plain Content-Type" >&2
+  exit 1
+}
+[[ -s "${RAW_DIR}/case2.body" ]] || {
+  echo "FAIL: Case 2 - plain-text metrics body is empty" >&2
+  exit 1
+}
+echo "  PASS: Plain-text format returned with non-empty body"
+
+# --- Case 3: Prometheus exposition format ---
+echo "==> Case 3: Prometheus exposition format"
+curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
+  -H "${ACCEPT_PROMETHEUS}" --max-time 30 \
+  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case3.hdr" || {
+  echo "FAIL: Case 3 - expected HTTP 200 for Prometheus metrics" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_PROMETHEUS}" "${RAW_DIR}/case3.hdr" || {
+  echo "INFO: Case 3 - Prometheus Content-Type variant not matched; checking body format as fallback" >&2
+  grep -qi "^# HELP" "${RAW_DIR}/case3.body" || {
+    echo "FAIL: Case 3 - response body does not look like Prometheus format" >&2
+    exit 1
+  }
+}
+echo "  PASS: Prometheus format returned"
+
+# --- Case 4: Non-empty metrics body ---
+echo "==> Case 4: Metrics endpoint returns non-empty body"
+[[ -s "${RAW_DIR}/case1.body" ]] || {
+  echo "FAIL: Case 4 - JSON metrics body is empty" >&2
+  exit 1
+}
+echo "  PASS: All format bodies are non-empty"
+
+# --- Case 5: JSON metrics contain required top-level keys ---
+echo "==> Case 5: JSON metrics contain required top-level keys"
+python3 -c "
+import json, sys
+data = json.load(open('${RAW_DIR}/case1.body'))
+required = ['total_requests', 'converted_total', 'skipped_total']
+missing = [k for k in required if k not in data]
+if missing:
+    print(f'FAIL: missing keys: {missing}', file=sys.stderr)
+    sys.exit(1)
+print('  PASS: JSON contains required top-level keys')
+" || exit 1
+
+# --- Case 6: Prometheus metrics contain expected metric family prefixes ---
+echo "==> Case 6: Prometheus metrics contain expected metric family prefixes"
+grep -q "^# HELP nginx_markdown" "${RAW_DIR}/case3.body" || {
+  echo "FAIL: Case 6 - no HELP lines with nginx_markdown prefix in Prometheus output" >&2
+  exit 1
+}
+grep -q "^# TYPE nginx_markdown" "${RAW_DIR}/case3.body" || {
+  echo "FAIL: Case 6 - no TYPE lines with nginx_markdown prefix in Prometheus output" >&2
+  exit 1
+}
+echo "  PASS: Prometheus output contains HELP and TYPE annotations"
+
+# --- Case 7: After a conversion, request counters are non-zero ---
+echo "==> Case 7: Counters non-zero after conversion"
+# Trigger a conversion request
+curl -sS -o /dev/null -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/test.html" || {
+  echo "FAIL: Case 7 - conversion request failed" >&2
+  exit 1
+}
+# Re-fetch JSON metrics
+curl -sS -o "${RAW_DIR}/case7.body" \
+  -H "${ACCEPT_JSON}" --max-time 30 \
+  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+python3 -c "
+import json, sys
+data = json.load(open('${RAW_DIR}/case7.body'))
+total = data.get('total_requests', 0)
+converted = data.get('converted_total', 0)
+if total < 1:
+    print(f'FAIL: total_requests is {total}, expected >= 1', file=sys.stderr)
+    sys.exit(1)
+if converted < 1:
+    print(f'FAIL: converted_total is {converted}, expected >= 1', file=sys.stderr)
+    sys.exit(1)
+print(f'  PASS: total_requests={total}, converted_total={converted} (non-zero)')
+" || exit 1
+
+# --- Case 8: Invalid Accept header returns plain-text fallback ---
+echo "==> Case 8: Invalid Accept header falls back to plain-text"
+curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
+  -H 'Accept: application/xml' --max-time 30 \
+  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+grep -qi "${PATTERN_HTTP_200}" "${RAW_DIR}/case8.hdr" || {
+  echo "FAIL: Case 8 - expected HTTP 200 for unknown Accept" >&2
+  exit 1
+}
+grep -qi "${PATTERN_CT_TEXT}" "${RAW_DIR}/case8.hdr" || {
+  echo "FAIL: Case 8 - expected text/plain fallback for unknown Accept" >&2
+  exit 1
+}
+echo "  PASS: Unknown Accept returns plain-text fallback"
+
+echo ""
+echo "========================================"
+echo "All metrics-endpoint E2E tests passed!"
+echo "========================================"

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -34,18 +34,50 @@ readonly PATTERN_HTTP_200='HTTP/1.1 200'
 readonly PATTERN_CT_JSON='Content-Type: application/json'
 readonly PATTERN_CT_TEXT='Content-Type: text/plain'
 readonly PATTERN_CT_PROMETHEUS='Content-Type: text/plain.*version=0\.0\.4'
+readonly METRICS_ENDPOINT="http://127.0.0.1:${METRICS_PORT}/metrics"
+readonly APP_TEST_ENDPOINT="http://127.0.0.1:${PORT}/md/test.html"
 
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
 #
+# Assert that a file exists and is non-empty; fail otherwise.
+#
+# Arguments:
+#   $1 - case label (for diagnostic messages)
+#   $2 - file path to check
+# Output: FAIL diagnostic to stderr on failure
+# Exit behavior: exits 1 if file is missing or empty
+#
+assert_non_empty_body() {
+  local label="$1"
+  local filepath="$2"
+  [[ -s "${filepath}" ]] || {
+    echo "FAIL: ${label} - response body is empty" >&2
+    exit 1
+  }
+}
+
+#
 # Print command-line usage for this E2E script.
+#
+# Arguments: none
+# Output: usage text to stdout
+# Exit behavior: returns 0
 #
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--metrics-port PORT]
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--metrics-port PORT] [-h|--help]
 
 Build local NGINX with the markdown module and run metrics-endpoint E2E checks.
+
+Options:
+  --keep-artifacts       Keep build artifacts after run (default: remove on success)
+  --nginx-version VERSION
+                         NGINX version to build (default: ${NGINX_VERSION})
+  --port PORT            App server listen port (default: ${PORT})
+  --metrics-port PORT    Metrics endpoint listen port (default: ${METRICS_PORT})
+  -h, --help             Show this help message
 
 Checks:
   1) JSON format via Accept: application/json
@@ -65,6 +97,10 @@ EOF
 #
 # Trap handler: stop NGINX, then optionally remove build artifacts.
 #
+# Arguments: none (reads global state)
+# Output: diagnostic messages to stderr
+# Exit behavior: returns 0
+#
 cleanup() {
   local rc=$?
 
@@ -79,7 +115,7 @@ cleanup() {
   if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
     echo "Metrics-endpoint E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
   elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
-    echo "Metrics-endpoint E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+    echo "Metrics-endpoint E2E succeeded. Artifacts kept at: ${BUILDROOT}" >&2
   fi
   return 0
 }
@@ -140,17 +176,17 @@ RAW_DIR="${BUILDROOT}/raw"
 mkdir -p "${RAW_DIR}"
 
 # --- Build or reuse NGINX ---
-echo "==> Host architecture: $(uname -m)"
+echo "==> Host architecture: $(uname -m)" >&2
 if [[ -n "${NGINX_BIN}" ]]; then
-  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})" >&2
   LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
   NGINX_EXECUTABLE="${NGINX_BIN}"
 else
-  echo "==> Building Rust converter (${RUST_TARGET})"
+  echo "==> Building Rust converter (${RUST_TARGET})" >&2
   markdown_prepare_rust_converter_release \
     "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
 
-  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}" >&2
   curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
   mkdir -p "${BUILDROOT}/src"
   tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
@@ -221,16 +257,16 @@ http {
 }
 EOF
 
-echo "==> Starting NGINX on 127.0.0.1:${PORT} (app) and 127.0.0.1:${METRICS_PORT} (metrics)"
+echo "==> Starting NGINX on 127.0.0.1:${PORT} (app) and 127.0.0.1:${METRICS_PORT} (metrics)" >&2
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
 markdown_wait_for_http "http://127.0.0.1:${PORT}/nomd/test.html" "NGINX app" || exit 1
-markdown_wait_for_http "http://127.0.0.1:${METRICS_PORT}/metrics" "NGINX metrics" || exit 1
+markdown_wait_for_http "${METRICS_ENDPOINT}" "NGINX metrics" || exit 1
 
 # --- Case 1: JSON format via Accept: application/json ---
-echo "==> Case 1: JSON format via Accept: application/json"
+echo "==> Case 1: JSON format via Accept: application/json" >&2
 curl -sS -D "${RAW_DIR}/case1.hdr" -o "${RAW_DIR}/case1.body" \
   -H "${ACCEPT_JSON}" --max-time 30 \
-  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+  "${METRICS_ENDPOINT}" >/dev/null
 markdown_expect_status "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_HTTP_200}"
 markdown_expect_header "Case 1" "${RAW_DIR}/case1.hdr" "${PATTERN_CT_JSON}"
 METRICS_BODY="${RAW_DIR}/case1.body" python3 -c '
@@ -240,26 +276,23 @@ json.load(open(os.environ["METRICS_BODY"]))
   echo "FAIL: Case 1 - metrics body is not valid JSON" >&2
   exit 1
 }
-echo "  PASS: JSON format returned with correct Content-Type"
+echo "  PASS: JSON format returned with correct Content-Type" >&2
 
 # --- Case 2: Plain-text format (default, no Accept override) ---
-echo "==> Case 2: Plain-text format (default)"
+echo "==> Case 2: Plain-text format (default)" >&2
 curl -sS -D "${RAW_DIR}/case2.hdr" -o "${RAW_DIR}/case2.body" \
   --max-time 30 \
-  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+  "${METRICS_ENDPOINT}" >/dev/null
 markdown_expect_status "Case 2" "${RAW_DIR}/case2.hdr" "${PATTERN_HTTP_200}"
 markdown_expect_header "Case 2" "${RAW_DIR}/case2.hdr" "${PATTERN_CT_TEXT}"
-[[ -s "${RAW_DIR}/case2.body" ]] || {
-  echo "FAIL: Case 2 - plain-text metrics body is empty" >&2
-  exit 1
-}
-echo "  PASS: Plain-text format returned with non-empty body"
+assert_non_empty_body "Case 2" "${RAW_DIR}/case2.body"
+echo "  PASS: Plain-text format returned with non-empty body" >&2
 
 # --- Case 3: Prometheus exposition format ---
-echo "==> Case 3: Prometheus exposition format"
+echo "==> Case 3: Prometheus exposition format" >&2
 curl -sS -D "${RAW_DIR}/case3.hdr" -o "${RAW_DIR}/case3.body" \
   -H "${ACCEPT_PROMETHEUS}" --max-time 30 \
-  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+  "${METRICS_ENDPOINT}" >/dev/null
 markdown_expect_status "Case 3" "${RAW_DIR}/case3.hdr" "${PATTERN_HTTP_200}"
 grep -qi "${PATTERN_CT_PROMETHEUS}" "${RAW_DIR}/case3.hdr" || {
   echo "INFO: Case 3 - Prometheus Content-Type variant not matched; checking body format as fallback" >&2
@@ -268,26 +301,17 @@ grep -qi "${PATTERN_CT_PROMETHEUS}" "${RAW_DIR}/case3.hdr" || {
     exit 1
   }
 }
-echo "  PASS: Prometheus format returned"
+echo "  PASS: Prometheus format returned" >&2
 
 # --- Case 4: Non-empty metrics body ---
-echo "==> Case 4: Metrics endpoint returns non-empty body for all formats"
-[[ -s "${RAW_DIR}/case1.body" ]] || {
-  echo "FAIL: Case 4 - JSON metrics body is empty" >&2
-  exit 1
-}
-[[ -s "${RAW_DIR}/case2.body" ]] || {
-  echo "FAIL: Case 4 - plain-text metrics body is empty" >&2
-  exit 1
-}
-[[ -s "${RAW_DIR}/case3.body" ]] || {
-  echo "FAIL: Case 4 - Prometheus metrics body is empty" >&2
-  exit 1
-}
-echo "  PASS: All format bodies are non-empty"
+echo "==> Case 4: Metrics endpoint returns non-empty body for all formats" >&2
+assert_non_empty_body "Case 4 (JSON)" "${RAW_DIR}/case1.body"
+assert_non_empty_body "Case 4 (plain-text)" "${RAW_DIR}/case2.body"
+assert_non_empty_body "Case 4 (Prometheus)" "${RAW_DIR}/case3.body"
+echo "  PASS: All format bodies are non-empty" >&2
 
 # --- Case 5: JSON metrics contain required top-level keys ---
-echo "==> Case 5: JSON metrics contain required top-level keys"
+echo "==> Case 5: JSON metrics contain required top-level keys" >&2
 METRICS_BODY="${RAW_DIR}/case1.body" python3 -c '
 import json, os, sys
 data = json.load(open(os.environ["METRICS_BODY"]))
@@ -296,11 +320,11 @@ missing = [k for k in required if k not in data]
 if missing:
     print(f"FAIL: missing keys: {missing}", file=sys.stderr)
     sys.exit(1)
-print("  PASS: JSON contains required top-level keys")
+print("  PASS: JSON contains required top-level keys", file=sys.stderr)
 ' || exit 1
 
 # --- Case 6: Prometheus metrics contain expected metric family prefixes ---
-echo "==> Case 6: Prometheus metrics contain expected metric family prefixes"
+echo "==> Case 6: Prometheus metrics contain expected metric family prefixes" >&2
 grep -q "^# HELP nginx_markdown" "${RAW_DIR}/case3.body" || {
   echo "FAIL: Case 6 - no HELP lines with nginx_markdown prefix in Prometheus output" >&2
   exit 1
@@ -309,20 +333,20 @@ grep -q "^# TYPE nginx_markdown" "${RAW_DIR}/case3.body" || {
   echo "FAIL: Case 6 - no TYPE lines with nginx_markdown prefix in Prometheus output" >&2
   exit 1
 }
-echo "  PASS: Prometheus output contains HELP and TYPE annotations"
+echo "  PASS: Prometheus output contains HELP and TYPE annotations" >&2
 
 # --- Case 7: After a conversion, request counters are non-zero ---
-echo "==> Case 7: Counters non-zero after conversion"
+echo "==> Case 7: Counters non-zero after conversion" >&2
 # Trigger a conversion request
 curl -sS -o /dev/null -H "${ACCEPT_MARKDOWN}" --max-time 30 \
-  "http://127.0.0.1:${PORT}/md/test.html" || {
+  "${APP_TEST_ENDPOINT}" || {
   echo "FAIL: Case 7 - conversion request failed" >&2
   exit 1
 }
 # Re-fetch JSON metrics
 curl -sS -o "${RAW_DIR}/case7.body" \
   -H "${ACCEPT_JSON}" --max-time 30 \
-  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+  "${METRICS_ENDPOINT}" >/dev/null
 METRICS_BODY="${RAW_DIR}/case7.body" python3 -c '
 import json, os, sys
 data = json.load(open(os.environ["METRICS_BODY"]))
@@ -334,19 +358,19 @@ if total < 1:
 if converted < 1:
     print(f"FAIL: converted_total is {converted}, expected >= 1", file=sys.stderr)
     sys.exit(1)
-print(f"  PASS: total_requests={total}, converted_total={converted} (non-zero)")
+print(f"  PASS: total_requests={total}, converted_total={converted} (non-zero)", file=sys.stderr)
 ' || exit 1
 
 # --- Case 8: Invalid Accept header returns plain-text fallback ---
-echo "==> Case 8: Invalid Accept header falls back to plain-text"
+echo "==> Case 8: Invalid Accept header falls back to plain-text" >&2
 curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
   -H 'Accept: application/xml' --max-time 30 \
-  "http://127.0.0.1:${METRICS_PORT}/metrics" >/dev/null
+  "${METRICS_ENDPOINT}" >/dev/null
 markdown_expect_status "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_HTTP_200}"
 markdown_expect_header "Case 8" "${RAW_DIR}/case8.hdr" "${PATTERN_CT_TEXT}"
-echo "  PASS: Unknown Accept returns plain-text fallback"
+echo "  PASS: Unknown Accept returns plain-text fallback" >&2
 
-echo ""
-echo "========================================"
-echo "All metrics-endpoint E2E tests passed!"
-echo "========================================"
+echo "" >&2
+echo "========================================" >&2
+echo "All metrics-endpoint E2E tests passed!" >&2
+echo "========================================" >&2

--- a/tools/e2e/verify_metrics_endpoint_e2e.sh
+++ b/tools/e2e/verify_metrics_endpoint_e2e.sh
@@ -56,6 +56,7 @@ assert_non_empty_body() {
     echo "FAIL: ${label} - response body is empty" >&2
     exit 1
   }
+  return 0
 }
 
 #

--- a/tools/e2e/verify_proxy_tls_backend_e2e.sh
+++ b/tools/e2e/verify_proxy_tls_backend_e2e.sh
@@ -319,7 +319,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/simple" "NGINX" || exit 1
 
 echo "==> Case 1: proxy/TLS Markdown conversion"
 basic_code="$(curl -sS -D "${RAW_DIR}/basic.hdr" -o "${RAW_DIR}/basic.body" \
@@ -369,7 +369,7 @@ grep -qi '^Content-Type: text/html' "${RAW_DIR}/error.hdr" || {
 
 echo "==> Case 4: HEAD through proxy"
 head_code="$(curl -sS -D "${RAW_DIR}/head.hdr" -o "${RAW_DIR}/head.body" \
-  -X HEAD -H 'Accept: text/markdown' \
+  --head -H 'Accept: text/markdown' \
   "http://127.0.0.1:${PORT}/simple" \
   -w '%{http_code}')"
 [[ "${head_code}" == "200" ]] || { echo "Expected HEAD /simple 200, got ${head_code}" >&2; exit 1; }

--- a/tools/e2e/verify_proxy_tls_backend_e2e.sh
+++ b/tools/e2e/verify_proxy_tls_backend_e2e.sh
@@ -36,6 +36,9 @@ EOF
   return 0
 }
 
+# shellcheck disable=SC1090
+source "${NATIVE_BUILD_HELPER}"
+
 nginx_supports_ssl_upstream() {
   local nginx_bin="$1"
   "${nginx_bin}" -V 2>&1 | grep -q -- '--with-http_ssl_module'
@@ -84,9 +87,6 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-
-# shellcheck disable=SC1090
-source "${NATIVE_BUILD_HELPER}"
 
 if (( ${#ORIG_ARGS[@]} )); then
   markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"

--- a/tools/e2e/verify_proxy_tls_backend_e2e.sh
+++ b/tools/e2e/verify_proxy_tls_backend_e2e.sh
@@ -42,18 +42,6 @@ nginx_supports_ssl_upstream() {
   return $?
 }
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --keep-artifacts)
@@ -61,27 +49,27 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --backend-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       BACKEND_PORT="$2"
       shift 2
       ;;
     --nginx-bin-output)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_BIN_OUTPUT_FILE="$2"
       shift 2
       ;;
     --buildroot-output)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       BUILDROOT_OUTPUT_FILE="$2"
       shift 2
       ;;
@@ -368,6 +356,7 @@ grep -qi '^Content-Type: text/html' "${RAW_DIR}/error.hdr" || {
 }
 
 echo "==> Case 4: HEAD through proxy"
+: > "${RAW_DIR}/head.body"
 head_code="$(curl -sS -D "${RAW_DIR}/head.hdr" -o "${RAW_DIR}/head.body" \
   --head -H 'Accept: text/markdown' \
   "http://127.0.0.1:${PORT}/simple" \

--- a/tools/e2e/verify_security_e2e.sh
+++ b/tools/e2e/verify_security_e2e.sh
@@ -288,7 +288,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/sec/script" "NGINX" || exit 1
 
 # --- Case 1: <script> content is stripped ---
 echo "==> Case 1: <script> content is stripped from Markdown output"

--- a/tools/e2e/verify_security_e2e.sh
+++ b/tools/e2e/verify_security_e2e.sh
@@ -43,16 +43,6 @@ EOF
   return 0
 }
 
-require_flag_value() {
-  local flag_name="$1"
-  if [[ $# -lt 2 || -z "${2-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-  return 0
-}
-
 cleanup() {
   local rc=$?
   if [[ -n "${UPSTREAM_PID}" ]]; then
@@ -75,9 +65,9 @@ trap cleanup EXIT
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --keep-artifacts) KEEP_ARTIFACTS=1; shift ;;
-    --nginx-version)  require_flag_value "$1" "${2-}"; NGINX_VERSION="$2"; shift 2 ;;
-    --port)           require_flag_value "$1" "${2-}"; PORT="$2"; shift 2 ;;
-    --upstream-port)  require_flag_value "$1" "${2-}"; UPSTREAM_PORT="$2"; shift 2 ;;
+    --nginx-version)  markdown_require_flag_value "$1" "${2-}"; NGINX_VERSION="$2"; shift 2 ;;
+    --port)           markdown_require_flag_value "$1" "${2-}"; PORT="$2"; shift 2 ;;
+    --upstream-port)  markdown_require_flag_value "$1" "${2-}"; UPSTREAM_PORT="$2"; shift 2 ;;
     -h|--help)        usage; exit 0 ;;
     *)                echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -164,7 +154,6 @@ CONTROL_CHAR_URL_HTML = b"""<html><head><title>Control URL Test</title></head>
 <p>Safe content</p></body></html>
 """
 
-
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -196,7 +185,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -206,7 +194,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()
@@ -288,7 +275,7 @@ EOF
 
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-markdown_wait_for_http "http://127.0.0.1:${PORT}/sec/script" "NGINX" || exit 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/script" "NGINX" || exit 1
 
 # --- Case 1: <script> content is stripped ---
 echo "==> Case 1: <script> content is stripped from Markdown output"

--- a/tools/e2e/verify_status_codes_e2e.sh
+++ b/tools/e2e/verify_status_codes_e2e.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E validation for upstream status code passthrough.
+#
+# Validates that non-2xx status codes from upstream are properly handled:
+#  1) 403 Forbidden - no conversion, passthrough HTML
+#  2) 404 Not Found - no conversion, passthrough HTML
+#  3) 500 Internal Server Error - no conversion, passthrough
+#  4) 502 Bad Gateway - no conversion, passthrough
+#  5) 503 Service Unavailable - no conversion, passthrough
+#  6) 301 Redirect - not converted, follows redirect
+#  7) 302 Redirect - not converted, follows redirect
+#  8) 410 Gone - no conversion, passthrough
+
+NGINX_VERSION="${NGINX_VERSION:-1.28.2}"
+PORT="${PORT:-18105}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-19105}"
+KEEP_ARTIFACTS=0
+NGINX_BIN="${NGINX_BIN:-}"
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NATIVE_BUILD_HELPER="${WORKSPACE_ROOT}/tools/lib/nginx_markdown_native_build.sh"
+BUILDROOT=""
+RUNTIME=""
+RUST_TARGET=""
+NGINX_EXECUTABLE=""
+LOAD_MODULE_LINE=""
+UPSTREAM_PID=""
+ORIG_ARGS=("$@")
+
+readonly ACCEPT_MARKDOWN='Accept: text/markdown'
+readonly PATTERN_CT_HTML='^Content-Type: text/html'
+
+# shellcheck source=tools/lib/nginx_markdown_native_build.sh
+source "${NATIVE_BUILD_HELPER}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
+
+Build local NGINX with the markdown module and run upstream status-code E2E checks.
+
+Checks:
+  1) 403 passthrough
+  2) 404 passthrough
+  3) 500 passthrough
+  4) 502 passthrough
+  5) 503 passthrough
+  6) 410 passthrough
+  7) 301 redirect handling
+  8) 302 redirect handling
+
+Set NGINX_BIN to reuse an existing module-enabled nginx binary and skip rebuilding.
+EOF
+  return 0
+}
+
+require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${RUNTIME}" && -n "${NGINX_EXECUTABLE}" && -x "${NGINX_EXECUTABLE}" ]]; then
+    "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf -s stop >/dev/null 2>&1 || true
+  fi
+
+  if [[ $rc -eq 0 && "${KEEP_ARTIFACTS}" -eq 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    rm -rf "${BUILDROOT}" || true
+  fi
+
+  if [[ $rc -ne 0 && -n "${BUILDROOT}" && -d "${BUILDROOT}" ]]; then
+    echo "Status-code E2E failed. Artifacts kept at: ${BUILDROOT}" >&2
+  elif [[ "${KEEP_ARTIFACTS}" -eq 1 && -n "${BUILDROOT}" ]]; then
+    echo "Status-code E2E succeeded. Artifacts kept at: ${BUILDROOT}"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --nginx-version)
+      require_flag_value "$1" "${2:-}"
+      NGINX_VERSION="$2"
+      shift 2
+      ;;
+    --port)
+      require_flag_value "$1" "${2:-}"
+      PORT="$2"
+      shift 2
+      ;;
+    --upstream-port)
+      require_flag_value "$1" "${2:-}"
+      UPSTREAM_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#ORIG_ARGS[@]} )); then
+  markdown_ensure_native_apple_silicon "$0" "${ORIG_ARGS[@]}"
+else
+  markdown_ensure_native_apple_silicon "$0"
+fi
+
+for cmd in curl python3 grep; do
+  markdown_need_cmd "$cmd"
+done
+if [[ -z "${NGINX_BIN}" ]]; then
+  for cmd in tar make cargo; do
+    markdown_need_cmd "$cmd"
+  done
+fi
+
+RUST_TARGET="$(markdown_detect_rust_target)"
+BUILDROOT="$(mktemp -d /tmp/nginx-status-code-e2e.XXXXXX)"
+RUNTIME="${BUILDROOT}/runtime"
+RAW_DIR="${BUILDROOT}/raw"
+UPSTREAM_SCRIPT="${BUILDROOT}/status_code_upstream.py"
+mkdir -p "${RAW_DIR}"
+
+# --- Upstream server that returns various status codes ---
+cat > "${UPSTREAM_SCRIPT}" <<'PY'
+#!/usr/bin/env python3
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+HTML_ERROR = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>Error</title></head>
+<body><h1>Error Page</h1></body></html>
+"""
+
+HTML_OK = b"""<!doctype html>
+<html><head><meta charset="UTF-8"><title>OK</title></head>
+<body><h1>OK Page</h1></body></html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args):
+        return
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/health":
+            body = b"ok\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/ok":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_OK)))
+            self.end_headers()
+            self.wfile.write(HTML_OK)
+            return
+        if path == "/403":
+            self.send_response(403)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/404":
+            self.send_response(404)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/500":
+            self.send_response(500)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/502":
+            self.send_response(502)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/503":
+            self.send_response(503)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/410":
+            self.send_response(410)
+            self.send_header("Content-Type", "text/html; charset=UTF-8")
+            self.send_header("Content-Length", str(len(HTML_ERROR)))
+            self.end_headers()
+            self.wfile.write(HTML_ERROR)
+            return
+        if path == "/301":
+            self.send_response(301)
+            self.send_header("Location", "/ok")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if path == "/302":
+            self.send_response(302)
+            self.send_header("Location", "/ok")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19105)
+    args = parser.parse_args()
+    if args.serve:
+        server = ThreadingHTTPServer((args.host, args.port), Handler)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+chmod +x "${UPSTREAM_SCRIPT}"
+
+# --- Build or reuse NGINX ---
+echo "==> Host architecture: $(uname -m)"
+if [[ -n "${NGINX_BIN}" ]]; then
+  echo "==> Reusing existing NGINX binary (${NGINX_BIN})"
+  LOAD_MODULE_LINE="$(markdown_prepare_runtime_reuse "${NGINX_BIN}" "${RUNTIME}")"
+  NGINX_EXECUTABLE="${NGINX_BIN}"
+else
+  echo "==> Building Rust converter (${RUST_TARGET})"
+  markdown_prepare_rust_converter_release \
+    "${WORKSPACE_ROOT}" "${RUST_TARGET}" --features streaming >/dev/null
+
+  echo "==> Downloading/building NGINX ${NGINX_VERSION}"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -o "${BUILDROOT}/nginx.tar.gz"
+  mkdir -p "${BUILDROOT}/src"
+  tar -xzf "${BUILDROOT}/nginx.tar.gz" -C "${BUILDROOT}/src" --strip-components=1
+  (
+    cd "${BUILDROOT}/src"
+    ./configure \
+      --without-http_rewrite_module \
+      --with-cc-opt="-DMARKDOWN_STREAMING_ENABLED" \
+      --prefix="${RUNTIME}" \
+      --add-module="${WORKSPACE_ROOT}/components/nginx-module" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)" >/dev/null
+    make install >/dev/null
+  )
+  NGINX_EXECUTABLE="${RUNTIME}/sbin/nginx"
+fi
+
+mkdir -p "${RUNTIME}/conf" "${RUNTIME}/logs"
+
+# --- Start upstream ---
+echo "==> Starting status-code upstream on 127.0.0.1:${UPSTREAM_PORT}"
+python3 "${UPSTREAM_SCRIPT}" --serve --host 127.0.0.1 --port "${UPSTREAM_PORT}" > "${RAW_DIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+markdown_wait_for_http "http://127.0.0.1:${UPSTREAM_PORT}/health" "Upstream on ${UPSTREAM_PORT}" || exit 1
+
+# --- NGINX config ---
+cat > "${RUNTIME}/conf/nginx.conf" <<EOF
+${LOAD_MODULE_LINE}worker_processes 1;
+error_log logs/error.log info;
+pid logs/nginx.pid;
+
+events { worker_connections 512; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 5;
+
+    server {
+        listen 127.0.0.1:${PORT};
+        server_name localhost;
+
+        location /md/ {
+            markdown_filter on;
+            markdown_max_size 10m;
+            markdown_on_error pass;
+            markdown_timeout 120000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass http://127.0.0.1:${UPSTREAM_PORT}/;
+        }
+    }
+}
+EOF
+
+echo "==> Starting NGINX on 127.0.0.1:${PORT}"
+"${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
+markdown_wait_for_http "http://127.0.0.1:${PORT}/md/ok" "NGINX on ${PORT}" || exit 1
+
+# Helper: verify status code passthrough (no conversion)
+check_status_passthrough() {
+  local case_num="$1"
+  local status_code="$2"
+  local path="$3"
+  local hdr="${RAW_DIR}/status_${status_code}.hdr"
+  local body="${RAW_DIR}/status_${status_code}.body"
+
+  echo "==> Case ${case_num}: ${status_code} passthrough"
+  curl -sS -D "${hdr}" -o "${body}" \
+    -H "${ACCEPT_MARKDOWN}" --max-time 30 \
+    "http://127.0.0.1:${PORT}/md/${path}" || true
+
+  grep -qi "HTTP/1.1 ${status_code}" "${hdr}" || {
+    echo "FAIL: Case ${case_num} - expected HTTP ${status_code}" >&2
+    exit 1
+  }
+  grep -qi "${PATTERN_CT_HTML}" "${hdr}" || {
+    echo "FAIL: Case ${case_num} - expected text/html (no conversion for ${status_code})" >&2
+    exit 1
+  }
+  echo "  PASS: ${status_code} passthrough with HTML Content-Type"
+}
+
+# --- Cases 1-6: Error status codes ---
+check_status_passthrough 1 403 "403"
+check_status_passthrough 2 404 "404"
+check_status_passthrough 3 500 "500"
+check_status_passthrough 4 502 "502"
+check_status_passthrough 5 503 "503"
+check_status_passthrough 6 410 "410"
+
+# --- Case 7: 301 redirect ---
+echo "==> Case 7: 301 redirect handling"
+curl -sS -D "${RAW_DIR}/case7.hdr" -o "${RAW_DIR}/case7.body" \
+  -H "${ACCEPT_MARKDOWN}" -L --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/301" >/dev/null
+# After following redirect, should reach /ok which gets converted
+grep -qi 'HTTP/1.1 200' "${RAW_DIR}/case7.hdr" || {
+  echo "FAIL: Case 7 - expected 200 after following 301 redirect" >&2
+  exit 1
+}
+echo "  PASS: 301 redirect followed successfully"
+
+# --- Case 8: 302 redirect ---
+echo "==> Case 8: 302 redirect handling"
+curl -sS -D "${RAW_DIR}/case8.hdr" -o "${RAW_DIR}/case8.body" \
+  -H "${ACCEPT_MARKDOWN}" -L --max-time 30 \
+  "http://127.0.0.1:${PORT}/md/302" >/dev/null
+grep -qi 'HTTP/1.1 200' "${RAW_DIR}/case8.hdr" || {
+  echo "FAIL: Case 8 - expected 200 after following 302 redirect" >&2
+  exit 1
+}
+echo "  PASS: 302 redirect followed successfully"
+
+echo ""
+echo "=============================================="
+echo "All status-code passthrough E2E tests passed!"
+echo "=============================================="

--- a/tools/e2e/verify_status_codes_e2e.sh
+++ b/tools/e2e/verify_status_codes_e2e.sh
@@ -34,6 +34,9 @@ readonly PATTERN_CT_HTML='^Content-Type: text/html'
 # shellcheck source=tools/lib/nginx_markdown_native_build.sh
 source "${NATIVE_BUILD_HELPER}"
 
+#
+# Print command-line usage for this E2E script.
+#
 usage() {
   cat <<EOF
 Usage: $(basename "$0") [--keep-artifacts] [--nginx-version VERSION] [--port PORT] [--upstream-port PORT]
@@ -55,6 +58,9 @@ EOF
   return 0
 }
 
+#
+# Trap handler: stop upstream and NGINX, then optionally remove build artifacts.
+#
 cleanup() {
   local rc=$?
 

--- a/tools/e2e/verify_status_codes_e2e.sh
+++ b/tools/e2e/verify_status_codes_e2e.sh
@@ -55,18 +55,6 @@ EOF
   return 0
 }
 
-require_flag_value() {
-  local flag_name="$1"
-
-  if [[ $# -lt 2 || -z "${2:-}" ]]; then
-    echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
-  fi
-
-  return 0
-}
-
 cleanup() {
   local rc=$?
 
@@ -98,17 +86,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --nginx-version)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       NGINX_VERSION="$2"
       shift 2
       ;;
     --port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --upstream-port)
-      require_flag_value "$1" "${2:-}"
+      markdown_require_flag_value "$1" "${2:-}"
       UPSTREAM_PORT="$2"
       shift 2
       ;;
@@ -162,7 +150,6 @@ HTML_OK = b"""<!doctype html>
 <html><head><meta charset="UTF-8"><title>OK</title></head>
 <body><h1>OK Page</h1></body></html>
 """
-
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -245,7 +232,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -255,7 +241,6 @@ def main():
     if args.serve:
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
-
 
 if __name__ == "__main__":
     main()
@@ -335,7 +320,19 @@ echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
 markdown_wait_for_http "http://127.0.0.1:${PORT}/md/ok" "NGINX on ${PORT}" || exit 1
 
-# Helper: verify status code passthrough (no conversion)
+# Verify upstream HTTP status passthrough without markdown conversion.
+#
+# Args:
+#   $1 - case number for diagnostics
+#   $2 - expected upstream status code (e.g. 403, 502)
+#   $3 - upstream path (relative to /md/)
+# Globals:
+#   RAW_DIR, ACCEPT_MARKDOWN, PORT, PATTERN_CT_HTML
+# Output:
+#   PASS message on stdout; FAIL message on stderr.
+# Exits:
+#   1 when status line or Content-Type assertion fails.
+#   Returns 0 on success.
 check_status_passthrough() {
   local case_num="$1"
   local status_code="$2"
@@ -357,6 +354,7 @@ check_status_passthrough() {
     exit 1
   }
   echo "  PASS: ${status_code} passthrough with HTML Content-Type"
+  return 0
 }
 
 # --- Cases 1-6: Error status codes ---

--- a/tools/e2e/verify_streaming_failure_cache_e2e.sh
+++ b/tools/e2e/verify_streaming_failure_cache_e2e.sh
@@ -1087,7 +1087,7 @@ EOF
 # ---------------------------------------------------------------------------
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-sleep 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/simple" "NGINX" || exit 1
 
 echo ""
 echo "${SEPARATOR}"

--- a/tools/e2e/verify_streaming_failure_cache_e2e.sh
+++ b/tools/e2e/verify_streaming_failure_cache_e2e.sh
@@ -103,16 +103,6 @@ EOF
     return 0
 }
 
-require_flag_value() {
-    local flag_name="$1"
-    if [[ $# -lt 2 || -z "${2-}" ]]; then
-        echo "Missing value for ${flag_name}" >&2
-        usage >&2
-        exit 2
-    fi
-    return 0
-}
-
 report_case() {
     local case_id="$1"
     local status="$2"
@@ -370,27 +360,27 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --nginx-bin)
-            require_flag_value "$1" "${2-}"
+            markdown_require_flag_value "$1" "${2-}"
             NGINX_BIN="$2"
             shift 2
             ;;
         --nginx-version)
-            require_flag_value "$1" "${2-}"
+            markdown_require_flag_value "$1" "${2-}"
             NGINX_VERSION="$2"
             shift 2
             ;;
         --port)
-            require_flag_value "$1" "${2-}"
+            markdown_require_flag_value "$1" "${2-}"
             PORT="$2"
             shift 2
             ;;
         --upstream-port)
-            require_flag_value "$1" "${2-}"
+            markdown_require_flag_value "$1" "${2-}"
             UPSTREAM_PORT="$2"
             shift 2
             ;;
         --markdown-max-size)
-            require_flag_value "$1" "${2-}"
+            markdown_require_flag_value "$1" "${2-}"
             MARKDOWN_MAX_SIZE="$2"
             shift 2
             ;;
@@ -405,7 +395,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
 
 # ---------------------------------------------------------------------------
 # Test plan (always printed)
@@ -583,7 +572,6 @@ PARTIAL_HTML_PREFIX = (
     '<p>This content will be followed by an abrupt connection close.</p>'
 )
 
-
 def build_oversize_payload():
     prefix = (
         '<!doctype html><html><head><meta charset="UTF-8">'
@@ -601,9 +589,7 @@ def build_oversize_payload():
     out += suffix
     return out.encode('utf-8')
 
-
 OVERSIZE_BODY = build_oversize_payload()
-
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -731,7 +717,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--serve", action="store_true")
@@ -750,14 +735,12 @@ def main():
         server = ThreadingHTTPServer((args.host, args.port), Handler)
         server.serve_forever()
 
-
 if __name__ == "__main__":
     main()
 UPSTREAM_PY
 
 chmod +x "${UPSTREAM_SCRIPT}"
 eval "$(python3 "${UPSTREAM_SCRIPT}" --print-metrics)"
-
 
 # ---------------------------------------------------------------------------
 # Prepare NGINX runtime (reuse existing binary)
@@ -1081,13 +1064,12 @@ http {
 }
 EOF
 
-
 # ---------------------------------------------------------------------------
 # Start NGINX
 # ---------------------------------------------------------------------------
 echo "==> Starting NGINX on 127.0.0.1:${PORT}"
 "${NGINX_EXECUTABLE}" -p "${RUNTIME}" -c conf/nginx.conf
-markdown_wait_for_http "http://127.0.0.1:${PORT}/simple" "NGINX" || exit 1
+markdown_wait_for_http "http://127.0.0.1:${PORT}/t01/simple" "NGINX" || exit 1
 
 echo ""
 echo "${SEPARATOR}"
@@ -1302,7 +1284,6 @@ if [[ ${t06_pass} -eq 1 ]]; then
 else
     report_case "10.6" "FAIL" "if_modified_since_only allows streaming"
 fi
-
 
 # ---------------------------------------------------------------------------
 # 10.7 Streaming response headers

--- a/tools/lib/nginx_markdown_native_build.sh
+++ b/tools/lib/nginx_markdown_native_build.sh
@@ -369,11 +369,9 @@ markdown_wait_for_http() {
 #
 # Intended for use in argument-parsing loops: the caller passes the flag
 # name and the prospective value; if the value is missing or empty, an
-# error is printed and the script exits with status 2.
-#
-# This function relies on the caller's scope providing a `usage` function
-# (bash dynamic scoping).  Callers that do not define `usage` should
-# not use this helper.
+# error is printed and the function returns 2.  Under set -e, the
+# non-zero return will terminate the caller; callers that run without
+# set -e should check the return value explicitly.
 #
 # Args:
 #   $1 - flag name (e.g. --nginx-version) for diagnostics.
@@ -381,16 +379,15 @@ markdown_wait_for_http() {
 # Stdout:
 #   None.
 # Stderr:
-#   Missing-value diagnostic and usage text on failure.
+#   Missing-value diagnostic on failure.
 # Returns:
-#   0 when the flag has a value; exits with 2 otherwise.
+#   0 when the flag has a value; 2 otherwise.
 markdown_require_flag_value() {
   local flag_name="$1"
 
   if [[ $# -lt 2 || -z "${2:-}" ]]; then
     echo "Missing value for ${flag_name}" >&2
-    usage >&2
-    exit 2
+    return 2
   fi
 
   return 0
@@ -448,6 +445,9 @@ markdown_expect_header() {
 
 # Extract a header value from a header file.
 #
+# Uses awk for POSIX portability; avoids GNU-sed /I flag which is
+# not available on macOS BSD sed.
+#
 # Args:
 #   $1 - header file path.
 #   $2 - header name (e.g. "ETag").
@@ -461,6 +461,9 @@ markdown_extract_header() {
   local hdr_file="$1"
   local header="$2"
 
-  grep -i "^${header}:" "${hdr_file}" | sed "s/^${header}:[[:space:]]*//I" | tr -d '\r\n'
+  awk -v hdr="${header}" 'BEGIN { lower=tolower(hdr) }
+    tolower($1) ~ tolower(hdr) ":" {
+      sub(/^[^:]+:[[:space:]]+/, ""); sub(/\r$/, ""); print; exit
+    }' "${hdr_file}"
   return 0
 }

--- a/tools/lib/nginx_markdown_native_build.sh
+++ b/tools/lib/nginx_markdown_native_build.sh
@@ -330,6 +330,7 @@ markdown_prepare_rust_converter_release() {
     markdown_copy_rust_release_archive "${workspace_root}" "${rust_target}"
     markdown_sync_converter_header "${workspace_root}"
   )
+  return 0
 }
 
 # Wait for an HTTP endpoint to become reachable.

--- a/tools/lib/nginx_markdown_native_build.sh
+++ b/tools/lib/nginx_markdown_native_build.sh
@@ -331,3 +331,35 @@ markdown_prepare_rust_converter_release() {
     markdown_sync_converter_header "${workspace_root}"
   )
 }
+
+# Wait for an HTTP endpoint to become reachable.
+#
+# Args:
+#   $1 - URL to poll.
+#   $2 - human-readable label for failure diagnostics.
+# Stdout:
+#   None.
+# Stderr:
+#   Timeout diagnostics and curl output on failure.
+# Returns:
+#   0 when the endpoint responds; 1 after timeout (~5s).
+markdown_wait_for_http() {
+  local url="$1"
+  local label="$2"
+  local curl_output=""
+  local _i
+
+  for _i in $(seq 1 50); do
+    if curl -sS --max-time 1 "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  curl_output=$(curl -sS --max-time 2 "$url" 2>&1 || true)
+  echo "${label} failed to become ready after 5s" >&2
+  if [[ -n "${curl_output}" ]]; then
+    echo "curl output: ${curl_output}" >&2
+  fi
+  return 1
+}

--- a/tools/lib/nginx_markdown_native_build.sh
+++ b/tools/lib/nginx_markdown_native_build.sh
@@ -342,7 +342,8 @@ markdown_prepare_rust_converter_release() {
 # Stderr:
 #   Timeout diagnostics and curl output on failure.
 # Returns:
-#   0 when the endpoint responds; 1 after timeout (~5s).
+#   0 when the endpoint responds; 1 after ~5s of unreachable attempts
+#   (wall-clock can grow if the server accepts but stalls per request).
 markdown_wait_for_http() {
   local url="$1"
   local label="$2"
@@ -362,4 +363,104 @@ markdown_wait_for_http() {
     echo "curl output: ${curl_output}" >&2
   fi
   return 1
+}
+
+# Validate that a CLI flag received a non-empty value.
+#
+# Intended for use in argument-parsing loops: the caller passes the flag
+# name and the prospective value; if the value is missing or empty, an
+# error is printed and the script exits with status 2.
+#
+# This function relies on the caller's scope providing a `usage` function
+# (bash dynamic scoping).  Callers that do not define `usage` should
+# not use this helper.
+#
+# Args:
+#   $1 - flag name (e.g. --nginx-version) for diagnostics.
+#   $2 - flag value; must be non-empty.
+# Stdout:
+#   None.
+# Stderr:
+#   Missing-value diagnostic and usage text on failure.
+# Returns:
+#   0 when the flag has a value; exits with 2 otherwise.
+markdown_require_flag_value() {
+  local flag_name="$1"
+
+  if [[ $# -lt 2 || -z "${2:-}" ]]; then
+    echo "Missing value for ${flag_name}" >&2
+    usage >&2
+    exit 2
+  fi
+
+  return 0
+}
+
+# Assert that an HTTP status line pattern appears in a header file.
+#
+# Args:
+#   $1 - case label for diagnostics (e.g. "Case 1").
+#   $2 - header file path.
+#   $3 - grep pattern (e.g. "HTTP/1.1 200").
+# Stdout:
+#   None on success.
+# Stderr:
+#   FAIL message on assertion failure.
+# Exits:
+#   1 when the pattern is not found.
+#   Returns 0 on success.
+markdown_expect_status() {
+  local label="$1"
+  local hdr_file="$2"
+  local pattern="$3"
+
+  grep -qi "${pattern}" "${hdr_file}" || {
+    echo "FAIL: ${label} - expected ${pattern}" >&2
+    exit 1
+  }
+  return 0
+}
+
+# Assert that a header pattern appears in a header file.
+#
+# Args:
+#   $1 - case label for diagnostics (e.g. "Case 1").
+#   $2 - header file path.
+#   $3 - grep pattern (e.g. "^ETag:").
+# Stdout:
+#   None on success.
+# Stderr:
+#   FAIL message on assertion failure.
+# Exits:
+#   1 when the pattern is not found.
+#   Returns 0 on success.
+markdown_expect_header() {
+  local label="$1"
+  local hdr_file="$2"
+  local pattern="$3"
+
+  grep -qi "${pattern}" "${hdr_file}" || {
+    echo "FAIL: ${label} - expected header matching ${pattern}" >&2
+    exit 1
+  }
+  return 0
+}
+
+# Extract a header value from a header file.
+#
+# Args:
+#   $1 - header file path.
+#   $2 - header name (e.g. "ETag").
+# Stdout:
+#   The header value with leading whitespace and trailing CR/LF stripped.
+# Stderr:
+#   None.
+# Returns:
+#   0 always.
+markdown_extract_header() {
+  local hdr_file="$1"
+  local header="$2"
+
+  grep -i "^${header}:" "${hdr_file}" | sed "s/^${header}:[[:space:]]*//I" | tr -d '\r\n'
+  return 0
 }


### PR DESCRIPTION
## Summary by Sourcery

Extend the NGINX markdown module end-to-end test suite with new coverage for metrics, conditional requests, configuration merging, auth/cache behavior, and status-code passthrough, while improving test robustness and wiring the new checks into the main suite and build tooling.

Enhancements:
- Introduce a reusable markdown_wait_for_http helper in the native build library for polling HTTP endpoints during tests.

Build:
- Expose dedicated Makefile targets for each new E2E suite (metrics-endpoint, conditional-requests, config-merge, auth-cache, status-codes) and document them in the help output.

Tests:
- Add new E2E scripts covering config merge behavior across http/server/location scopes, conditional request handling (ETag/If-None-Match/If-Modified-Since), auth/cache interactions, upstream status-code passthrough, and the metrics endpoint in multiple formats.
- Wire the new E2E scripts into the canonical suite runner and Makefile targets, including keep-artifacts support and summary reporting.
- Harden existing E2E scripts by validating required flag values and waiting for NGINX readiness via an HTTP health check instead of fixed sleeps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added many new end-to-end verifications (metrics, conditional requests/304/HEAD, config-merge precedence, auth↔cache behavior, status-code passthrough & redirects, Accept negotiation, error/fail-open, streaming edge cases, large/huge responses). Suite now uses active HTTP readiness checks for reliability.

* **Chores**
  * Added runnable targets to invoke the new verifications; centralised shared E2E helper utilities and bumped release to 0.5.6; updated ignore rules.

* **Documentation**
  * Expanded E2E testing docs and tooling overview to document the new scenarios and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->