### PR TITLE
fix(release-gates): skip optional local specs in framework checks

### DIFF
--- a/tools/release/gates/tests/test_validate_release_gates_compat.py
+++ b/tools/release/gates/tests/test_validate_release_gates_compat.py
@@ -86,3 +86,23 @@ def test_single_classification_column_rejects_missing_state_cell():
     assert result.has_failures
     fail_detail = next(d for s, _, d in result.results if s == "FAIL")
     assert "missing classification" in fail_detail
+
+
+def test_framework_mode_does_not_require_optional_kiro_specs(monkeypatch, tmp_path):
+    """Default framework gate should validate repo-owned artifacts only."""
+    from tools.release.gates import validate_release_gates
+
+    missing_specs_dir = tmp_path / "missing-specs"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_release_gates.py",
+            "--mode",
+            "framework",
+            "--specs-dir",
+            str(missing_specs_dir),
+        ],
+    )
+
+    assert validate_release_gates.main() == 0

--- a/tools/release/gates/tests/test_validate_release_gates_compat.py
+++ b/tools/release/gates/tests/test_validate_release_gates_compat.py
@@ -106,3 +106,23 @@ def test_framework_mode_does_not_require_optional_kiro_specs(monkeypatch, tmp_pa
     )
 
     assert validate_release_gates.main() == 0
+
+
+def test_strict_mode_requires_optional_kiro_specs(monkeypatch, tmp_path):
+    """Strict mode should still fail when the specs tree is absent."""
+    from tools.release.gates import validate_release_gates
+
+    missing_specs_dir = tmp_path / "missing-specs"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_release_gates.py",
+            "--mode",
+            "strict",
+            "--specs-dir",
+            str(missing_specs_dir),
+        ],
+    )
+
+    assert validate_release_gates.main() == 1

--- a/tools/release/gates/validate_release_gates.py
+++ b/tools/release/gates/validate_release_gates.py
@@ -1062,8 +1062,16 @@ def main() -> int:
     specs_dir = args.specs_dir.resolve()
     result = ValidationResult()
 
-    # Determine which sub-specs to check for per-spec validations
-    target_subspecs = SUBSPECS_050 if args.mode == "strict" else SPEC12_ONLY
+    # Determine which sub-specs to check for per-spec validations.
+    #
+    # Framework mode validates the repo-owned governance artifacts below
+    # (compatibility matrix, checklist, test matrix, etc.).  The historical
+    # .kiro/specs tree is an optional local adapter surface in this repository,
+    # so the default framework gate must not fail just because that local
+    # directory is absent.  Strict mode remains available for environments
+    # that intentionally provide the full sub-spec tree and want every
+    # per-spec document check enforced.
+    target_subspecs = SUBSPECS_050 if args.mode == "strict" else []
 
     # Per-sub-spec checks (scoped by mode)
     per_spec_checks: dict[str, object] = {

--- a/tools/release/legacy/tests/test_release_gate_checks.py
+++ b/tools/release/legacy/tests/test_release_gate_checks.py
@@ -239,3 +239,25 @@ def test_dod_evaluation_skips_fenced_code_blocks(tmp_path: Path):
     # Should NOT detect the fenced DoD table — vacuous pass with no PASS messages.
     assert passed
     assert not any("PASS" in msg and "notes.md" in msg for msg in messages)
+
+
+def test_legacy_release_gate_runner_skips_absent_optional_specs(tmp_path: Path):
+    """Legacy gate target should not require the optional local .kiro tree."""
+    from tools.release.legacy.validate_release_gates import _run_checks
+
+    release_dir = tmp_path / "release-gates"
+    release_dir.mkdir()
+    (release_dir / "release-checklist.md").write_text(
+        "- [ ] make release-gates-check-legacy\n",
+        encoding="utf-8",
+    )
+
+    results = _run_checks(str(tmp_path / "missing-specs"), str(release_dir))
+
+    assert all(passed for _, passed, _ in results)
+    assert any(
+        "SKIP_NOT_PRESENT" in message
+        for check_name, _, messages in results
+        if check_name == "Document Existence (Property 2)"
+        for message in messages
+    )

--- a/tools/release/legacy/tests/test_scope_evaluation_pbt.py
+++ b/tools/release/legacy/tests/test_scope_evaluation_pbt.py
@@ -93,7 +93,7 @@ def evaluate_scope(
 
 def _extract_non_goals_from_scope_doc() -> tuple[str, ...]:
     """Extract bullet items from the Non-Goals section of the scope doc."""
-    repo_root = Path(__file__).resolve().parents[3]
+    repo_root = Path(__file__).resolve().parents[4]
     doc_path = repo_root / "docs/project/release-gates/scope-evaluation-process.md"
     lines = doc_path.read_text(encoding="utf-8").splitlines()
 

--- a/tools/release/legacy/validate_release_gates.py
+++ b/tools/release/legacy/validate_release_gates.py
@@ -48,31 +48,31 @@ def _run_checks(
             passed, msgs = False, [f"Exception: {exc}"]
         results.append((check_name, passed, msgs))
 
-    run_check(
-        "Document Existence (Property 2)",
-        check_document_existence,
-        specs_dir,
-    )
-    run_check(
-        "Requirements Completeness (Property 1)",
-        check_requirements_completeness,
-        specs_dir,
-    )
-    run_check(
-        "Design Completeness (Property 1 — R3.4)",
-        check_design_completeness,
-        specs_dir,
-    )
-    run_check(
-        "Boundary Descriptions (Property 3)",
-        check_boundary_descriptions,
-        specs_dir,
-    )
-    run_check(
-        "DoD Evaluation Tables (Property 5)",
-        check_dod_evaluation_tables,
-        specs_dir,
-    )
+    def skip_local_spec_check(check_name: str) -> None:
+        """Record a passing skip for absent optional local spec adapters."""
+        results.append((
+            check_name,
+            True,
+            [
+                f"SKIP_NOT_PRESENT: optional local specs directory {specs_dir} "
+                "is absent",
+            ],
+        ))
+
+    spec_checks: List[Tuple[str, Callable[[str], Tuple[bool, List[str]]]]] = [
+        ("Document Existence (Property 2)", check_document_existence),
+        ("Requirements Completeness (Property 1)", check_requirements_completeness),
+        ("Design Completeness (Property 1 — R3.4)", check_design_completeness),
+        ("Boundary Descriptions (Property 3)", check_boundary_descriptions),
+        ("DoD Evaluation Tables (Property 5)", check_dod_evaluation_tables),
+    ]
+
+    if os.path.isdir(specs_dir):
+        for check_name, check_fn in spec_checks:
+            run_check(check_name, check_fn, specs_dir)
+    else:
+        for check_name, _ in spec_checks:
+            skip_local_spec_check(check_name)
     run_check(
         "Checklist Verifiability (Property 11)",
         check_checklist_verifiability,


### PR DESCRIPTION
### Motivation
- The framework-level release-gates validator should focus on repo-owned governance artifacts and not fail when the optional local `.kiro/specs` adapter tree is absent. 
- The legacy gate runner and related tests needed to treat an absent local specs tree as an intentional, optional adapter so validation and tests are robust in minimal checkout environments.

### Description
- In `tools/release/gates/validate_release_gates.py` framework mode no longer requires `.kiro/specs` entries by using an empty `target_subspecs` list when `--mode framework` is selected. 
- In `tools/release/legacy/validate_release_gates.py` the `_run_checks()` flow now records `SKIP_NOT_PRESENT` pass entries when the optional specs directory is missing instead of failing, preserving checklist validation of repo-owned docs. 
- Added regression tests: `tools/release/gates/tests/test_validate_release_gates_compat.py` verifies framework behavior with a missing specs dir, and `tools/release/legacy/tests/test_release_gate_checks.py` verifies the legacy runner skip behavior; fixed `tools/release/legacy/tests/test_scope_evaluation_pbt.py` repo-root calculation so the non-goals doc is resolved correctly.

### Testing
- Ran `python3 -m pytest tools -q` and verified the tools test-suite completes successfully (tools tests passed). 
- Ran `make release-gates-check` and `make release-gates-check-legacy` and both validators passed in framework mode with the new skip semantics. 
- Ran full harness and CI checks including `make harness-check-full`, `make docs-check`, `make test-rust`, and `make test-nginx-unit`, and observed the expected pass results reported by the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8f5d2630832bb0427b28e066d378)

## Summary by Sourcery

Relax release gate validation so framework and legacy runners treat the optional local .kiro/specs tree as non-fatal when absent.

Bug Fixes:
- Ensure the legacy release gate runner records SKIP_NOT_PRESENT passes instead of failing when the optional specs directory is missing.
- Adjust framework-mode validation to skip per-spec checks when the optional .kiro/specs tree is not provided.
- Fix scope evaluation tests to correctly locate the non-goals documentation from the repository root.

Tests:
- Add regression tests covering framework mode behavior with a missing specs directory.
- Add tests verifying the legacy release gate runner skip semantics for absent optional specs.