### PR TITLE
Run release gates only for tagged commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,58 +562,6 @@ jobs:
           name: coverage-reports
           path: coverage/
 
-  release-gates-070:
-    name: v0.7.0 Release Gates
-    needs: changes
-    if: >-
-      github.event_name != 'pull_request'
-      && (needs.changes.outputs.nginx == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.docs == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install release gate deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            curl \
-            pkg-config \
-            python3 \
-            zip \
-            zlib1g-dev
-
-          NFPM_VERSION="2.46.3"
-          NFPM_TARBALL="nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz"
-          curl -fsSL -o "${NFPM_TARBALL}" "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/${NFPM_TARBALL}"
-          chmod +x packaging/scripts/verify-checksum.sh
-          packaging/scripts/verify-checksum.sh \
-            -f "${NFPM_TARBALL}" \
-            -i "nfpm-${NFPM_VERSION}-linux-x86_64"
-          sudo tar -xz -C /usr/local/bin nfpm -f "${NFPM_TARBALL}"
-          nfpm --version
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Install nightly fuzz tooling
-        run: |
-          rustup toolchain install nightly --profile minimal
-          cargo install cargo-fuzz --locked
-          cargo install cbindgen --locked
-
-      - name: Set up Helm
-        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: '4.2.0'
-
-      - name: Run v0.7.0 release gates
-        run: RELEASE_GATE_REQUIRE_PACKAGES=0 RELEASE_GATE_ALLOW_SKIP_NATIVE_E2E=1 make release-gates-check-070
-
   corpus-benchmark:
     name: Corpus Benchmark Gate
     needs: changes

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -608,6 +608,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install release gate dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            dpkg-dev \
+            file \
+            gzip \
+            rpm \
+            tar
+        shell: bash
+
       - name: Download all DEB artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,6 +1,6 @@
 # Release Packages — Unified DEB/RPM build, test, sign, and publish pipeline
 #
-# Architecture: prepare → build (matrix) → package (matrix) → smoke-test (matrix) → integrity → publish
+# Architecture: prepare → build (matrix) → package (matrix) → smoke-test (matrix) → release-gate (tag) → integrity → publish
 #
 # Triggers:
 #   - Tag push (v*): full pipeline ending with GitHub Release upload
@@ -65,6 +65,7 @@ permissions: {}
 #   - build:               Compile Rust library + NGINX dynamic module (matrix)
 #   - package:             Generate .deb/.rpm via nFPM (matrix)
 #   - smoke-test:          Container install + module load verification (matrix)
+#   - release-gate:        Tag-only release governance and artifact layout gate
 #   - integrity-checksums: SHA256SUMS generation (no protected environment)
 #   - integrity-signing:   Optional GPG signing (protected environment, tag only)
 #   - publish:             Upload to GitHub Release (tag) or workflow artifacts (dispatch)
@@ -589,6 +590,45 @@ jobs:
         shell: bash
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Release Gate Job: tag-only release governance gate
+  # Runs after package smoke tests and before publication. Pull requests and
+  # branch CI deliberately do not run release gates.
+  # ─────────────────────────────────────────────────────────────────────────────
+  release-gate:
+    name: Release Gate (tag only)
+    needs: smoke-test
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Download all DEB artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pkg-deb-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Download all RPM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pkg-rpm-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Run tag release gates
+        run: |
+          make release-gates-check-strict
+          bash tools/release/gates/check_install_layout.sh dist/*.deb dist/*.rpm
+        shell: bash
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Integrity Checksums Job: SHA256SUMS generation (no protected environment)
   # Generates checksums for all package artifacts. Does not require signing
   # secrets or protected environment approval.
@@ -702,10 +742,12 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   publish:
     name: Publish
-    needs: [integrity-checksums, integrity-signing]
+    needs: [release-gate, integrity-checksums, integrity-signing]
     if: >-
       always()
       && needs.integrity-checksums.result == 'success'
+      && (needs.release-gate.result == 'success'
+          || needs.release-gate.result == 'skipped')
       && (needs.integrity-signing.result == 'success'
           || needs.integrity-signing.result == 'skipped')
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,6 +1,8 @@
 # Release Packages — Unified DEB/RPM build, test, sign, and publish pipeline
 #
-# Architecture: prepare → build (matrix) → package (matrix) → smoke-test (matrix) → release-gate (tag) → integrity → publish
+# Architecture: prepare → build (matrix) → package (matrix) → smoke-test (matrix) → integrity → publish
+# Tag releases also run release-gate after smoke-test; publish waits for both
+# release-gate and integrity to pass.
 #
 # Triggers:
 #   - Tag push (v*): full pipeline ending with GitHub Release upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ dynconf dry-run/rollback, and runtime diagnostics.
   - `packaging/debian/` directory with control, postinst, postrm, conffiles.
   - `packaging/rpm/` directory with SPEC file and build scripts.
   - NGINX ABI dependency declarations for both package formats.
-  - GPG signing pipeline for package artifacts and future repository metadata.
+  - GPG signing pipeline for package artifacts and repository metadata support.
   - APT repository metadata placeholder (`dists/<codename>/...`).
   - YUM repository metadata placeholder (`repodata/repomd.xml`).
   - Public v0.7.0 package installation uses GitHub Release DEB/RPM artifacts

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Current release (0.7.0):
 - Rust URL control character validation and link escaping
 - FFI ABI layout verification and header drift detection
 - New error codes: DecompressionBudgetExceeded(9), ParseTimeout(10), ParseBudgetExceeded(11)
-- DEB/RPM packaging with GitHub Release artifacts; APT/YUM repository publishing is planned but not yet available
+- DEB/RPM packaging with GitHub Release artifacts; APT/YUM repository publishing is not part of the 0.7.0 GA channel
 - Package release gates for canonical module paths, artifact names, checksums, and architecture-matched smoke tests
 - Kubernetes deployment examples and Helm chart with secure stock-image defaults plus explicit module-enabled configuration
 - Runtime diagnostics endpoint
@@ -441,7 +441,7 @@ Near-term focus:
 - Strengthen cross-environment evidence automation for release gates
 - Continue tightening operator diagnostics for conversion drifts and degradations
 
-Future exploration:
+Post-0.7.0 exploration:
 
 - OpenTelemetry tracing integration
 - Additional Markdown flavors and output formats

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -425,7 +425,7 @@ v0.7.0 是一个正确性、分发和可运维性版本：
 - Rust URL 控制字符验证与 link 转义
 - FFI ABI 布局验证与 header 漂移检测
 - 新错误码：DecompressionBudgetExceeded(9)、ParseTimeout(10)、ParseBudgetExceeded(11)
-- DEB/RPM GitHub Release artifact 分发；APT/YUM 仓库发布仍为计划项
+- DEB/RPM GitHub Release artifact 分发；APT/YUM 仓库发布不属于 0.7.0 GA 渠道
 - Package release gate 覆盖 canonical module path、artifact name、checksum 与架构匹配的 smoke test
 - Kubernetes 部署示例与默认适配 stock NGINX、显式支持模块启用配置的 Helm chart
 - 运行时诊断端点
@@ -437,11 +437,11 @@ v0.7.0 是一个正确性、分发和可运维性版本：
 - 强化 release gate 的跨环境证据自动化
 - 持续增强 conversion drift/degradation 的运维诊断能力
 
-未来探索：
+0.7.0 后续探索：
 
 - OpenTelemetry tracing 集成
 - 更多 Markdown 风格与输出格式
-- 扩展分发形态（apt/yum/brew 及 ingress 侧交付）
+- 扩展分发形态（APT/YUM 仓库、Homebrew 及 ingress 侧交付）
 
 ## 许可证
 

--- a/docs/guides/GPG_KEY_MANAGEMENT.md
+++ b/docs/guides/GPG_KEY_MANAGEMENT.md
@@ -94,9 +94,9 @@ gpg --keyserver keys.openpgp.org --send-keys <KEY_ID>
 
 ## 3. Key Import Instructions
 
-Public APT/YUM repositories are not available yet. The examples below are for
-future self-hosted repository publication after the repository URL and signing
-key are real. For current v0.7.0+ package artifacts, download the package and
+Public APT/YUM repositories are not part of the 0.7.0 GA channel. The examples
+below are for self-hosted repository publication after the repository URL and
+signing key are real. For current v0.7.0+ package artifacts, download the package and
 `SHA256SUMS` file from the same GitHub Release and follow
 `PACKAGE_INSTALLATION.md`.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -171,7 +171,7 @@ If you need deterministic control over compiler flags or local patching, use [Ma
 
 Starting with v0.7.0, release workflows build DEB and RPM artifacts for
 supported Linux distributions and attach them to GitHub Releases. Public
-APT/YUM repository publishing is planned but is not available yet, so do not
+APT/YUM repository publishing is not part of the 0.7.0 GA channel, so do not
 use `apt-get install nginx-module-markdown` or `yum install
 nginx-module-markdown` unless you operate your own package repository.
 
@@ -222,7 +222,7 @@ channels. Package filenames include the target NGINX version because NGINX
 dynamic module packages are ABI-sensitive.
 
 For full details on artifact naming, checksum verification, upgrade, rollback,
-and the future repository-publishing model, see [Package Installation
+and repository-publishing prerequisites, see [Package Installation
 Guide](PACKAGE_INSTALLATION.md) and [Package Distribution
 Strategy](PACKAGE_DISTRIBUTION.md).
 

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -6,8 +6,10 @@ official NGINX repository packages.
 
 ## Repository Publishing Status
 
-GitHub Releases are the 0.7.0 GA distribution channel for DEB and RPM package
-artifacts. Public APT/YUM repositories are not part of the 0.7.0 GA channel.
+GitHub Releases are the current distribution channel for DEB and RPM package
+artifacts, including the 0.7.0 GA channel.
+Public APT/YUM repositories are planned but not available yet.
+They are not part of the 0.7.0 GA channel.
 
 Bare package-manager installation commands only work after an operator
 publishes and configures a real APT or YUM repository. Until then, download the

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -6,8 +6,8 @@ official NGINX repository packages.
 
 ## Repository Publishing Status
 
-GitHub Releases are the current distribution channel for DEB and RPM package
-artifacts. Public APT/YUM repositories are planned but not available yet.
+GitHub Releases are the 0.7.0 GA distribution channel for DEB and RPM package
+artifacts. Public APT/YUM repositories are not part of the 0.7.0 GA channel.
 
 Bare package-manager installation commands only work after an operator
 publishes and configures a real APT or YUM repository. Until then, download the

--- a/docs/project/0.7.0-agent-handoff.md
+++ b/docs/project/0.7.0-agent-handoff.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |------|-----|
 | Version | 0.7.0 |
-| Status | DRAFT |
+| Status | FINAL |
 | Created | 2026-05-17 |
 
 ## Handoff Summary

--- a/docs/project/0.7.0-coding-task-plan.md
+++ b/docs/project/0.7.0-coding-task-plan.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |------|-----|
 | Version | 0.7.0 |
-| Status | DRAFT |
+| Status | FINAL |
 | Created | 2026-05-17 |
 | Source Spec | kiro/specs/27-v070_prod/spec.md |
 | Source Design | kiro/specs/27-v070_prod/design.md |

--- a/docs/project/0.7.0-implementation-design.md
+++ b/docs/project/0.7.0-implementation-design.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |------|-----|
 | Version | 0.7.0 |
-| Status | DRAFT |
+| Status | FINAL |
 | Created | 2026-05-17 |
 | Predecessor | 0.6.7 implementation |
 | Spec Source | kiro/specs/27-v070_prod/spec.md, design.md, tasks.md |

--- a/docs/project/0.7.0-rust-first-migration-plan.md
+++ b/docs/project/0.7.0-rust-first-migration-plan.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |------|-----|
 | Version | 0.7.0 |
-| Status | DRAFT |
+| Status | FINAL |
 | Created | 2026-05-17 |
 
 ## 1. Boundary Principles

--- a/docs/project/0.7.0-validation-matrix.md
+++ b/docs/project/0.7.0-validation-matrix.md
@@ -3,8 +3,9 @@
 | Field | Value |
 |------|-----|
 | Version | 0.7.0 |
-| Status | DRAFT |
+| Status | FINAL |
 | Created | 2026-05-17 |
+| Updated | 2026-05-29 |
 
 ## Risk Pack × Verification Command Matrix
 
@@ -39,8 +40,8 @@
 |-----------|-----------|-----------|
 | A | `make test-nginx-unit-streaming && make test-rust && make verify-chunked-native-e2e-smoke` | + `make test-rust-fuzz-smoke && make test-nginx-integration && make test-e2e-rust && make coverage-c && make coverage-rust` |
 | B | `make test-rust && make test-nginx-unit && make coverage-rust` | + `make test-rust-fuzz-smoke && make test-e2e-rust && make coverage-c` |
-| C | `make docs-check && make release-gates-check` | + DEB/RPM smoke, signature verification |
-| D | `make docs-check && helm lint charts/nginx-markdown` | + K8s smoke, E2E |
+| C | `make docs-check` | + tag-only `release-packages.yml` release-gate job, DEB/RPM smoke, signature verification |
+| D | `make docs-check && helm lint charts/nginx-markdown` | + K8s smoke, E2E when promoted beyond feasibility |
 | E | `make test-nginx-unit && make docs-check && make harness-check` | + `make verify-streaming-failure-cache-e2e && make release-gates-check-strict && make harness-check-full` |
 
 ## Gate × Verification Command Matrix
@@ -49,9 +50,39 @@
 |------|---------|---------|
 | Gate 1 (P0 Correctness) | `make test-nginx-unit-streaming && make test-rust && make test-rust-fuzz-smoke && make verify-chunked-native-e2e-smoke && make coverage-c && make coverage-rust` | Any command non-zero exit |
 | Gate 2 (Rust-first) | `make test-rust && make build && make check-headers && make test-e2e-rust` | Any command non-zero exit |
-| Gate 3 (Package) | DEB/RPM build passes + signature verification + smoke tests | Build failure or invalid signature |
-| Gate 4 (K8s) | `helm lint` + K8s smoke | helm lint fails or smoke does not pass |
+| Gate 3 (Package) | GitHub Release DEB/RPM artifacts build + install-layout validation + smoke tests + optional signature verification | Build, layout, smoke, checksum, or required signature failure |
+| Gate 4 (K8s) | `helm lint`; K8s smoke remains feasibility scope unless explicitly promoted | helm lint fails |
 | Gate 5 (Operability) | `make harness-check-full && make docs-check && make release-gates-check-strict` | Any command non-zero exit |
+
+## Release Gate Policy
+
+- Pull request and branch CI do not run release gates.
+- Release gates run only from the tag publishing path in
+  `.github/workflows/release-packages.yml` after package smoke tests pass and
+  before GitHub Release publication.
+- `make release-gates-check-070` remains the local comprehensive release
+  readiness command for maintainers who have nightly fuzz tooling, `NGINX_BIN`,
+  and release packages available. The tag publishing workflow is the canonical
+  CI release gate for artifact publication.
+- 0.7.0 GA includes GitHub Release DEB/RPM artifacts and package smoke tests.
+  APT/YUM repository publication is not part of the 0.7.0 GA distribution
+  channel until repository URLs, signing keys, and publication workflows are
+  real and validated.
+- K8s chart lint/render validation is a 0.7.0 gate. Live cluster smoke remains
+  feasibility evidence unless explicitly promoted to a GA blocker.
+
+## Final Release Scope
+
+The 0.7.0 release baseline is final for source, Rust ABI, NGINX module,
+release workflow, GitHub Release DEB/RPM artifacts, checksums, package smoke,
+docs, and harness governance.
+
+The following are not 0.7.0 GA blockers unless a maintainer explicitly
+promotes them before tagging:
+
+- APT/YUM repository publication.
+- Live cluster K8s smoke beyond chart lint/render validation.
+- Re-running local native E2E on a workstation without `NGINX_BIN`.
 
 ## Document Updates
 
@@ -59,6 +90,7 @@
 |------|------|------|------|
 | 0.7.0-draft | 2026-05-17 | spec-agent | Initial v0.7.0 validation matrix |
 | 0.7.0-impl | 2026-05-18 | codex | Added real command execution results and gate-scope notes |
+| 0.7.0-final | 2026-05-29 | Kang | Marked matrix final, made release gates tag-only, and clarified package/K8s GA scope |
 
 ## Validation Run (2026-05-18)
 
@@ -78,6 +110,7 @@
 | Item | Result | Notes |
 |------|------|------|
 | Coverage (`make coverage-c`, `make coverage-rust`) | PASS | C and Rust coverage pipelines completed and generated lcov artifacts |
-| Fuzz smoke (`make test-rust-fuzz-smoke`) | SKIP | Not executed in this pass |
-| Chunked native E2E smoke | SKIP | Not executed in this pass |
-| Package/K8s smoke | SKIP | Gate 3/4 are marked future/feasibility for 0.7.0 |
+| Fuzz smoke (`make test-rust-fuzz-smoke`) | LOCAL TAG AUDIT | Required for final local tag audit unless explicitly waived by the release owner |
+| Chunked native E2E smoke | LOCAL TAG AUDIT | Required for final local tag audit when `NGINX_BIN` is available |
+| Package smoke | RELEASE-WORKFLOW | Tag publishing path builds DEB/RPM artifacts, validates install layout, and runs package smoke before publication |
+| K8s smoke | FEASIBILITY | Chart lint/render remains GA blocking; live cluster smoke is non-blocking unless explicitly promoted |

--- a/docs/project/release-gates/0.7.0-release-gates.md
+++ b/docs/project/release-gates/0.7.0-release-gates.md
@@ -47,40 +47,45 @@
 
 ---
 
-## Gate 3: Package Distribution (Future/Experimental for 0.7.0)
+## Gate 3: Package Distribution
 
 | Check Item | Verification Command | Blocking Condition |
 |--------|---------|---------|
-| DEB build full matrix | CI workflow | Build failure |
-| RPM build full matrix | CI workflow | Build failure |
+| DEB build full matrix | Tag `release-packages.yml` workflow | Build failure |
+| RPM build full matrix | Tag `release-packages.yml` workflow | Build failure |
 | DEB package signature | `gpg --verify` | Invalid signature |
 | RPM package signature | `rpm -K` | Invalid signature |
 | DEB metadata integrity | `dpkg-deb --info` | Missing field |
 | RPM metadata integrity | `rpm -qip` | Missing field |
 | NGINX ABI dependency declaration | Package metadata check | Dependency missing or mismatched |
-| Install smoke (Ubuntu 22.04) | `dpkg -i + nginx -V + curl` | Install or verification failure |
-| Install smoke (AlmaLinux 9) | `rpm -i + nginx -V + curl` | Install or verification failure |
+| Install smoke | Tag `release-packages.yml` smoke-test matrix | Install or verification failure |
 | Upgrade/rollback tests | Version switch test | Upgrade or rollback failure |
 | Installation docs integrity | `make docs-check` | Docs missing or outdated |
 
 **Prerequisites**: Gate 2 passes
-**Acceptance Criteria**: Future scope; non-blocking for 0.7.0 GA unless explicitly promoted.
+**Acceptance Criteria**: GitHub Release DEB/RPM artifacts, checksums,
+install-layout validation, and package smoke tests pass before publication.
+APT/YUM repository publication is outside the 0.7.0 artifact channel until
+repository URLs, signing keys, and publication workflows are real and
+validated.
 
 ---
 
-## Gate 4: Kubernetes/Ingress (Feasibility only for 0.7.0)
+## Gate 4: Kubernetes/Ingress
 
 | Check Item | Verification Command | Blocking Condition |
 |--------|---------|---------|
 | Helm chart lint | `helm lint charts/nginx-markdown` | Lint failure |
 | Helm template rendering | `helm template test charts/nginx-markdown` | Rendering failure |
 | K8s manifest dry-run | `kubectl apply --dry-run=client -f manifest/` | Verification failure |
-| K8s smoke tests | Smoke script | Functionality not passing |
+| K8s smoke tests | Smoke script | Functionality not passing when promoted for the release |
 | Custom image build | `docker build` | Build failure |
-| F5 feasibility assessment | Documentation complete | Assessment incomplete |
+| F5 integration assessment | Documentation complete | Assessment incomplete |
 
 **Prerequisites**: Gate 3 passes
-**Acceptance Criteria**: Feasibility documentation only; non-blocking for 0.7.0 GA.
+**Acceptance Criteria**: Chart lint/render validation passes for 0.7.0 GA.
+Live cluster smoke and F5 integration evidence are release evidence inputs and
+become blocking only when explicitly promoted for the tag.
 
 ---
 
@@ -141,12 +146,17 @@
 | Gate 5 | Full team | After Phase 4 completion | All PASS |
 | Gate 6 | Release engineer | After fuzz/packaging integration | All PASS |
 
-**Final Go**: 0.7.0 release blocking scope is Gates 1, 2, 5, and 6. Gates 3/4 are tracked as future/feasibility unless promoted by explicit release decision.
+**Final Go**: 0.7.0 release blocking scope is Gates 1 through 6 as defined
+above. Gate 3 is satisfied by the tag `release-packages.yml` build,
+install-layout, checksum, and smoke-test chain. Gate 4 is satisfied by chart
+lint/render validation; live cluster smoke and F5 integration evidence are
+recorded as release evidence inputs when promoted for a tag.
 
 ## Document Updates
 
 | Version | Date | Author | Changes |
 |------|------|------|------|
 | 0.7.0-draft | 2026-05-17 | spec-agent | Initial v0.7.0 release gates definition |
-| 0.7.0-impl | 2026-05-18 | codex | Mark package/K8s gates as future/feasibility and clarify blocking scope |
+| 0.7.0-impl | 2026-05-18 | codex | Added implementation-era package/K8s gate scope notes |
 | 0.7.0-int | 2026-05-20 | spec-33 | Add Gate 6 (Fuzz & Packaging Infrastructure) reflecting validate_fuzz_packaging_070.py checks |
+| 0.7.0-final | 2026-05-29 | Kang | Finalized 0.7.0 package/K8s gates and moved release gate execution to tag publication |

--- a/docs/project/release-gates/v070-gates.md
+++ b/docs/project/release-gates/v070-gates.md
@@ -8,7 +8,7 @@
 | Source | design.md §14.0 |
 | Detailed Gates | [0.7.0-release-gates.md](./0.7.0-release-gates.md) |
 
-> This document defines the 5 release gates for v0.7.0 as specified in the
+> This document defines the 6 release gates for v0.7.0 as specified in the
 > technical design (§14.0). Each gate must pass before the release can proceed.
 > For detailed check items, verification commands, and Go/No-Go criteria, see
 > [0.7.0-release-gates.md](./0.7.0-release-gates.md).
@@ -79,7 +79,7 @@ for a tag.
 | 3.4 | Install smoke tests | `dpkg -i` + `rpm -i` + `nginx -V` + `curl` | Module loads and converts |
 | 3.5 | Upgrade/rollback tests | Version switch test | Upgrade and rollback succeed without service interruption |
 
-**Fail action**: Non-blocking for 0.7.0 GA (future scope). Track as P1 for next release.
+**Fail action**: Block release. Resolve package build, install-layout, checksum, smoke-test, or signature gaps before proceeding.
 
 ---
 
@@ -93,7 +93,7 @@ for a tag.
 | 4.2 | K8s smoke tests | Smoke script execution | Conversion, Accept negotiation, /metrics all pass |
 | 4.3 | F5 feasibility assessment | Documentation review | Assessment document complete with conclusions |
 
-**Fail action**: Non-blocking for 0.7.0 GA (feasibility scope). Track findings for future releases.
+**Fail action**: Block release. Resolve chart lint/render validation gaps before proceeding; record live cluster smoke when promoted for a tag.
 
 ---
 

--- a/docs/project/release-gates/v070-gates.md
+++ b/docs/project/release-gates/v070-gates.md
@@ -27,8 +27,11 @@ Gate 5: Operability + Docs (depends on Gate 1; can run parallel to Gates 2-4)
 Gate 6: Fuzz & Packaging Infrastructure (depends on Gate 1; validates specs 29-32 artifacts)
 ```
 
-**Release-blocking scope**: Gates 1, 2, 5, and 6 are blocking for 0.7.0 GA.
-Gates 3 and 4 are tracked as future/feasibility unless explicitly promoted.
+**Release-blocking scope**: Gates 1 through 6 are blocking for 0.7.0 GA as
+defined in this document. Gate 3 is satisfied by the tag package workflow's
+build, install-layout, checksum, and smoke-test chain. Gate 4 is satisfied by
+chart lint/render validation, with live cluster smoke recorded when promoted
+for a tag.
 
 ---
 

--- a/tools/release/gates/validate_release_gates_070.py
+++ b/tools/release/gates/validate_release_gates_070.py
@@ -33,14 +33,18 @@ HEADERS_IMPL_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_htt
 DECOMPRESSION_C = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_http_markdown_decompression.c"
 FILTER_MODULE_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_http_markdown_filter_module.h"
 
+GATE_1 = "Gate 1"
+GATE_2 = "Gate 2"
 GATE_3 = "Gate 3"
 GATE_4 = "Gate 4"
+GATE_5 = "Gate 5"
 GATE_LOCAL_SCRIPTS = {
     GATE_3: "gate3_local_package_smoke.sh",
     GATE_4: "gate4_local_k8s_smoke.sh",
 }
 RELEASE_GATES_070_DOC_GATE = "release-gates:070-doc"
 CARGO_VERSION_070_GATE = "cargo:version-070"
+BlockingItems = list[tuple[str, bool]]
 
 
 class ValidationResult:
@@ -255,7 +259,7 @@ def check_structure(result: ValidationResult) -> None:
     if not gates:
         result.fail(RELEASE_GATES_070_DOC_GATE, "missing release gate doc")
         return
-    if "Gate 1" in gates and "Gate 2" in gates and "Gate 3" in gates and "Gate 4" in gates and "Gate 5" in gates:
+    if all(gate in gates for gate in (GATE_1, GATE_2, GATE_3, GATE_4, GATE_5)):
         result.pass_(RELEASE_GATES_070_DOC_GATE, "gate doc includes Gate 1..5")
     else:
         result.fail(RELEASE_GATES_070_DOC_GATE, "gate definitions incomplete")
@@ -280,7 +284,125 @@ def check_structure(result: ValidationResult) -> None:
         result.fail(CARGO_VERSION_070_GATE, "Cargo.toml missing")
 
 
-def _build_blocking_items() -> dict[str, list[tuple[str, bool]]]:
+def _gate_1_items(
+    gates: str,
+    mk: str,
+    docs: str,
+    cfg: str,
+    err: str,
+    abi: str,
+    exports: str,
+    payload: str,
+    decomp: str,
+    filter_h: str,
+) -> BlockingItems:
+    return [
+        ("make test-nginx-unit-streaming", "`make test-nginx-unit-streaming`" in gates and "test-nginx-unit-streaming" in mk),
+        ("make test-rust", "`make test-rust`" in gates and re.search(r"\btest-rust:", mk) is not None),
+        ("make build && make check-headers", "check-headers" in mk and "make check-headers" in docs),
+        ("bounded decompression", "markdown_decompress_max_size" in cfg and "DecompressionBudgetExceeded" in err),
+        ("accept negotiation", "FFIAcceptResult" in abi and "markdown_negotiate_accept" in exports),
+        ("decomp budget exceeded metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(decompressions.budget_exceeded_total)" in payload),
+        ("decomp budget exceeded return code", "NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED" in filter_h and "NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED" in decomp),
+        ("decomp budget exceeded resource_limit path", "NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT" in payload and "DECOMP_BUDGET_EXCEEDED" in payload),
+    ]
+
+
+def _gate_2_items(
+    docs: str,
+    abi: str,
+    unit_test_files: str,
+    conversion: str,
+    payload: str,
+    decision_log: str,
+    headers: str,
+) -> BlockingItems:
+    return [
+        ("ffi boundary tests", "make test-nginx-unit" in docs and "make test-rust" in docs),
+        ("layout tests", "test_ffi_header_plan_layout" in abi and "test_ffi_accept_result_layout" in abi),
+        ("reason code source", "reason code" in read(FFI_CONTRACT_PATH).lower()),
+        ("delivery semantics tests", "delivery_counter_test.c" in unit_test_files),
+        ("delivery_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in conversion or "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in payload),
+        ("decision_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.decision_count)" in decision_log),
+        ("parse_timeouts_total metric write", "parse_interrupts.parse_timeouts_total" in conversion),
+        ("parse_budget_exceeded_total metric write", "parse_interrupts.parse_budget_exceeded_total" in conversion),
+        ("header plan ffi integration", "markdown_build_header_plan" in headers and "ngx_http_markdown_apply_header_plan" in headers),
+    ]
+
+
+def _gate_3_items(release_packages: str) -> BlockingItems:
+    return [
+        (
+            "tag package workflow gate",
+            "release-gate:" in release_packages
+            and "github.ref_type == 'tag'" in release_packages
+            and "needs: smoke-test" in release_packages,
+        ),
+        (
+            "release gate package tools",
+            "Install release gate dependencies" in release_packages
+            and "dpkg-dev" in release_packages
+            and "rpm" in release_packages,
+        ),
+        (
+            "package smoke matrix",
+            "smoke-test:" in release_packages
+            and "packaging/scripts/smoke-test-basic.sh" in release_packages,
+        ),
+        (
+            "install layout validation",
+            "check_install_layout.sh" in release_packages
+            and "dist/*.deb dist/*.rpm" in release_packages,
+        ),
+        (
+            "publish waits for release gate",
+            "needs: [release-gate, integrity-checksums, integrity-signing]" in release_packages
+            and "needs.release-gate.result == 'success'" in release_packages,
+        ),
+    ]
+
+
+def _gate_4_items(gates: str, docs: str) -> BlockingItems:
+    return [
+        (
+            "helm lint/render final scope",
+            "helm lint charts/nginx-markdown" in gates
+            and "helm template test charts/nginx-markdown" in gates
+            and "Chart lint/render validation passes for 0.7.0 GA" in gates,
+        ),
+        (
+            "k8s release matrix final scope",
+            "K8s chart lint/render validation is a 0.7.0 gate" in docs,
+        ),
+    ]
+
+
+def _gate_5_items(
+    mk: str,
+    gates: str,
+    release_packages: str,
+    release_deb: str,
+    release_rpm: str,
+) -> BlockingItems:
+    return [
+        ("make harness-check-full", "harness-check-full" in mk and "make harness-check-full" in gates),
+        ("make docs-check", "docs-check" in mk and "make docs-check" in gates),
+        ("release gates strict", "release-gates-check-strict" in mk),
+        ("release packages has nm preflight", "binutils" in release_packages and "command -v nm" in release_packages),
+        ("rust toolchain pinned", _toolchain_matches_cargo()),
+        ("release-packages pinned rust", _workflow_uses_pinned_toolchain(release_packages)),
+        ("release-deb pinned rust", _workflow_uses_pinned_toolchain(release_deb)),
+        ("release-rpm pinned rust", _workflow_uses_pinned_toolchain(release_rpm)),
+        ("release-packages build invariants", _workflow_has_release_build_invariants(release_packages)),
+        ("release-deb build invariants", _workflow_has_release_build_invariants(release_deb)),
+        ("release-rpm build invariants", _workflow_has_release_build_invariants(release_rpm)),
+        ("release-packages official marker", _workflow_identifies_release_path(release_packages, official=True)),
+        ("release-deb legacy marker", _workflow_identifies_release_path(release_deb, official=False)),
+        ("release-rpm legacy marker", _workflow_identifies_release_path(release_rpm, official=False)),
+    ]
+
+
+def _build_blocking_items() -> dict[str, BlockingItems]:
     """Build the blocking items dictionary from source file contents."""
     gates = read(RELEASE_GATES_MD)
     mk = read(MAKEFILE)
@@ -304,78 +426,11 @@ def _build_blocking_items() -> dict[str, list[tuple[str, bool]]]:
     )
 
     return {
-        "Gate 1": [
-            ("make test-nginx-unit-streaming", "`make test-nginx-unit-streaming`" in gates and "test-nginx-unit-streaming" in mk),
-            ("make test-rust", "`make test-rust`" in gates and re.search(r"\btest-rust:", mk) is not None),
-            ("make build && make check-headers", "check-headers" in mk and "make check-headers" in docs),
-            ("bounded decompression", "markdown_decompress_max_size" in cfg and "DecompressionBudgetExceeded" in err),
-            ("accept negotiation", "FFIAcceptResult" in abi and "markdown_negotiate_accept" in exports),
-            ("decomp budget exceeded metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(decompressions.budget_exceeded_total)" in payload),
-            ("decomp budget exceeded return code", "NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED" in filter_h and "NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED" in decomp),
-            ("decomp budget exceeded resource_limit path", "NGX_HTTP_MARKDOWN_ERROR_RESOURCE_LIMIT" in payload and "DECOMP_BUDGET_EXCEEDED" in payload),
-        ],
-        "Gate 2": [
-            ("ffi boundary tests", "make test-nginx-unit" in docs and "make test-rust" in docs),
-            ("layout tests", "test_ffi_header_plan_layout" in abi and "test_ffi_accept_result_layout" in abi),
-            ("reason code source", "reason code" in read(FFI_CONTRACT_PATH).lower()),
-            ("delivery semantics tests", "delivery_counter_test.c" in unit_test_files),
-            ("delivery_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in conversion or "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in payload),
-            ("decision_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.decision_count)" in decision_log),
-            ("parse_timeouts_total metric write", "parse_interrupts.parse_timeouts_total" in conversion),
-            ("parse_budget_exceeded_total metric write", "parse_interrupts.parse_budget_exceeded_total" in conversion),
-            ("header plan ffi integration", "markdown_build_header_plan" in headers and "ngx_http_markdown_apply_header_plan" in headers),
-        ],
-        "Gate 3": [
-            (
-                "tag package workflow gate",
-                "release-gate:" in release_packages
-                and "github.ref_type == 'tag'" in release_packages
-                and "needs: smoke-test" in release_packages,
-            ),
-            (
-                "package smoke matrix",
-                "smoke-test:" in release_packages
-                and "packaging/scripts/smoke-test-basic.sh" in release_packages,
-            ),
-            (
-                "install layout validation",
-                "check_install_layout.sh" in release_packages
-                and "dist/*.deb dist/*.rpm" in release_packages,
-            ),
-            (
-                "publish waits for release gate",
-                "needs: [release-gate, integrity-checksums, integrity-signing]" in release_packages
-                and "needs.release-gate.result == 'success'" in release_packages,
-            ),
-        ],
-        "Gate 4": [
-            (
-                "helm lint/render final scope",
-                "helm lint charts/nginx-markdown" in gates
-                and "helm template test charts/nginx-markdown" in gates
-                and "Chart lint/render validation passes for 0.7.0 GA" in gates,
-            ),
-            (
-                "k8s release matrix final scope",
-                "K8s chart lint/render validation is a 0.7.0 gate" in docs,
-            ),
-        ],
-        "Gate 5": [
-            ("make harness-check-full", "harness-check-full" in mk and "make harness-check-full" in gates),
-            ("make docs-check", "docs-check" in mk and "make docs-check" in gates),
-            ("release gates strict", "release-gates-check-strict" in mk),
-            ("release packages has nm preflight", "binutils" in release_packages and "command -v nm" in release_packages),
-            ("rust toolchain pinned", _toolchain_matches_cargo()),
-            ("release-packages pinned rust", _workflow_uses_pinned_toolchain(release_packages)),
-            ("release-deb pinned rust", _workflow_uses_pinned_toolchain(release_deb)),
-            ("release-rpm pinned rust", _workflow_uses_pinned_toolchain(release_rpm)),
-            ("release-packages build invariants", _workflow_has_release_build_invariants(release_packages)),
-            ("release-deb build invariants", _workflow_has_release_build_invariants(release_deb)),
-            ("release-rpm build invariants", _workflow_has_release_build_invariants(release_rpm)),
-            ("release-packages official marker", _workflow_identifies_release_path(release_packages, official=True)),
-            ("release-deb legacy marker", _workflow_identifies_release_path(release_deb, official=False)),
-            ("release-rpm legacy marker", _workflow_identifies_release_path(release_rpm, official=False)),
-        ],
+        GATE_1: _gate_1_items(gates, mk, docs, cfg, err, abi, exports, payload, decomp, filter_h),
+        GATE_2: _gate_2_items(docs, abi, unit_test_files, conversion, payload, decision_log, headers),
+        GATE_3: _gate_3_items(release_packages),
+        GATE_4: _gate_4_items(gates, docs),
+        GATE_5: _gate_5_items(mk, gates, release_packages, release_deb, release_rpm),
     }
 
 

--- a/tools/release/gates/validate_release_gates_070.py
+++ b/tools/release/gates/validate_release_gates_070.py
@@ -35,7 +35,6 @@ FILTER_MODULE_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_ht
 
 GATE_3 = "Gate 3"
 GATE_4 = "Gate 4"
-GATE_FUTURE = {GATE_3, GATE_4}
 GATE_LOCAL_SCRIPTS = {
     GATE_3: "gate3_local_package_smoke.sh",
     GATE_4: "gate4_local_k8s_smoke.sh",
@@ -326,6 +325,41 @@ def _build_blocking_items() -> dict[str, list[tuple[str, bool]]]:
             ("parse_budget_exceeded_total metric write", "parse_interrupts.parse_budget_exceeded_total" in conversion),
             ("header plan ffi integration", "markdown_build_header_plan" in headers and "ngx_http_markdown_apply_header_plan" in headers),
         ],
+        "Gate 3": [
+            (
+                "tag package workflow gate",
+                "release-gate:" in release_packages
+                and "github.ref_type == 'tag'" in release_packages
+                and "needs: smoke-test" in release_packages,
+            ),
+            (
+                "package smoke matrix",
+                "smoke-test:" in release_packages
+                and "packaging/scripts/smoke-test-basic.sh" in release_packages,
+            ),
+            (
+                "install layout validation",
+                "check_install_layout.sh" in release_packages
+                and "dist/*.deb dist/*.rpm" in release_packages,
+            ),
+            (
+                "publish waits for release gate",
+                "needs: [release-gate, integrity-checksums, integrity-signing]" in release_packages
+                and "needs.release-gate.result == 'success'" in release_packages,
+            ),
+        ],
+        "Gate 4": [
+            (
+                "helm lint/render final scope",
+                "helm lint charts/nginx-markdown" in gates
+                and "helm template test charts/nginx-markdown" in gates
+                and "Chart lint/render validation passes for 0.7.0 GA" in gates,
+            ),
+            (
+                "k8s release matrix final scope",
+                "K8s chart lint/render validation is a 0.7.0 gate" in docs,
+            ),
+        ],
         "Gate 5": [
             ("make harness-check-full", "harness-check-full" in mk and "make harness-check-full" in gates),
             ("make docs-check", "docs-check" in mk and "make docs-check" in gates),
@@ -350,14 +384,9 @@ def check_blocking_items(result: ValidationResult, mode: str) -> None:
     report = read(VALIDATION_MATRIX_MD) if mode == "evidence" else None
     _record_blocking_items(result, blocking_items, report)
 
-    for gate in sorted(GATE_FUTURE):
-        if os.environ.get("RELEASE_GATE_LOCAL_DOCKER") == "1":
+    if os.environ.get("RELEASE_GATE_LOCAL_DOCKER") == "1":
+        for gate in sorted(GATE_LOCAL_SCRIPTS):
             _run_local_gate(result, gate)
-        else:
-            result.skip(
-                f"{gate}:scope",
-                "future/feasibility gate; set RELEASE_GATE_LOCAL_DOCKER=1 to run locally via Docker",
-            )
 
 
 def print_report(result: ValidationResult) -> None:

--- a/tools/release/gates/validate_release_gates_070.py
+++ b/tools/release/gates/validate_release_gates_070.py
@@ -38,6 +38,8 @@ GATE_2 = "Gate 2"
 GATE_3 = "Gate 3"
 GATE_4 = "Gate 4"
 GATE_5 = "Gate 5"
+GATE_6 = "Gate 6"
+ALL_GATES = (GATE_1, GATE_2, GATE_3, GATE_4, GATE_5, GATE_6)
 GATE_LOCAL_SCRIPTS = {
     GATE_3: "gate3_local_package_smoke.sh",
     GATE_4: "gate4_local_k8s_smoke.sh",
@@ -259,8 +261,8 @@ def check_structure(result: ValidationResult) -> None:
     if not gates:
         result.fail(RELEASE_GATES_070_DOC_GATE, "missing release gate doc")
         return
-    if all(gate in gates for gate in (GATE_1, GATE_2, GATE_3, GATE_4, GATE_5)):
-        result.pass_(RELEASE_GATES_070_DOC_GATE, "gate doc includes Gate 1..5")
+    if all(gate in gates for gate in ALL_GATES):
+        result.pass_(RELEASE_GATES_070_DOC_GATE, "gate doc includes Gate 1..6")
     else:
         result.fail(RELEASE_GATES_070_DOC_GATE, "gate definitions incomplete")
 
@@ -310,6 +312,7 @@ def _gate_1_items(
 
 def _gate_2_items(
     docs: str,
+    ffi_contract: str,
     abi: str,
     unit_test_files: str,
     conversion: str,
@@ -320,7 +323,7 @@ def _gate_2_items(
     return [
         ("ffi boundary tests", "make test-nginx-unit" in docs and "make test-rust" in docs),
         ("layout tests", "test_ffi_header_plan_layout" in abi and "test_ffi_accept_result_layout" in abi),
-        ("reason code source", "reason code" in read(FFI_CONTRACT_PATH).lower()),
+        ("reason code source", "reason code" in ffi_contract.lower()),
         ("delivery semantics tests", "delivery_counter_test.c" in unit_test_files),
         ("delivery_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in conversion or "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in payload),
         ("decision_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.decision_count)" in decision_log),
@@ -402,6 +405,26 @@ def _gate_5_items(
     ]
 
 
+def _gate_6_items(
+    mk: str,
+    gates: str,
+    release_packages: str,
+) -> BlockingItems:
+    return [
+        ("fuzz packaging validator", "validate_fuzz_packaging_070.py" in mk and "validate_fuzz_packaging_070.py" in gates),
+        ("fuzz target coverage", "fuzz:targets-exist" in gates and "fuzz/Cargo.toml" in gates),
+        ("clusterfuzzlite workflows", "fuzz:cflite-pr-workflow" in gates and "fuzz:cflite-batch-workflow" in gates),
+        ("corpus pruning", "fuzz:corpus-pruning" in gates and "cflite_cron.yml" in gates),
+        ("fuzz guide rules", "fuzz:guide-rules" in gates and "FUZZ-001..007" in gates),
+        ("release package workflow", "pkg:release-workflow" in gates and "release-packages.yml" in gates),
+        ("artifact naming with nginx version", "pkg:artifact-naming-workflow" in gates and "NGINX_VERSION" in gates),
+        ("sha256sums generation", "pkg:sha256sums" in gates and "SHA256SUMS" in gates),
+        ("install compatibility docs", "docs:install" in gates and "docs:compatibility" in gates),
+        ("package smoke test job", "pkg:smoke-test-job" in gates and "smoke test job" in gates.lower()),
+        ("release workflow checksum logic", "SHA256SUMS" in release_packages),
+    ]
+
+
 def _build_blocking_items() -> dict[str, BlockingItems]:
     """Build the blocking items dictionary from source file contents."""
     gates = read(RELEASE_GATES_MD)
@@ -409,6 +432,7 @@ def _build_blocking_items() -> dict[str, BlockingItems]:
     docs = read(VALIDATION_MATRIX_MD)
     cfg = read(CONFIG_DIRECTIVES_H)
     err = read(ERROR_RS)
+    ffi_contract = read(FFI_CONTRACT_PATH)
     abi = read(ABI_RS)
     exports = read(EXPORTS_RS)
     payload = read(PAYLOAD_IMPL_H)
@@ -427,10 +451,20 @@ def _build_blocking_items() -> dict[str, BlockingItems]:
 
     return {
         GATE_1: _gate_1_items(gates, mk, docs, cfg, err, abi, exports, payload, decomp, filter_h),
-        GATE_2: _gate_2_items(docs, abi, unit_test_files, conversion, payload, decision_log, headers),
+        GATE_2: _gate_2_items(
+            docs,
+            ffi_contract,
+            abi,
+            unit_test_files,
+            conversion,
+            payload,
+            decision_log,
+            headers,
+        ),
         GATE_3: _gate_3_items(release_packages),
         GATE_4: _gate_4_items(gates, docs),
         GATE_5: _gate_5_items(mk, gates, release_packages, release_deb, release_rpm),
+        GATE_6: _gate_6_items(mk, gates, release_packages),
     }
 
 


### PR DESCRIPTION


## Summary by Sourcery

Run v0.7.0 release gates only from the tagged release packaging workflow and finalize the 0.7.0 release scope and documentation accordingly.

Enhancements:
- Refactor 0.7.0 gate validation code into per-gate helpers and shared constants while expanding coverage to include package and Kubernetes gates.
- Adjust release gate execution to run via a tag-only job in the release-packages workflow after smoke tests and before publish, making publish depend on release-gate success or skip.

CI:
- Remove the standalone v0.7.0 release-gates CI job and introduce a tag-only release-gate job in the release-packages workflow that validates DEB/RPM artifacts and install layout before publication.

Documentation:
- Mark 0.7.0 documents as FINAL, clarify that DEB/RPM GitHub Release artifacts are the GA distribution channel while APT/YUM repositories and live K8s smoke are post-GA or non-blocking, and update gate/validation matrix docs to reflect tag-only release gate policy and final blocking scope.
- Clarify documentation around package installation, repository publishing prerequisites, and GPG key management to align with the 0.7.0 GA channel definition.
- Update English and Chinese READMEs and related guides to describe repository publishing as post-0.7.0 work and adjust language around future vs. post-GA exploration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated: added a tag-only release-gate validation step for packaged releases and removed an older release-gates job; publish now depends on the new gate.

* **Documentation**
  * Clarified v0.7.0 GA packaging: GitHub Releases deliver DEB/RPM artifacts; APT/YUM repos are not part of 0.7.0 GA.
  * Multiple v0.7.0 docs marked FINAL and release-gate guidance expanded for package and Kubernetes validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnkang/nginx-markdown-for-agents/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->