### PR TITLE
fix(streaming): const-qualify read-only params for Sonar S995

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -509,14 +509,14 @@ coverage-c:
 	lcov --add-tracefile $(COVERAGE_DIR)/tmp/c-e2e-coverage.lcov \
 	--add-tracefile $(COVERAGE_DIR)/tmp/c-unit/c-coverage.lcov \
 	--output-file $(COVERAGE_DIR)/tmp/c-combined-raw.lcov \
-	--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors inconsistent
+	--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors inconsistent,inconsistent --ignore-errors count,count
 	lcov --extract $(COVERAGE_DIR)/tmp/c-combined-raw.lcov \
 	"*/components/nginx-module/src/*" \
 	--output-file $(COVERAGE_DIR)/c-coverage.lcov \
-	--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors unused --ignore-errors inconsistent
+	--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors unused,unused --ignore-errors inconsistent,inconsistent
 	@echo "==> Combined C coverage report: $(COVERAGE_DIR)/c-coverage.lcov"
 	lcov --summary $(COVERAGE_DIR)/c-coverage.lcov --rc branch_coverage=1 \
-	--ignore-errors inconsistent
+	--ignore-errors inconsistent,inconsistent
 
 coverage-rust:
 	@mkdir -p $(COVERAGE_DIR)

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -73,7 +73,7 @@ static ngx_int_t
 ngx_http_markdown_streaming_process_chunk(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
-    ngx_http_markdown_conf_t *conf,
+    const ngx_http_markdown_conf_t *conf,
     const ngx_buf_t *buf);
 
 /*
@@ -360,7 +360,7 @@ static ngx_int_t
 ngx_http_markdown_streaming_ensure_handle(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
-    ngx_http_markdown_conf_t *conf,
+    const ngx_http_markdown_conf_t *conf,
     ngx_chain_t *in);
 
 /*
@@ -492,7 +492,7 @@ ngx_http_markdown_is_excluded_stream_type(
  */
 static void
 ngx_http_markdown_log_conditional_streaming(
-    ngx_http_request_t *r,
+    const ngx_http_request_t *r,
     const ngx_http_markdown_conf_t *conf)
 {
     /* r is used only inside ngx_log_debug0 which compiles to nothing
@@ -1754,7 +1754,7 @@ static ngx_int_t
 ngx_http_markdown_streaming_process_chunk(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
-    ngx_http_markdown_conf_t *conf,
+    const ngx_http_markdown_conf_t *conf,
     const ngx_buf_t *buf)
 {
     const u_char  *feed_data;
@@ -1878,7 +1878,7 @@ static ngx_int_t
 ngx_http_markdown_streaming_finalize_decomp(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
-    ngx_http_markdown_conf_t *conf)
+    const ngx_http_markdown_conf_t *conf)
 {
     u_char    *decomp_data;
     size_t     decomp_len;
@@ -2798,7 +2798,7 @@ static ngx_int_t
 ngx_http_markdown_streaming_ensure_handle(
     ngx_http_request_t *r,
     ngx_http_markdown_ctx_t *ctx,
-    ngx_http_markdown_conf_t *conf,
+    const ngx_http_markdown_conf_t *conf,
     ngx_chain_t *in)
 {
     ngx_int_t  rc;

--- a/components/nginx-module/tests/Makefile
+++ b/components/nginx-module/tests/Makefile
@@ -114,10 +114,10 @@ unit-coverage:
 		LDFLAGS_COMMON="--coverage"
 	@mkdir -p $(COV_DIR)
 	lcov --capture --directory build/unit --output-file $(COV_DIR)/raw.lcov \
-		--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors inconsistent
-	lcov --remove $(COV_DIR)/raw.lcov '*/tests/*' '/usr/*' \
+		--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors inconsistent,inconsistent --ignore-errors unsupported,unsupported
+	lcov --remove $(COV_DIR)/raw.lcov '*/tests/*' \
 		--output-file $(COV_DIR)/c-coverage.lcov \
-		--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors unused --ignore-errors inconsistent
+		--rc branch_coverage=1 --rc geninfo_unexecuted_blocks=1 --ignore-errors unused,unused --ignore-errors inconsistent,inconsistent
 	@rm -f $(COV_DIR)/raw.lcov
 	@echo "C coverage report: $(COV_DIR)/c-coverage.lcov"
 

--- a/tools/sonar/collect_nginx_coverage.sh
+++ b/tools/sonar/collect_nginx_coverage.sh
@@ -135,7 +135,10 @@ build_lcov_ignore_args() {
   # inconsistent: lcov limitation with branch tracking on multi-condition
   # if/else-if chains — line coverage is correct, only branch counts are
   # affected.  Known issue: https://github.com/linux-test-project/lcov/issues/296
-  args="--ignore-errors inconsistent"
+  #
+  # Repeat the same category twice to suppress message spam while still
+  # producing the report.
+  args="--ignore-errors inconsistent,inconsistent"
 
   if [[ "$(uname -s)" == "Darwin" ]]; then
     # mismatch: Apple Clang gcov produces version-mismatched .gcno/.gcda


### PR DESCRIPTION
## Summary by Sourcery

Const-qualify read-only request and configuration parameters in the nginx markdown streaming implementation to align with static analysis rules.

Enhancements:
- Ensure nginx markdown streaming functions treat configuration and request parameters as const where they are not modified, improving code safety and clarity.

Chores:
- Address Sonar rule S995 by updating function signatures to use const for read-only arguments in the streaming codepath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety in internal streaming helper functions through improved const-correctness annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->