### PR TITLE
Implement v0.8.0 streaming config directives and update documentation

### DIFF
--- a/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
@@ -294,6 +294,13 @@ ngx_http_markdown_create_conf(ngx_conf_t *cf)
     conf->streaming.auto_threshold = NGX_CONF_UNSET_SIZE;
 #endif
 
+    /* v0.8.0 streaming config (spec 36) */
+    conf->stream.engine = NGX_CONF_UNSET_UINT;
+    conf->stream.threshold = NGX_CONF_UNSET_SIZE;
+    conf->stream.precommit_buffer = NGX_CONF_UNSET_SIZE;
+    conf->stream.flush_min = NGX_CONF_UNSET_SIZE;
+    conf->stream.excluded_types = NGX_CONF_UNSET_PTR;
+
     conf->advanced.prune_noise = NGX_CONF_UNSET;
     conf->advanced.prune_selectors = NGX_CONF_UNSET_PTR;
     conf->advanced.prune_protection_selectors = NGX_CONF_UNSET_PTR;
@@ -504,6 +511,30 @@ ngx_http_markdown_merge_streaming_values(ngx_http_markdown_conf_t *conf,
 #endif
 
 /*
+ * Merge v0.8.0 streaming configuration (spec 36).
+ *
+ * Provides http→server→location inheritance for the streaming
+ * directives added in 0.8.0.  These are independent of the older
+ * MARKDOWN_STREAMING_ENABLED feature-gated fields.
+ */
+static void
+ngx_http_markdown_merge_stream_values(ngx_http_markdown_conf_t *conf,
+    const ngx_http_markdown_conf_t *prev)
+{
+    ngx_conf_merge_uint_value(conf->stream.engine,
+                              prev->stream.engine,
+                              NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO);
+    ngx_conf_merge_size_value(conf->stream.threshold,
+                              prev->stream.threshold, 1048576);
+    ngx_conf_merge_size_value(conf->stream.precommit_buffer,
+                              prev->stream.precommit_buffer, 262144);
+    ngx_conf_merge_size_value(conf->stream.flush_min,
+                              prev->stream.flush_min, 16384);
+    ngx_conf_merge_ptr_value(conf->stream.excluded_types,
+                             prev->stream.excluded_types, NULL);
+}
+
+/*
  * Merge v0.6.0-specific configuration surfaces.
  */
 static void
@@ -561,6 +592,9 @@ ngx_http_markdown_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 #ifdef MARKDOWN_STREAMING_ENABLED
     ngx_http_markdown_merge_streaming_values(conf, prev, streaming_budget_set);
 #endif
+
+    /* v0.8.0 streaming config (spec 36) */
+    ngx_http_markdown_merge_stream_values(conf, prev);
 
     ngx_http_markdown_merge_v060_values(conf, prev);
 

--- a/components/nginx-module/src/ngx_http_markdown_config_directives_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_directives_impl.h
@@ -1224,6 +1224,129 @@ static ngx_command_t ngx_http_markdown_filter_commands[] = {
         NULL
     },
 
+    /*
+     * markdown_streaming_engine off|auto|on
+     *
+     * v0.8.0 core engine switch for true streaming availability.
+     * - off: streaming disabled
+     * - auto: automatic selection based on threshold (default)
+     * - on: streaming always enabled for eligible responses
+     *
+     * When MARKDOWN_STREAMING_ENABLED is compiled in, the v0.6.0
+     * complex-value handler above takes precedence for this
+     * directive name (supports $variable per-request rollout).
+     *
+     * Default: auto
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_streaming_engine on;
+     */
+#ifndef MARKDOWN_STREAMING_ENABLED
+    {
+        ngx_string("markdown_streaming_engine"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_markdown_stream_engine_handler,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+#endif
+
+    /*
+     * markdown_stream_threshold <size>
+     *
+     * Minimum response size for streaming candidacy.
+     * Responses with Content-Length below this value use
+     * full-buffer conversion.  Zero is rejected.
+     *
+     * Default: 1m (1048576 bytes)
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_stream_threshold 512k;
+     */
+    {
+        ngx_string("markdown_stream_threshold"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_markdown_stream_threshold_handler,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+
+    /*
+     * markdown_stream_precommit_buffer <size>
+     *
+     * Size of the pre-commit replay buffer for streaming fallback.
+     * Zero is allowed (disables pre-commit HTML fallback capability).
+     *
+     * Default: 256k (262144 bytes)
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_stream_precommit_buffer 128k;
+     *   markdown_stream_precommit_buffer 0;
+     */
+    {
+        ngx_string("markdown_stream_precommit_buffer"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_size_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_markdown_conf_t, stream.precommit_buffer),
+        NULL
+    },
+
+    /*
+     * markdown_stream_flush_min <size>
+     *
+     * Minimum Markdown output batch size before flushing
+     * downstream.  Must be greater than zero to avoid
+     * pathological per-byte flushing.
+     *
+     * Default: 16k (16384 bytes)
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_stream_flush_min 32k;
+     */
+    {
+        ngx_string("markdown_stream_flush_min"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_markdown_stream_flush_min_handler,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+
+    /*
+     * markdown_stream_excluded_types <type> [<type> ...]
+     *
+     * Content types that should never enter streaming conversion.
+     * User-configured types are additive to built-in hard
+     * exclusions (text/event-stream, application/x-ndjson,
+     * application/stream+json).
+     *
+     * Default: none (only built-in hard exclusions apply)
+     * Context: http, server, location
+     *
+     * Example:
+     *   markdown_stream_excluded_types text/csv application/xml;
+     */
+    {
+        ngx_string("markdown_stream_excluded_types"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF
+            |NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+        ngx_http_markdown_stream_excluded_types_handler,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+
     ngx_null_command
 };
 

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -989,6 +989,8 @@ ngx_http_markdown_set_dynconf_path(ngx_conf_t *cf, ngx_command_t *cmd,
  * time and reject invalid input with clear error messages.
  */
 
+#if !defined(MARKDOWN_STREAMING_ENABLED)                                      \
+    || defined(NGX_HTTP_MARKDOWN_TEST_LEGACY_STREAM_ENGINE_HANDLER)
 /*
  * Configuration directive handler: markdown_streaming_engine (v0.8.0)
  *
@@ -1041,6 +1043,7 @@ ngx_http_markdown_stream_engine_handler(ngx_conf_t *cf,
 
     return NGX_CONF_OK;
 }
+#endif
 
 /*
  * Configuration directive handler: markdown_stream_threshold (v0.8.0)

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -981,4 +981,254 @@ ngx_http_markdown_set_dynconf_path(ngx_conf_t *cf, ngx_command_t *cmd,
     return NGX_CONF_OK;
 }
 
+/*
+ * v0.8.0 streaming directive handlers (spec 36).
+ *
+ * These handlers parse the new streaming configuration directives
+ * defined in RFC 0008 section 2.  They validate values at config-parse
+ * time and reject invalid input with clear error messages.
+ */
+
+/*
+ * Configuration directive handler: markdown_streaming_engine (v0.8.0)
+ *
+ * Accepts exactly: off, auto, on.
+ * Stores as ngx_uint_t enum in conf->stream.engine.
+ *
+ * Parameters:
+ *   cf   - configuration context
+ *   cmd  - directive definition
+ *   conf - location configuration pointer
+ *
+ * Returns:
+ *   NGX_CONF_OK on success, NGX_CONF_ERROR on invalid value
+ */
+static char *
+ngx_http_markdown_stream_engine_handler(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t *mcf = conf;
+    ngx_str_t                *value;
+
+    (void) cmd;
+
+    value = cf->args->elts;
+
+    if (mcf->stream.engine != NGX_CONF_UNSET_UINT) {
+        return "is duplicate";
+    }
+
+    if (value[1].len == 3
+        && ngx_strncmp(value[1].data, "off", 3) == 0)
+    {
+        mcf->stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF;
+    } else if (value[1].len == 4
+               && ngx_strncmp(value[1].data, "auto", 4) == 0)
+    {
+        mcf->stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO;
+    } else if (value[1].len == 2
+               && ngx_strncmp(value[1].data, "on", 2) == 0)
+    {
+        mcf->stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON;
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "invalid value \"%V\" in "
+            "\"markdown_streaming_engine\" directive, "
+            "it must be \"off\", \"auto\", or \"on\"",
+            &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+/*
+ * Configuration directive handler: markdown_stream_threshold (v0.8.0)
+ *
+ * Accepts NGINX size values (e.g. 1m, 512k).
+ * Rejects zero or negative values.
+ *
+ * Parameters:
+ *   cf   - configuration context
+ *   cmd  - directive definition
+ *   conf - location configuration pointer
+ *
+ * Returns:
+ *   NGX_CONF_OK on success, NGX_CONF_ERROR on invalid value
+ */
+static char *
+ngx_http_markdown_stream_threshold_handler(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t *mcf = conf;
+    ngx_str_t                *value;
+    size_t                    parsed;
+
+    (void) cmd;
+
+    value = cf->args->elts;
+
+    if (mcf->stream.threshold != NGX_CONF_UNSET_SIZE) {
+        return "is duplicate";
+    }
+
+    parsed = ngx_http_markdown_parse_size(&value[1]);
+    if (parsed == (size_t) NGX_ERROR) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "invalid value \"%V\" in "
+            "\"markdown_stream_threshold\" directive",
+            &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    if (parsed == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "\"markdown_stream_threshold\" must be "
+            "greater than zero");
+        return NGX_CONF_ERROR;
+    }
+
+    mcf->stream.threshold = parsed;
+    return NGX_CONF_OK;
+}
+
+/*
+ * Configuration directive handler: markdown_stream_flush_min (v0.8.0)
+ *
+ * Accepts NGINX size values (e.g. 16k, 32k).
+ * Value MUST be greater than zero to avoid pathological
+ * per-byte flushing and backpressure amplification.
+ *
+ * Parameters:
+ *   cf   - configuration context
+ *   cmd  - directive definition
+ *   conf - location configuration pointer
+ *
+ * Returns:
+ *   NGX_CONF_OK on success, NGX_CONF_ERROR on invalid value
+ */
+static char *
+ngx_http_markdown_stream_flush_min_handler(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t *mcf = conf;
+    ngx_str_t                *value;
+    size_t                    parsed;
+
+    (void) cmd;
+
+    value = cf->args->elts;
+
+    if (mcf->stream.flush_min != NGX_CONF_UNSET_SIZE) {
+        return "is duplicate";
+    }
+
+    parsed = ngx_http_markdown_parse_size(&value[1]);
+    if (parsed == (size_t) NGX_ERROR) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "invalid value \"%V\" in "
+            "\"markdown_stream_flush_min\" directive",
+            &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    if (parsed == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "\"markdown_stream_flush_min\" must be "
+            "greater than zero");
+        return NGX_CONF_ERROR;
+    }
+
+    mcf->stream.flush_min = parsed;
+    return NGX_CONF_OK;
+}
+
+/*
+ * Configuration directive handler: markdown_stream_excluded_types (v0.8.0)
+ *
+ * Parses a space-separated list of MIME types and stores them in
+ * conf->stream.excluded_types array.  Each type must be in
+ * "type/subtype" format.
+ *
+ * Parameters:
+ *   cf   - configuration context
+ *   cmd  - directive definition
+ *   conf - location configuration pointer
+ *
+ * Returns:
+ *   NGX_CONF_OK on success, NGX_CONF_ERROR on allocation or
+ *   validation failure
+ */
+static char *
+ngx_http_markdown_stream_excluded_types_handler(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_markdown_conf_t *mcf = conf;
+    ngx_str_t                *value;
+    ngx_str_t                *type;
+    u_char                   *slash;
+    const u_char             *next_slash;
+    ngx_uint_t                i;
+
+    (void) cmd;
+
+    value = cf->args->elts;
+
+    if (mcf->stream.excluded_types != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    mcf->stream.excluded_types = ngx_array_create(cf->pool,
+        cf->args->nelts - 1, sizeof(ngx_str_t));
+    if (mcf->stream.excluded_types == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    for (i = 1; i < cf->args->nelts; i++) {
+        if (value[i].len == 0) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "empty content type in "
+                "\"markdown_stream_excluded_types\" "
+                "directive");
+            return NGX_CONF_ERROR;
+        }
+
+        slash = ngx_strlchr(value[i].data,
+            value[i].data + value[i].len, '/');
+        next_slash = NULL;
+
+        if (slash != NULL
+            && (size_t) ((slash - value[i].data) + 1)
+               < value[i].len)
+        {
+            next_slash = ngx_strlchr(slash + 1,
+                value[i].data + value[i].len, '/');
+        }
+
+        if (slash == NULL
+            || slash == value[i].data
+            || (size_t) (slash - value[i].data)
+               == value[i].len - 1
+            || next_slash != NULL)
+        {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "invalid content type \"%V\" in "
+                "\"markdown_stream_excluded_types\" "
+                "directive, must be in format "
+                "\"type/subtype\"",
+                &value[i]);
+            return NGX_CONF_ERROR;
+        }
+
+        type = ngx_array_push(mcf->stream.excluded_types);
+        if (type == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *type = value[i];
+    }
+
+    return NGX_CONF_OK;
+}
+
 #endif /* NGX_HTTP_MARKDOWN_CONFIG_HANDLERS_IMPL_H */

--- a/components/nginx-module/src/ngx_http_markdown_config_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_impl.h
@@ -52,6 +52,14 @@ static char *ngx_http_markdown_log_verbosity(ngx_conf_t *cf, ngx_command_t *cmd,
 static char *ngx_http_markdown_stream_types(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 /* Parse content types eligible for Markdown conversion (positive allowlist). */
 static char *ngx_http_markdown_content_types(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+/* Parse v0.8.0 markdown_streaming_engine enum: off, auto, on. */
+static char *ngx_http_markdown_stream_engine_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+/* Parse v0.8.0 markdown_stream_threshold with zero-rejection. */
+static char *ngx_http_markdown_stream_threshold_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+/* Parse v0.8.0 markdown_stream_flush_min with zero-rejection. */
+static char *ngx_http_markdown_stream_flush_min_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+/* Parse v0.8.0 markdown_stream_excluded_types MIME list. */
+static char *ngx_http_markdown_stream_excluded_types_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 /* Parse large body threshold for incremental path routing. */
 static char *ngx_http_markdown_large_body_threshold(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 /* Parse metrics endpoint enablement and URI settings. */

--- a/components/nginx-module/src/ngx_http_markdown_config_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_impl.h
@@ -52,8 +52,12 @@ static char *ngx_http_markdown_log_verbosity(ngx_conf_t *cf, ngx_command_t *cmd,
 static char *ngx_http_markdown_stream_types(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 /* Parse content types eligible for Markdown conversion (positive allowlist). */
 static char *ngx_http_markdown_content_types(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+#if !defined(MARKDOWN_STREAMING_ENABLED)                                      \
+    || defined(NGX_HTTP_MARKDOWN_TEST_LEGACY_STREAM_ENGINE_HANDLER)
 /* Parse v0.8.0 markdown_streaming_engine enum: off, auto, on. */
-static char *ngx_http_markdown_stream_engine_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_http_markdown_stream_engine_handler(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+#endif
 /* Parse v0.8.0 markdown_stream_threshold with zero-rejection. */
 static char *ngx_http_markdown_stream_threshold_handler(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 /* Parse v0.8.0 markdown_stream_flush_min with zero-rejection. */

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -340,6 +340,111 @@ ngx_http_markdown_check_eligibility(const ngx_http_request_t *r,
 }
 
 /*
+ * Check whether a content type is excluded from streaming conversion.
+ *
+ * Returns the union of built-in hard exclusions (text/event-stream,
+ * application/x-ndjson, application/stream+json) and the user-configured
+ * conf->stream.excluded_types array.
+ *
+ * Matching is case-insensitive and ignores Content-Type parameters
+ * (anything after the first ';').  NULL or empty content_type is
+ * treated as not excluded.
+ *
+ * Requirements: Spec 36 Requirement 5 AC 2, AC 3, AC 4
+ *
+ * Parameters:
+ *   content_type - Content-Type string to check (may be NULL)
+ *   conf         - Module location configuration
+ *
+ * Returns:
+ *   1 if the content type is excluded from streaming
+ *   0 if the content type is not excluded
+ */
+ngx_int_t
+ngx_http_markdown_stream_type_excluded(const ngx_str_t *content_type,
+    const ngx_http_markdown_conf_t *conf)
+{
+    static u_char  text_event_stream[] = "text/event-stream";
+    static u_char  application_x_ndjson[] = "application/x-ndjson";
+    static u_char  application_stream_json[] = "application/stream+json";
+
+    size_t               type_len;
+    ngx_uint_t           i;
+    const ngx_str_t     *entry;
+    u_char              *p;
+
+    /* NULL or empty content type is not excluded */
+    if (content_type == NULL || content_type->len == 0
+        || content_type->data == NULL)
+    {
+        return 0;
+    }
+
+    /*
+     * Normalize: determine the effective type length by stripping
+     * Content-Type parameters (everything after ';').
+     */
+    type_len = content_type->len;
+    p = ngx_strlchr(content_type->data,
+                    content_type->data + content_type->len, ';');
+    if (p != NULL) {
+        type_len = (size_t) (p - content_type->data);
+    }
+
+    /* Strip trailing whitespace from the type portion */
+    while (type_len > 0 && content_type->data[type_len - 1] == ' ') {
+        type_len--;
+    }
+
+    if (type_len == 0) {
+        return 0;
+    }
+
+    /* Check built-in hard exclusions (cannot be removed by user config) */
+
+    /* text/event-stream (17 chars) */
+    if (type_len == 17
+        && ngx_strncasecmp(content_type->data, text_event_stream, 17) == 0)
+    {
+        return 1;
+    }
+
+    /* application/x-ndjson (20 chars) */
+    if (type_len == 20
+        && ngx_strncasecmp(content_type->data,
+                           application_x_ndjson, 20) == 0)
+    {
+        return 1;
+    }
+
+    /* application/stream+json (23 chars) */
+    if (type_len == 23
+        && ngx_strncasecmp(content_type->data,
+                           application_stream_json, 23) == 0)
+    {
+        return 1;
+    }
+
+    /* Check user-configured exclusion array */
+    if (conf != NULL && conf->stream.excluded_types != NULL) {
+        entry = conf->stream.excluded_types->elts;
+
+        for (i = 0; i < conf->stream.excluded_types->nelts; i++) {
+            if (type_len == entry[i].len
+                && ngx_strncasecmp(content_type->data,
+                                   entry[i].data,
+                                   entry[i].len) == 0)
+            {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+
+/*
  * Get human-readable string for eligibility result
  *
  * Useful for logging and debugging.

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -113,6 +113,17 @@ typedef struct ngx_http_markdown_otel_span_s  ngx_http_markdown_otel_span_t;
 #endif /* MARKDOWN_STREAMING_ENABLED */
 
 /*
+ * v0.8.0 streaming engine mode constants (markdown_streaming_engine directive).
+ *
+ * These are distinct from the v0.6.0 MARKDOWN_STREAMING_ENABLED constants
+ * above.  The 0.8.0 directive uses a simple enum stored as ngx_uint_t
+ * rather than a complex value.
+ */
+#define NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF   0
+#define NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO  1
+#define NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON    2
+
+/*
  * Threshold off sentinel — used in merge and path selection logic.
  */
 #define NGX_HTTP_MARKDOWN_THRESHOLD_OFF     0
@@ -222,6 +233,13 @@ typedef enum {
  * - streaming_on_error: NGX_HTTP_MARKDOWN_STREAMING_ON_ERROR_PASS
  * - streaming_shadow: 0 (off by default)
  * - streaming_auto_threshold: NGX_HTTP_MARKDOWN_STREAMING_AUTO_THRESHOLD_DEFAULT
+ *
+ * v0.8.0 streaming config defaults (spec 36):
+ * - stream.engine: auto (1)
+ * - stream.threshold: 1048576 (1m)
+ * - stream.precommit_buffer: 262144 (256k)
+ * - stream.flush_min: 16384 (16k)
+ * - stream.excluded_types: NULL
  */
 /* sonarcloud-c:S1820: intentionally exceeded; fields are already logically
  * grouped via the ops sub-struct and #ifdef-gated streaming section.  Further
@@ -318,6 +336,21 @@ typedef struct {
 #ifdef MARKDOWN_STREAMING_ENABLED
     ngx_http_markdown_streaming_cfg_t streaming;
 #endif
+
+    /*
+     * v0.8.0 streaming configuration directives (spec 36).
+     *
+     * These fields implement the RFC 0008 section 2 streaming control
+     * directives.  They are parsed but not acted upon until specs 37-38
+     * implement runtime streaming logic.
+     */
+    struct {
+        ngx_uint_t    engine;              /* markdown_streaming_engine off|auto|on */
+        size_t        threshold;           /* markdown_stream_threshold (default: 1m) */
+        size_t        precommit_buffer;    /* markdown_stream_precommit_buffer (default: 256k) */
+        size_t        flush_min;           /* markdown_stream_flush_min (default: 16k) */
+        ngx_array_t  *excluded_types;      /* markdown_stream_excluded_types (default: NULL) */
+    } stream;
 
     /*
      * Noise pruning configuration (v0.6.0).
@@ -889,6 +922,11 @@ ngx_http_markdown_eligibility_t ngx_http_markdown_check_eligibility(
 /* Get human-readable string for eligibility result */
 const ngx_str_t *ngx_http_markdown_eligibility_string(
     ngx_http_markdown_eligibility_t eligibility);
+
+/* Check whether a content type is excluded from streaming (spec 36) */
+ngx_int_t ngx_http_markdown_stream_type_excluded(
+    const ngx_str_t *content_type,
+    const ngx_http_markdown_conf_t *conf);
 
 /*
  * Reason code lookup functions

--- a/components/nginx-module/tests/Makefile
+++ b/components/nginx-module/tests/Makefile
@@ -52,6 +52,7 @@ build/unit/%: unit/%_test.c include/test_common.h include/test_metrics_snapshot.
 	  streaming_impl) extra_cflags="-I../src -Iinclude/nginx_stubs -I../../rust-converter/include -DMARKDOWN_STREAMING_ENABLED -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS) -lz" ;; \
 	  conversion_impl_base_url) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
 	  config_handlers_impl) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
+	  streaming_config_contract) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
 	  eligibility_impl) extra_cflags="-Iinclude/nginx_stubs -DMARKDOWN_STREAMING_ENABLED -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
 	  config_core_impl) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \
 	  v070_default_values) extra_cflags="-Iinclude/nginx_stubs -ffunction-sections" ; extra_ldflags="$(SECTION_GC_LDFLAGS)" ;; \

--- a/components/nginx-module/tests/unit/eligibility_impl_test.c
+++ b/components/nginx-module/tests/unit/eligibility_impl_test.c
@@ -79,6 +79,19 @@ ngx_strncasecmp(const u_char *s1, const u_char *s2, size_t n)
     return 0;
 }
 
+static u_char *
+ngx_strlchr(u_char *p, u_char *last, u_char c)
+{
+    while (p < last) {
+        if (*p == c) {
+            return p;
+        }
+        p++;
+    }
+
+    return NULL;
+}
+
 #include "../../src/ngx_http_markdown_eligibility.c"
 
 

--- a/components/nginx-module/tests/unit/streaming_config_contract_test.c
+++ b/components/nginx-module/tests/unit/streaming_config_contract_test.c
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 
 #define MARKDOWN_STREAMING_ENABLED 1
+#define NGX_HTTP_MARKDOWN_TEST_LEGACY_STREAM_ENGINE_HANDLER 1
 
 #include "../../src/ngx_http_markdown_filter_module.h"
 

--- a/components/nginx-module/tests/unit/streaming_config_contract_test.c
+++ b/components/nginx-module/tests/unit/streaming_config_contract_test.c
@@ -3,7 +3,10 @@
  *
  * Validates the v0.8.0 streaming configuration directives (spec 36):
  * - Valid values for each directive (5.1)
+ * - v0.8.0 stream_engine_handler direct tests (5.1b)
  * - Invalid values rejected (5.2)
+ * - v0.8.0 stream_engine_handler rejection tests (5.2b)
+ * - Allocation failure paths (5.2c)
  * - Default inheritance (5.3)
  * - Reserved directive rejected (5.4)
  * - Hard exclusions always present (5.5)
@@ -64,6 +67,19 @@ static char ngx_conf_error_val[] = "ERROR";
 #define NGX_MAX_SIZE_T_VALUE ((size_t) -1)
 #endif
 
+#ifndef NGX_HTTP_GET
+#define NGX_HTTP_GET  0
+#endif
+#ifndef NGX_HTTP_HEAD
+#define NGX_HTTP_HEAD 1
+#endif
+#ifndef NGX_HTTP_OK
+#define NGX_HTTP_OK  200
+#endif
+#ifndef NGX_HTTP_PARTIAL_CONTENT
+#define NGX_HTTP_PARTIAL_CONTENT 206
+#endif
+
 #define ngx_strncmp(s1, s2, n) \
     strncmp((const char *) (s1), (const char *) (s2), (n))
 
@@ -81,8 +97,32 @@ struct ngx_array_s {
     ngx_pool_t *pool;
 };
 
+typedef struct ngx_table_elt_s ngx_table_elt_t;
+
+struct ngx_table_elt_s {
+    ngx_str_t   key;
+    ngx_str_t   value;
+    ngx_uint_t  hash;
+};
+
+typedef struct ngx_http_headers_in_s ngx_http_headers_in_t;
+
+struct ngx_http_headers_in_s {
+    ngx_table_elt_t *range;
+};
+
+typedef struct ngx_http_headers_out_s ngx_http_headers_out_t;
+
+struct ngx_http_headers_out_s {
+    ngx_str_t   content_type;
+    ngx_uint_t  status;
+    off_t       content_length_n;
+};
+
 struct ngx_http_request_s {
-    int dummy;
+    ngx_uint_t              method;
+    ngx_http_headers_out_t  headers_out;
+    ngx_http_headers_in_t   headers_in;
 };
 
 struct ngx_http_complex_value_s {
@@ -217,6 +257,11 @@ ngx_array_create(ngx_pool_t *pool, ngx_uint_t n, size_t size)
     ngx_array_t *a;
     UNUSED(pool);
 
+    if (g_next_palloc_fails > 0) {
+        g_next_palloc_fails--;
+        return NULL;
+    }
+
     a = calloc(1, sizeof(ngx_array_t));
     if (a == NULL) {
         return NULL;
@@ -298,6 +343,13 @@ ngx_http_conf_get_module_main_conf(ngx_conf_t *cf, ngx_module_t module)
 }
 
 #include "../../src/ngx_http_markdown_config_handlers_impl.h"
+
+/*
+ * Include the production eligibility source so we test the real
+ * ngx_http_markdown_stream_type_excluded() instead of a local
+ * reimplementation.  All required stubs are defined above.
+ */
+#include "../../src/ngx_http_markdown_eligibility.c"
 
 static ngx_pool_t g_pool;
 
@@ -471,6 +523,55 @@ test_valid_values(void)
 }
 
 /* ================================================================
+ * 5.1b v0.8.0 stream_engine_handler direct
+ * ================================================================ */
+static void
+test_stream_engine_handler_valid(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("5.1b v0.8.0 stream_engine_handler direct");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&cmd.name, "markdown_streaming_engine");
+    set_arg(&values[0], "markdown_streaming_engine");
+
+    /* off -> STREAM_ENGINE_OFF */
+    init_conf(&mcf);
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_engine_handler 'off' should return NGX_CONF_OK");
+    TEST_ASSERT(mcf.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF,
+        "stream_engine_handler 'off' should set engine to OFF (0)");
+
+    /* auto -> STREAM_ENGINE_AUTO */
+    init_conf(&mcf);
+    set_arg(&values[1], "auto");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_engine_handler 'auto' should return NGX_CONF_OK");
+    TEST_ASSERT(mcf.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO,
+        "stream_engine_handler 'auto' should set engine to AUTO (1)");
+
+    /* on -> STREAM_ENGINE_ON */
+    init_conf(&mcf);
+    set_arg(&values[1], "on");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_engine_handler 'on' should return NGX_CONF_OK");
+    TEST_ASSERT(mcf.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON,
+        "stream_engine_handler 'on' should set engine to ON (2)");
+
+    TEST_PASS("5.1b v0.8.0 stream_engine_handler accepts valid values");
+}
+
+/* ================================================================
  * 5.2 Invalid values rejected
  * ================================================================ */
 static void
@@ -570,11 +671,109 @@ test_invalid_values(void)
 }
 
 /* ================================================================
+ * 5.2b v0.8.0 stream_engine_handler rejection
+ * ================================================================ */
+static void
+test_stream_engine_handler_rejection(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("5.2b v0.8.0 stream_engine_handler rejection");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&cmd.name, "markdown_streaming_engine");
+    set_arg(&values[0], "markdown_streaming_engine");
+
+    /* Invalid value: "yes" */
+    init_conf(&mcf);
+    set_arg(&values[1], "yes");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_engine_handler 'yes' should return NGX_CONF_ERROR");
+    TEST_ASSERT(mcf.stream.engine == NGX_CONF_UNSET_UINT,
+        "stream_engine_handler 'yes' should leave engine unchanged");
+
+    /* Invalid value: "always" */
+    init_conf(&mcf);
+    set_arg(&values[1], "always");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_engine_handler 'always' should return NGX_CONF_ERROR");
+
+    /* Invalid value: empty string */
+    init_conf(&mcf);
+    set_arg(&values[1], "");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_engine_handler '' should return NGX_CONF_ERROR");
+
+    /* Duplicate detection: call twice, second should return "is duplicate" */
+    init_conf(&mcf);
+    set_arg(&values[1], "on");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_engine_handler first call should succeed");
+    TEST_ASSERT(mcf.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON,
+        "stream_engine_handler first call should set engine");
+
+    /* Second call with engine already set -> "is duplicate" */
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_stream_engine_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc != NGX_CONF_OK && rc != NGX_CONF_ERROR,
+        "stream_engine_handler duplicate should return error string");
+    TEST_ASSERT(strcmp(rc, "is duplicate") == 0,
+        "stream_engine_handler duplicate should return 'is duplicate'");
+
+    TEST_PASS("5.2b v0.8.0 stream_engine_handler rejects invalid/duplicate");
+}
+
+/* ================================================================
+ * 5.2c Allocation failure paths
+ * ================================================================ */
+static void
+test_allocation_failure(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    char                    *rc;
+
+    TEST_SUBSECTION("5.2c Allocation failure paths");
+
+    setup_cf(&cf, &args, values, 2);
+    set_arg(&cmd.name, "markdown_stream_excluded_types");
+    set_arg(&values[0], "markdown_stream_excluded_types");
+    set_arg(&values[1], "text/csv");
+
+    /* Force the next allocation call to fail */
+    init_conf(&mcf);
+    g_next_palloc_fails = 1;
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "excluded_types handler should return NGX_CONF_ERROR on alloc failure");
+    TEST_ASSERT(mcf.stream.excluded_types == NULL,
+        "excluded_types should be NULL after array allocation failure");
+    g_next_palloc_fails = 0;
+
+    TEST_PASS("5.2c Allocation failure correctly handled");
+}
+
+/* ================================================================
  * 5.3 Default inheritance
  * ================================================================ */
 
 /*
- * Simulates ngx_conf_merge_uint_value macro behavior.
+ * Local merge helpers mirror the standard ngx_conf_merge_* macros.
+ * These are trivial NGINX patterns unlikely to diverge from production.
+ * Production merge function: ngx_http_markdown_merge_stream_values()
+ * in src/ngx_http_markdown_config_core_impl.h.
  */
 static void
 merge_uint_value(ngx_uint_t *conf, ngx_uint_t prev, ngx_uint_t def)
@@ -584,9 +783,6 @@ merge_uint_value(ngx_uint_t *conf, ngx_uint_t prev, ngx_uint_t def)
     }
 }
 
-/*
- * Simulates ngx_conf_merge_size_value macro behavior.
- */
 static void
 merge_size_value(size_t *conf, size_t prev, size_t def)
 {
@@ -595,9 +791,6 @@ merge_size_value(size_t *conf, size_t prev, size_t def)
     }
 }
 
-/*
- * Simulates ngx_conf_merge_ptr_value macro behavior.
- */
 static void
 merge_ptr_value(ngx_array_t **conf, ngx_array_t *prev, ngx_array_t *def)
 {
@@ -743,88 +936,6 @@ test_reserved_directive_rejected(void)
 /* ================================================================
  * 5.5 Hard exclusions always present
  * ================================================================ */
-
-/*
- * Local re-implementation of the production exclusion check for unit
- * testing.  Mirrors ngx_http_markdown_stream_type_excluded() from
- * ngx_http_markdown_eligibility.c exactly.
- */
-static ngx_int_t
-test_stream_type_excluded(const ngx_str_t *content_type,
-    const ngx_http_markdown_conf_t *conf)
-{
-    static u_char  text_event_stream[] = "text/event-stream";
-    static u_char  application_x_ndjson[] = "application/x-ndjson";
-    static u_char  application_stream_json[] = "application/stream+json";
-
-    size_t               type_len;
-    ngx_uint_t           i;
-    const ngx_str_t     *entry;
-    u_char              *p;
-
-    if (content_type == NULL || content_type->len == 0
-        || content_type->data == NULL)
-    {
-        return 0;
-    }
-
-    type_len = content_type->len;
-    p = ngx_strlchr(content_type->data,
-                    content_type->data + content_type->len, ';');
-    if (p != NULL) {
-        type_len = (size_t) (p - content_type->data);
-    }
-
-    /* Strip trailing whitespace from type portion */
-    while (type_len > 0 && content_type->data[type_len - 1] == ' ') {
-        type_len--;
-    }
-
-    if (type_len == 0) {
-        return 0;
-    }
-
-    /* text/event-stream (17 chars) */
-    if (type_len == 17
-        && ngx_strncasecmp(content_type->data, text_event_stream, 17) == 0)
-    {
-        return 1;
-    }
-
-    /* application/x-ndjson (20 chars) */
-    if (type_len == 20
-        && ngx_strncasecmp(content_type->data,
-                           application_x_ndjson, 20) == 0)
-    {
-        return 1;
-    }
-
-    /* application/stream+json (23 chars) */
-    if (type_len == 23
-        && ngx_strncasecmp(content_type->data,
-                           application_stream_json, 23) == 0)
-    {
-        return 1;
-    }
-
-    /* Check user-configured exclusion array */
-    if (conf != NULL && conf->stream.excluded_types != NULL) {
-        entry = conf->stream.excluded_types->elts;
-
-        for (i = 0; i < conf->stream.excluded_types->nelts; i++) {
-            if (type_len == entry[i].len
-                && ngx_strncasecmp(content_type->data,
-                                   entry[i].data,
-                                   entry[i].len) == 0)
-            {
-                return 1;
-            }
-        }
-    }
-
-    return 0;
-}
-
 static void
 test_hard_exclusions_always_present(void)
 {
@@ -838,32 +949,32 @@ test_hard_exclusions_always_present(void)
 
     /* text/event-stream */
     set_arg(&ct, "text/event-stream");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "text/event-stream should be hard-excluded");
 
     /* application/x-ndjson */
     set_arg(&ct, "application/x-ndjson");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "application/x-ndjson should be hard-excluded");
 
     /* application/stream+json */
     set_arg(&ct, "application/stream+json");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "application/stream+json should be hard-excluded");
 
     /* Non-excluded type should not be excluded */
     set_arg(&ct, "text/html");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 0,
         "text/html should NOT be excluded");
 
     /* NULL content_type should return 0 */
-    TEST_ASSERT(test_stream_type_excluded(NULL, &conf) == 0,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(NULL, &conf) == 0,
         "NULL content_type should not be excluded");
 
     /* Empty content_type should return 0 */
     ct.data = NULL;
     ct.len = 0;
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 0,
         "empty content_type should not be excluded");
 
     /* User cannot remove hard exclusions */
@@ -882,20 +993,20 @@ test_hard_exclusions_always_present(void)
 
         /* Hard exclusion still present with user config */
         set_arg(&ct, "text/event-stream");
-        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
             "hard exclusion preserved with user config");
 
         set_arg(&ct, "application/x-ndjson");
-        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
             "application/x-ndjson hard exclusion preserved");
 
         set_arg(&ct, "application/stream+json");
-        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
             "application/stream+json hard exclusion preserved");
 
         /* User-configured type also excluded */
         set_arg(&ct, "text/csv");
-        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
             "user-configured type should also be excluded");
     }
 
@@ -963,52 +1074,52 @@ test_hard_exclusions_with_parameters(void)
 
     /* text/event-stream; charset=utf-8 */
     set_arg(&ct, "text/event-stream; charset=utf-8");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "text/event-stream; charset=utf-8 should be excluded");
 
     /* TEXT/EVENT-STREAM (case variation) */
     set_arg(&ct, "TEXT/EVENT-STREAM");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "TEXT/EVENT-STREAM (uppercase) should be excluded");
 
     /* Text/Event-Stream (mixed case) */
     set_arg(&ct, "Text/Event-Stream");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "Text/Event-Stream (mixed case) should be excluded");
 
     /* application/x-ndjson; boundary=something */
     set_arg(&ct, "application/x-ndjson; boundary=something");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "application/x-ndjson; boundary=something should be excluded");
 
     /* APPLICATION/X-NDJSON */
     set_arg(&ct, "APPLICATION/X-NDJSON");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "APPLICATION/X-NDJSON (uppercase) should be excluded");
 
     /* application/stream+json; charset=utf-8 */
     set_arg(&ct, "application/stream+json; charset=utf-8");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "application/stream+json with params should be excluded");
 
     /* APPLICATION/STREAM+JSON */
     set_arg(&ct, "APPLICATION/STREAM+JSON");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "APPLICATION/STREAM+JSON (uppercase) should be excluded");
 
     /* text/event-stream with trailing space before semicolon */
     set_arg(&ct, "text/event-stream ;charset=utf-8");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
         "text/event-stream with space before params should be excluded");
 
     /* Non-excluded type with parameters should not be excluded */
     set_arg(&ct, "text/html; charset=utf-8");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 0,
         "text/html; charset=utf-8 should NOT be excluded");
 
     /* Partial match should not be excluded */
     set_arg(&ct, "text/event-streaming");
-    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 0,
         "text/event-streaming (longer) should NOT be excluded");
 
     TEST_PASS("5.7 Hard exclusions match with parameters and case");
@@ -1025,7 +1136,10 @@ main(void)
     memset(&g_main_conf, 0, sizeof(g_main_conf));
 
     test_valid_values();
+    test_stream_engine_handler_valid();
     test_invalid_values();
+    test_stream_engine_handler_rejection();
+    test_allocation_failure();
     test_default_inheritance();
     test_reserved_directive_rejected();
     test_hard_exclusions_always_present();

--- a/components/nginx-module/tests/unit/streaming_config_contract_test.c
+++ b/components/nginx-module/tests/unit/streaming_config_contract_test.c
@@ -1,0 +1,1040 @@
+/*
+ * Test: streaming_config_contract
+ *
+ * Validates the v0.8.0 streaming configuration directives (spec 36):
+ * - Valid values for each directive (5.1)
+ * - Invalid values rejected (5.2)
+ * - Default inheritance (5.3)
+ * - Reserved directive rejected (5.4)
+ * - Hard exclusions always present (5.5)
+ * - Reserved directive absent from directive inventory (5.6)
+ * - Hard exclusions match MIME types with parameters (5.7)
+ *
+ * Requirements: Spec 36, Requirements 1-6, 9
+ */
+
+#include "../include/test_common.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+
+#define MARKDOWN_STREAMING_ENABLED 1
+
+#include "../../src/ngx_http_markdown_filter_module.h"
+
+#ifndef NGX_OK
+#define NGX_OK 0
+#endif
+#ifndef NGX_ERROR
+#define NGX_ERROR -1
+#endif
+#ifndef NGX_CONF_OK
+static char ngx_conf_ok_val[] = "OK";
+#define NGX_CONF_OK ngx_conf_ok_val
+#endif
+#ifndef NGX_CONF_ERROR
+static char ngx_conf_error_val[] = "ERROR";
+#define NGX_CONF_ERROR ngx_conf_error_val
+#endif
+
+#ifndef NGX_CONF_UNSET
+#define NGX_CONF_UNSET (-1)
+#endif
+#ifndef NGX_CONF_UNSET_UINT
+#define NGX_CONF_UNSET_UINT ((ngx_uint_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_SIZE
+#define NGX_CONF_UNSET_SIZE ((size_t) -1)
+#endif
+#ifndef NGX_CONF_UNSET_PTR
+#define NGX_CONF_UNSET_PTR ((void *) -1)
+#endif
+
+#ifndef NGX_LOG_EMERG
+#define NGX_LOG_EMERG 1
+#endif
+#ifndef NGX_LOG_DEBUG
+#define NGX_LOG_DEBUG 2
+#endif
+#ifndef NGX_LOG_INFO
+#define NGX_LOG_INFO 3
+#endif
+
+#ifndef NGX_MAX_SIZE_T_VALUE
+#define NGX_MAX_SIZE_T_VALUE ((size_t) -1)
+#endif
+
+#define ngx_strncmp(s1, s2, n) \
+    strncmp((const char *) (s1), (const char *) (s2), (n))
+
+typedef intptr_t ngx_err_t;
+
+struct ngx_pool_s {
+    int dummy;
+};
+
+struct ngx_array_s {
+    void       *elts;
+    ngx_uint_t  nelts;
+    size_t      size;
+    ngx_uint_t  nalloc;
+    ngx_pool_t *pool;
+};
+
+struct ngx_http_request_s {
+    int dummy;
+};
+
+struct ngx_http_complex_value_s {
+    ngx_str_t  value;
+};
+
+typedef struct {
+    ngx_conf_t                 *cf;
+    ngx_str_t                  *value;
+    ngx_http_complex_value_t   *complex_value;
+} ngx_http_compile_complex_value_t;
+
+struct ngx_conf_s {
+    ngx_pool_t  *pool;
+    ngx_array_t *args;
+};
+
+struct ngx_command_s {
+    ngx_str_t  name;
+};
+
+struct ngx_module_s {
+    int dummy;
+};
+
+typedef struct {
+    ngx_int_t (*handler)(ngx_http_request_t *r);
+} ngx_http_core_loc_conf_t;
+
+/*
+ * Global module symbols required by the config implementation header.
+ */
+ngx_module_t ngx_http_markdown_filter_module;
+ngx_module_t ngx_http_core_module;
+
+static ngx_http_core_loc_conf_t *g_clcf;
+static ngx_int_t g_compile_complex_rc;
+static ngx_http_markdown_main_conf_t g_main_conf;
+static ngx_uint_t g_diagnostics_recording_requested;
+
+static ngx_int_t
+ngx_http_markdown_metrics_handler(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_markdown_diagnostics_handler(ngx_http_request_t *r)
+{
+    UNUSED(r);
+    return NGX_OK;
+}
+
+void
+ngx_http_markdown_diagnostics_enable_recording(void)
+{
+    g_diagnostics_recording_requested = 1;
+}
+
+static ngx_int_t
+ngx_ascii_strncasecmp(const u_char *s1, const u_char *s2, size_t n)
+{
+    for (size_t i = 0; i < n; i++) {
+        u_char c1 = (u_char) tolower((unsigned char) s1[i]);
+        u_char c2 = (u_char) tolower((unsigned char) s2[i]);
+        if (c1 != c2) {
+            return (ngx_int_t) c1 - (ngx_int_t) c2;
+        }
+    }
+    return 0;
+}
+
+static ngx_int_t
+ngx_strcasecmp(u_char *s1, u_char *s2)
+{
+    if (s1 == NULL || s2 == NULL) {
+        return NGX_ERROR;
+    }
+    size_t i = 0;
+    while (s1[i] != '\0' && s2[i] != '\0') {
+        ngx_int_t diff = ngx_ascii_strncasecmp(&s1[i], &s2[i], 1);
+        if (diff != 0) {
+            return diff;
+        }
+        i++;
+    }
+    return (ngx_int_t) tolower((unsigned char) s1[i])
+         - (ngx_int_t) tolower((unsigned char) s2[i]);
+}
+
+static ngx_int_t
+ngx_strncasecmp(u_char *s1, u_char *s2, size_t n)
+{
+    return ngx_ascii_strncasecmp(s1, s2, n);
+}
+
+static u_char *
+ngx_strlchr(u_char *p, u_char *last, u_char c)
+{
+    while (p < last) {
+        if (*p == c) {
+            return p;
+        }
+        p++;
+    }
+    return NULL;
+}
+
+static void
+ngx_memzero(void *p, size_t n)
+{
+    memset(p, 0, n);
+}
+
+static int g_next_palloc_fails;
+
+static void *
+ngx_palloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    if (g_next_palloc_fails > 0) {
+        g_next_palloc_fails--;
+        return NULL;
+    }
+    return malloc(size);
+}
+
+static ngx_array_t *
+ngx_array_create(ngx_pool_t *pool, ngx_uint_t n, size_t size)
+{
+    ngx_array_t *a;
+    UNUSED(pool);
+
+    a = calloc(1, sizeof(ngx_array_t));
+    if (a == NULL) {
+        return NULL;
+    }
+    a->size = size;
+    a->nalloc = (n == 0) ? 1 : n;
+    a->pool = pool;
+    a->elts = calloc(a->nalloc, size);
+    if (a->elts == NULL) {
+        free(a);
+        return NULL;
+    }
+    return a;
+}
+
+static void *
+ngx_array_push(ngx_array_t *a)
+{
+    void *elt;
+    if (a == NULL) {
+        return NULL;
+    }
+    if (a->nelts >= a->nalloc) {
+        void      *new_elts;
+        ngx_uint_t new_nalloc;
+
+        new_nalloc = a->nalloc * 2;
+        new_elts = realloc(a->elts, new_nalloc * a->size);
+        if (new_elts == NULL) {
+            return NULL;
+        }
+        memset((u_char *) new_elts + (a->nalloc * a->size),
+               0, (new_nalloc - a->nalloc) * a->size);
+        a->elts = new_elts;
+        a->nalloc = new_nalloc;
+    }
+    elt = (u_char *) a->elts + (a->nelts * a->size);
+    memset(elt, 0, a->size);
+    a->nelts++;
+    return elt;
+}
+
+static ngx_int_t
+ngx_http_compile_complex_value(ngx_http_compile_complex_value_t *ccv)
+{
+    if (ccv == NULL || ccv->value == NULL || ccv->complex_value == NULL) {
+        return NGX_ERROR;
+    }
+    ccv->complex_value->value = *ccv->value;
+    return g_compile_complex_rc;
+}
+
+static void
+ngx_conf_log_error(ngx_uint_t level, ngx_conf_t *cf, ngx_err_t err,
+    const char *fmt, ...)
+{
+    va_list ap;
+    UNUSED(level);
+    UNUSED(cf);
+    UNUSED(err);
+    va_start(ap, fmt);
+    va_end(ap);
+}
+
+static void *
+ngx_http_conf_get_module_loc_conf(ngx_conf_t *cf, ngx_module_t module)
+{
+    UNUSED(cf);
+    UNUSED(module);
+    return g_clcf;
+}
+
+static void *
+ngx_http_conf_get_module_main_conf(ngx_conf_t *cf, ngx_module_t module)
+{
+    UNUSED(cf);
+    UNUSED(module);
+    return &g_main_conf;
+}
+
+#include "../../src/ngx_http_markdown_config_handlers_impl.h"
+
+static ngx_pool_t g_pool;
+
+static void
+set_arg(ngx_str_t *arg, const char *s)
+{
+    arg->data = (u_char *) (uintptr_t) s;
+    arg->len = strlen(s);
+}
+
+static void
+setup_cf(ngx_conf_t *cf, ngx_array_t *args, ngx_str_t *values,
+    ngx_uint_t count)
+{
+    args->elts = values;
+    args->nelts = count;
+    args->size = sizeof(ngx_str_t);
+    args->nalloc = count;
+    args->pool = &g_pool;
+
+    cf->pool = &g_pool;
+    cf->args = args;
+}
+
+static void
+init_conf(ngx_http_markdown_conf_t *mcf)
+{
+    memset(mcf, 0, sizeof(*mcf));
+    mcf->enabled_source = NGX_HTTP_MARKDOWN_ENABLED_UNSET;
+    mcf->enabled_complex = NULL;
+    mcf->on_error = NGX_CONF_UNSET_UINT;
+    mcf->flavor = NGX_CONF_UNSET_UINT;
+    mcf->policy.auth_policy = NGX_CONF_UNSET_UINT;
+    mcf->policy.auth_cookies = NGX_CONF_UNSET_PTR;
+    mcf->content_types = NGX_CONF_UNSET_PTR;
+    mcf->policy.conditional_requests = NGX_CONF_UNSET_UINT;
+    mcf->policy.log_verbosity = NGX_CONF_UNSET_UINT;
+    mcf->stream_types = NGX_CONF_UNSET_PTR;
+    mcf->large_body_threshold = NGX_CONF_UNSET_SIZE;
+    mcf->ops.metrics_format = NGX_CONF_UNSET_UINT;
+    mcf->streaming.engine = NULL;
+
+    /* v0.8.0 stream config fields */
+    mcf->stream.engine = NGX_CONF_UNSET_UINT;
+    mcf->stream.threshold = NGX_CONF_UNSET_SIZE;
+    mcf->stream.precommit_buffer = NGX_CONF_UNSET_SIZE;
+    mcf->stream.flush_min = NGX_CONF_UNSET_SIZE;
+    mcf->stream.excluded_types = NGX_CONF_UNSET_PTR;
+}
+
+/* ================================================================
+ * 5.1 Valid values for each directive
+ * ================================================================ */
+static void
+test_valid_values(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[4];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    const char              *rc;
+
+    TEST_SUBSECTION("5.1 Valid values for each directive");
+
+    setup_cf(&cf, &args, values, 2);
+    g_compile_complex_rc = NGX_OK;
+
+    /* markdown_streaming_engine: off */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_streaming_engine");
+    set_arg(&values[0], "markdown_streaming_engine");
+    set_arg(&values[1], "off");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "streaming_engine 'off' should be accepted");
+    TEST_ASSERT(mcf.streaming.engine != NULL,
+        "streaming_engine compiled value should be set for 'off'");
+
+    /* markdown_streaming_engine: auto */
+    init_conf(&mcf);
+    set_arg(&values[1], "auto");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "streaming_engine 'auto' should be accepted");
+
+    /* markdown_streaming_engine: on */
+    init_conf(&mcf);
+    set_arg(&values[1], "on");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "streaming_engine 'on' should be accepted");
+
+    /* markdown_stream_threshold: 1m */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_stream_threshold");
+    set_arg(&values[0], "markdown_stream_threshold");
+    set_arg(&values[1], "1m");
+    rc = ngx_http_markdown_stream_threshold_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_threshold '1m' should be accepted");
+    TEST_ASSERT(mcf.stream.threshold == 1048576,
+        "stream_threshold '1m' should parse to 1048576");
+
+    /* markdown_stream_threshold: 512k */
+    init_conf(&mcf);
+    set_arg(&values[1], "512k");
+    rc = ngx_http_markdown_stream_threshold_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_threshold '512k' should be accepted");
+    TEST_ASSERT(mcf.stream.threshold == 512 * 1024,
+        "stream_threshold '512k' should parse to 524288");
+
+    /* markdown_stream_precommit_buffer: 256k (parse_size validation) */
+    {
+        ngx_str_t sz;
+        size_t    parsed;
+
+        set_arg(&sz, "256k");
+        parsed = ngx_http_markdown_parse_size(&sz);
+        TEST_ASSERT(parsed == 256 * 1024,
+            "precommit_buffer '256k' should parse to 262144");
+
+        set_arg(&sz, "128k");
+        parsed = ngx_http_markdown_parse_size(&sz);
+        TEST_ASSERT(parsed == 128 * 1024,
+            "precommit_buffer '128k' should parse to 131072");
+
+        set_arg(&sz, "0");
+        parsed = ngx_http_markdown_parse_size(&sz);
+        TEST_ASSERT(parsed == 0,
+            "precommit_buffer '0' is valid (disables replay)");
+    }
+
+    /* markdown_stream_flush_min: 16k */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_stream_flush_min");
+    set_arg(&values[0], "markdown_stream_flush_min");
+    set_arg(&values[1], "16k");
+    rc = ngx_http_markdown_stream_flush_min_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_flush_min '16k' should be accepted");
+    TEST_ASSERT(mcf.stream.flush_min == 16 * 1024,
+        "stream_flush_min '16k' should parse to 16384");
+
+    /* markdown_stream_flush_min: 32k */
+    init_conf(&mcf);
+    set_arg(&values[1], "32k");
+    rc = ngx_http_markdown_stream_flush_min_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_flush_min '32k' should be accepted");
+    TEST_ASSERT(mcf.stream.flush_min == 32 * 1024,
+        "stream_flush_min '32k' should parse to 32768");
+
+    /* markdown_stream_excluded_types: space-separated MIME types */
+    init_conf(&mcf);
+    setup_cf(&cf, &args, values, 3);
+    set_arg(&cmd.name, "markdown_stream_excluded_types");
+    set_arg(&values[0], "markdown_stream_excluded_types");
+    set_arg(&values[1], "text/csv");
+    set_arg(&values[2], "application/xml");
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "stream_excluded_types should accept valid MIME types");
+    TEST_ASSERT(mcf.stream.excluded_types != NULL,
+        "excluded_types array should be allocated");
+    TEST_ASSERT(mcf.stream.excluded_types->nelts == 2,
+        "excluded_types should have 2 entries");
+
+    TEST_PASS("5.1 Valid values accepted for all directives");
+}
+
+/* ================================================================
+ * 5.2 Invalid values rejected
+ * ================================================================ */
+static void
+test_invalid_values(void)
+{
+    ngx_conf_t               cf;
+    ngx_array_t              args;
+    ngx_str_t                values[2];
+    ngx_command_t            cmd;
+    ngx_http_markdown_conf_t mcf;
+    const char              *rc;
+
+    TEST_SUBSECTION("5.2 Invalid values rejected");
+
+    setup_cf(&cf, &args, values, 2);
+    g_compile_complex_rc = NGX_OK;
+
+    /* markdown_streaming_engine: invalid_value */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_streaming_engine");
+    set_arg(&values[0], "markdown_streaming_engine");
+    set_arg(&values[1], "invalid_value");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "streaming_engine 'invalid_value' should be rejected");
+
+    /* markdown_streaming_engine: yes */
+    init_conf(&mcf);
+    set_arg(&values[1], "yes");
+    rc = ngx_http_markdown_streaming_engine(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "streaming_engine 'yes' should be rejected");
+
+    /* markdown_stream_threshold: 0 (must be > 0) */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_stream_threshold");
+    set_arg(&values[0], "markdown_stream_threshold");
+    set_arg(&values[1], "0");
+    rc = ngx_http_markdown_stream_threshold_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_threshold '0' should be rejected (must be > 0)");
+
+    /* markdown_stream_threshold: invalid */
+    init_conf(&mcf);
+    set_arg(&values[1], "invalid");
+    rc = ngx_http_markdown_stream_threshold_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_threshold 'invalid' should be rejected");
+
+    /* markdown_stream_flush_min: 0 (must be > 0) */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_stream_flush_min");
+    set_arg(&values[0], "markdown_stream_flush_min");
+    set_arg(&values[1], "0");
+    rc = ngx_http_markdown_stream_flush_min_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_flush_min '0' should be rejected (must be > 0)");
+
+    /* markdown_stream_flush_min: bad */
+    init_conf(&mcf);
+    set_arg(&values[1], "bad");
+    rc = ngx_http_markdown_stream_flush_min_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "stream_flush_min 'bad' should be rejected");
+
+    /* markdown_stream_excluded_types: invalid (no slash) */
+    init_conf(&mcf);
+    set_arg(&cmd.name, "markdown_stream_excluded_types");
+    set_arg(&values[0], "markdown_stream_excluded_types");
+    set_arg(&values[1], "noslash");
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "excluded_types 'noslash' should be rejected");
+
+    /* markdown_stream_excluded_types: empty string */
+    init_conf(&mcf);
+    set_arg(&values[1], "");
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "excluded_types empty string should be rejected");
+
+    /* markdown_stream_excluded_types: leading slash */
+    init_conf(&mcf);
+    set_arg(&values[1], "/html");
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "excluded_types '/html' should be rejected");
+
+    /* markdown_stream_excluded_types: trailing slash */
+    init_conf(&mcf);
+    set_arg(&values[1], "text/");
+    rc = ngx_http_markdown_stream_excluded_types_handler(&cf, &cmd, &mcf);
+    TEST_ASSERT(rc == NGX_CONF_ERROR,
+        "excluded_types 'text/' should be rejected");
+
+    TEST_PASS("5.2 Invalid values correctly rejected");
+}
+
+/* ================================================================
+ * 5.3 Default inheritance
+ * ================================================================ */
+
+/*
+ * Simulates ngx_conf_merge_uint_value macro behavior.
+ */
+static void
+merge_uint_value(ngx_uint_t *conf, ngx_uint_t prev, ngx_uint_t def)
+{
+    if (*conf == NGX_CONF_UNSET_UINT) {
+        *conf = (prev == NGX_CONF_UNSET_UINT) ? def : prev;
+    }
+}
+
+/*
+ * Simulates ngx_conf_merge_size_value macro behavior.
+ */
+static void
+merge_size_value(size_t *conf, size_t prev, size_t def)
+{
+    if (*conf == NGX_CONF_UNSET_SIZE) {
+        *conf = (prev == NGX_CONF_UNSET_SIZE) ? def : prev;
+    }
+}
+
+/*
+ * Simulates ngx_conf_merge_ptr_value macro behavior.
+ */
+static void
+merge_ptr_value(ngx_array_t **conf, ngx_array_t *prev, ngx_array_t *def)
+{
+    if (*conf == NGX_CONF_UNSET_PTR) {
+        *conf = (prev == NGX_CONF_UNSET_PTR) ? def : prev;
+    }
+}
+
+/*
+ * Merge v0.8.0 stream config (mirrors production merge function).
+ */
+static void
+merge_stream_config(ngx_http_markdown_conf_t *child,
+    const ngx_http_markdown_conf_t *parent)
+{
+    merge_uint_value(&child->stream.engine,
+                     parent->stream.engine,
+                     NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO);
+    merge_size_value(&child->stream.threshold,
+                     parent->stream.threshold, 1048576);
+    merge_size_value(&child->stream.precommit_buffer,
+                     parent->stream.precommit_buffer, 262144);
+    merge_size_value(&child->stream.flush_min,
+                     parent->stream.flush_min, 16384);
+    merge_ptr_value(&child->stream.excluded_types,
+                    parent->stream.excluded_types, NULL);
+}
+
+static void
+test_default_inheritance(void)
+{
+    ngx_http_markdown_conf_t parent;
+    ngx_http_markdown_conf_t child;
+
+    TEST_SUBSECTION("5.3 Default inheritance");
+
+    /* Test 1: Both unset -> defaults applied */
+    init_conf(&parent);
+    init_conf(&child);
+    merge_stream_config(&child, &parent);
+
+    TEST_ASSERT(child.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO,
+        "default engine should be auto");
+    TEST_ASSERT(child.stream.threshold == 1048576,
+        "default threshold should be 1m (1048576)");
+    TEST_ASSERT(child.stream.precommit_buffer == 262144,
+        "default precommit_buffer should be 256k (262144)");
+    TEST_ASSERT(child.stream.flush_min == 16384,
+        "default flush_min should be 16k (16384)");
+    TEST_ASSERT(child.stream.excluded_types == NULL,
+        "default excluded_types should be NULL");
+
+    /* Test 2: Parent sets value, child inherits */
+    init_conf(&parent);
+    init_conf(&child);
+    parent.stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON;
+    parent.stream.threshold = 512 * 1024;
+    parent.stream.precommit_buffer = 128 * 1024;
+    parent.stream.flush_min = 32 * 1024;
+    merge_stream_config(&child, &parent);
+
+    TEST_ASSERT(child.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON,
+        "child should inherit engine from parent");
+    TEST_ASSERT(child.stream.threshold == 512 * 1024,
+        "child should inherit threshold from parent");
+    TEST_ASSERT(child.stream.precommit_buffer == 128 * 1024,
+        "child should inherit precommit_buffer from parent");
+    TEST_ASSERT(child.stream.flush_min == 32 * 1024,
+        "child should inherit flush_min from parent");
+
+    /* Test 3: Child overrides parent */
+    init_conf(&parent);
+    init_conf(&child);
+    parent.stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON;
+    parent.stream.threshold = 2 * 1024 * 1024;
+    child.stream.engine = NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF;
+    child.stream.threshold = 256 * 1024;
+    merge_stream_config(&child, &parent);
+
+    TEST_ASSERT(child.stream.engine == NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF,
+        "child engine override should be preserved");
+    TEST_ASSERT(child.stream.threshold == 256 * 1024,
+        "child threshold override should be preserved");
+
+    /* Verify default enum values match design doc */
+    TEST_ASSERT(NGX_HTTP_MARKDOWN_STREAM_ENGINE_OFF == 0,
+        "STREAM_ENGINE_OFF must be 0");
+    TEST_ASSERT(NGX_HTTP_MARKDOWN_STREAM_ENGINE_AUTO == 1,
+        "STREAM_ENGINE_AUTO must be 1");
+    TEST_ASSERT(NGX_HTTP_MARKDOWN_STREAM_ENGINE_ON == 2,
+        "STREAM_ENGINE_ON must be 2");
+
+    TEST_PASS("5.3 Default inheritance works correctly");
+}
+
+/* ================================================================
+ * 5.4 Reserved directive rejected
+ * ================================================================ */
+static void
+test_reserved_directive_rejected(void)
+{
+    ngx_str_t bad_directive;
+    size_t    result;
+
+    TEST_SUBSECTION("5.4 Reserved directive rejected");
+
+    /*
+     * The reserved directive markdown_stream_flush_interval is NOT
+     * registered in the module's command array.  In production, using
+     * it would cause nginx -t to fail with "unknown directive".
+     *
+     * We verify this by confirming:
+     * 1. No handler function is callable with this name
+     * 2. The name is distinct from all implemented directives
+     * 3. parse_size rejects non-numeric values like "flush_interval"
+     */
+
+    set_arg(&bad_directive, "flush_interval");
+    result = ngx_http_markdown_parse_size(&bad_directive);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "parse_size should reject non-numeric 'flush_interval'");
+
+    /* Static assertion: reserved name differs from all implemented ones */
+    TEST_ASSERT(strcmp("markdown_stream_flush_interval",
+                       "markdown_stream_flush_min") != 0,
+        "reserved directive name differs from flush_min");
+    TEST_ASSERT(strcmp("markdown_stream_flush_interval",
+                       "markdown_stream_threshold") != 0,
+        "reserved directive name differs from threshold");
+    TEST_ASSERT(strcmp("markdown_stream_flush_interval",
+                       "markdown_streaming_engine") != 0,
+        "reserved directive name differs from streaming_engine");
+    TEST_ASSERT(strcmp("markdown_stream_flush_interval",
+                       "markdown_stream_precommit_buffer") != 0,
+        "reserved directive name differs from precommit_buffer");
+    TEST_ASSERT(strcmp("markdown_stream_flush_interval",
+                       "markdown_stream_excluded_types") != 0,
+        "reserved directive name differs from excluded_types");
+
+    TEST_PASS("5.4 Reserved directive is not registered");
+}
+
+/* ================================================================
+ * 5.5 Hard exclusions always present
+ * ================================================================ */
+
+/*
+ * Local re-implementation of the production exclusion check for unit
+ * testing.  Mirrors ngx_http_markdown_stream_type_excluded() from
+ * ngx_http_markdown_eligibility.c exactly.
+ */
+static ngx_int_t
+test_stream_type_excluded(const ngx_str_t *content_type,
+    const ngx_http_markdown_conf_t *conf)
+{
+    static u_char  text_event_stream[] = "text/event-stream";
+    static u_char  application_x_ndjson[] = "application/x-ndjson";
+    static u_char  application_stream_json[] = "application/stream+json";
+
+    size_t               type_len;
+    ngx_uint_t           i;
+    const ngx_str_t     *entry;
+    u_char              *p;
+
+    if (content_type == NULL || content_type->len == 0
+        || content_type->data == NULL)
+    {
+        return 0;
+    }
+
+    type_len = content_type->len;
+    p = ngx_strlchr(content_type->data,
+                    content_type->data + content_type->len, ';');
+    if (p != NULL) {
+        type_len = (size_t) (p - content_type->data);
+    }
+
+    /* Strip trailing whitespace from type portion */
+    while (type_len > 0 && content_type->data[type_len - 1] == ' ') {
+        type_len--;
+    }
+
+    if (type_len == 0) {
+        return 0;
+    }
+
+    /* text/event-stream (17 chars) */
+    if (type_len == 17
+        && ngx_strncasecmp(content_type->data, text_event_stream, 17) == 0)
+    {
+        return 1;
+    }
+
+    /* application/x-ndjson (20 chars) */
+    if (type_len == 20
+        && ngx_strncasecmp(content_type->data,
+                           application_x_ndjson, 20) == 0)
+    {
+        return 1;
+    }
+
+    /* application/stream+json (23 chars) */
+    if (type_len == 23
+        && ngx_strncasecmp(content_type->data,
+                           application_stream_json, 23) == 0)
+    {
+        return 1;
+    }
+
+    /* Check user-configured exclusion array */
+    if (conf != NULL && conf->stream.excluded_types != NULL) {
+        entry = conf->stream.excluded_types->elts;
+
+        for (i = 0; i < conf->stream.excluded_types->nelts; i++) {
+            if (type_len == entry[i].len
+                && ngx_strncasecmp(content_type->data,
+                                   entry[i].data,
+                                   entry[i].len) == 0)
+            {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static void
+test_hard_exclusions_always_present(void)
+{
+    ngx_http_markdown_conf_t conf;
+    ngx_str_t                ct;
+
+    TEST_SUBSECTION("5.5 Hard exclusions always present");
+
+    init_conf(&conf);
+    conf.stream.excluded_types = NULL;
+
+    /* text/event-stream */
+    set_arg(&ct, "text/event-stream");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "text/event-stream should be hard-excluded");
+
+    /* application/x-ndjson */
+    set_arg(&ct, "application/x-ndjson");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "application/x-ndjson should be hard-excluded");
+
+    /* application/stream+json */
+    set_arg(&ct, "application/stream+json");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "application/stream+json should be hard-excluded");
+
+    /* Non-excluded type should not be excluded */
+    set_arg(&ct, "text/html");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+        "text/html should NOT be excluded");
+
+    /* NULL content_type should return 0 */
+    TEST_ASSERT(test_stream_type_excluded(NULL, &conf) == 0,
+        "NULL content_type should not be excluded");
+
+    /* Empty content_type should return 0 */
+    ct.data = NULL;
+    ct.len = 0;
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+        "empty content_type should not be excluded");
+
+    /* User cannot remove hard exclusions */
+    {
+        ngx_array_t user_types;
+        ngx_str_t   user_elts[1];
+
+        set_arg(&user_elts[0], "text/csv");
+        user_types.elts = user_elts;
+        user_types.nelts = 1;
+        user_types.size = sizeof(ngx_str_t);
+        user_types.nalloc = 1;
+        user_types.pool = NULL;
+
+        conf.stream.excluded_types = &user_types;
+
+        /* Hard exclusion still present with user config */
+        set_arg(&ct, "text/event-stream");
+        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+            "hard exclusion preserved with user config");
+
+        set_arg(&ct, "application/x-ndjson");
+        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+            "application/x-ndjson hard exclusion preserved");
+
+        set_arg(&ct, "application/stream+json");
+        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+            "application/stream+json hard exclusion preserved");
+
+        /* User-configured type also excluded */
+        set_arg(&ct, "text/csv");
+        TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+            "user-configured type should also be excluded");
+    }
+
+    TEST_PASS("5.5 Hard exclusions always enforced");
+}
+
+/* ================================================================
+ * 5.6 Reserved directive absent from directive inventory
+ * ================================================================ */
+static void
+test_reserved_directive_absent_from_inventory(void)
+{
+    ngx_str_t fi_str;
+    size_t    parsed;
+
+    TEST_SUBSECTION("5.6 Reserved directive absent from inventory");
+
+    /*
+     * Enumerate known v0.8.0 handler function names and confirm
+     * that markdown_stream_flush_interval has no corresponding handler.
+     */
+    static const char *registered_handlers[] = {
+        "ngx_http_markdown_streaming_engine",
+        "ngx_http_markdown_stream_threshold_handler",
+        "ngx_http_markdown_stream_flush_min_handler",
+        "ngx_http_markdown_stream_excluded_types_handler",
+        NULL
+    };
+
+    const char *reserved = "ngx_http_markdown_stream_flush_interval_handler";
+    int found = 0;
+
+    for (int i = 0; registered_handlers[i] != NULL; i++) {
+        if (strcmp(registered_handlers[i], reserved) == 0) {
+            found = 1;
+            break;
+        }
+    }
+
+    TEST_ASSERT(found == 0,
+        "reserved directive handler NOT in inventory");
+
+    /* Verify "flush_interval" is not a parseable size token */
+    set_arg(&fi_str, "flush_interval");
+    parsed = ngx_http_markdown_parse_size(&fi_str);
+    TEST_ASSERT(parsed == (size_t) NGX_ERROR,
+        "'flush_interval' is not a valid size token");
+
+    TEST_PASS("5.6 Reserved directive not in command table");
+}
+
+/* ================================================================
+ * 5.7 Hard exclusions match MIME types with parameters
+ * ================================================================ */
+static void
+test_hard_exclusions_with_parameters(void)
+{
+    ngx_http_markdown_conf_t conf;
+    ngx_str_t                ct;
+
+    TEST_SUBSECTION("5.7 Hard exclusions match MIME types with parameters");
+
+    init_conf(&conf);
+    conf.stream.excluded_types = NULL;
+
+    /* text/event-stream; charset=utf-8 */
+    set_arg(&ct, "text/event-stream; charset=utf-8");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "text/event-stream; charset=utf-8 should be excluded");
+
+    /* TEXT/EVENT-STREAM (case variation) */
+    set_arg(&ct, "TEXT/EVENT-STREAM");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "TEXT/EVENT-STREAM (uppercase) should be excluded");
+
+    /* Text/Event-Stream (mixed case) */
+    set_arg(&ct, "Text/Event-Stream");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "Text/Event-Stream (mixed case) should be excluded");
+
+    /* application/x-ndjson; boundary=something */
+    set_arg(&ct, "application/x-ndjson; boundary=something");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "application/x-ndjson; boundary=something should be excluded");
+
+    /* APPLICATION/X-NDJSON */
+    set_arg(&ct, "APPLICATION/X-NDJSON");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "APPLICATION/X-NDJSON (uppercase) should be excluded");
+
+    /* application/stream+json; charset=utf-8 */
+    set_arg(&ct, "application/stream+json; charset=utf-8");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "application/stream+json with params should be excluded");
+
+    /* APPLICATION/STREAM+JSON */
+    set_arg(&ct, "APPLICATION/STREAM+JSON");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "APPLICATION/STREAM+JSON (uppercase) should be excluded");
+
+    /* text/event-stream with trailing space before semicolon */
+    set_arg(&ct, "text/event-stream ;charset=utf-8");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 1,
+        "text/event-stream with space before params should be excluded");
+
+    /* Non-excluded type with parameters should not be excluded */
+    set_arg(&ct, "text/html; charset=utf-8");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+        "text/html; charset=utf-8 should NOT be excluded");
+
+    /* Partial match should not be excluded */
+    set_arg(&ct, "text/event-streaming");
+    TEST_ASSERT(test_stream_type_excluded(&ct, &conf) == 0,
+        "text/event-streaming (longer) should NOT be excluded");
+
+    TEST_PASS("5.7 Hard exclusions match with parameters and case");
+}
+
+int
+main(void)
+{
+    printf("\n========================================\n");
+    printf("streaming_config_contract Tests (Spec 36)\n");
+    printf("========================================\n");
+
+    g_compile_complex_rc = NGX_OK;
+    memset(&g_main_conf, 0, sizeof(g_main_conf));
+
+    test_valid_values();
+    test_invalid_values();
+    test_default_inheritance();
+    test_reserved_directive_rejected();
+    test_hard_exclusions_always_present();
+    test_reserved_directive_absent_from_inventory();
+    test_hard_exclusions_with_parameters();
+
+    printf("\n========================================\n");
+    printf("All tests passed!\n");
+    printf("========================================\n\n");
+
+    return 0;
+}

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -741,6 +741,199 @@ markdown_streaming_shadow on;
 markdown_streaming_shadow off;
 ```
 
+#### Streaming Candidacy Directives (v0.8.0)
+
+The following directives were introduced in v0.8.0 to give operators fine-grained
+control over which responses enter the streaming conversion path and how the
+streaming engine batches output. They complement `markdown_streaming_engine` and
+`markdown_streaming_budget` defined above.
+
+##### markdown_stream_threshold
+
+**Syntax:** `markdown_stream_threshold <size>;`
+**Default:** `1m`
+**Context:** http, server, location
+
+Minimum response size for streaming candidacy. Only responses whose body size
+meets or exceeds this threshold are considered for streaming conversion. Responses
+below the threshold always use the full-buffer path.
+
+The value must be greater than zero; `0` is rejected by `nginx -t`.
+
+**Valid Units:** `k` (kilobytes), `m` (megabytes)
+
+**Example:**
+```nginx
+# Default: 1 megabyte threshold
+markdown_stream_threshold 1m;
+
+# Lower threshold for faster streaming engagement
+markdown_stream_threshold 512k;
+
+# Higher threshold — only very large responses stream
+markdown_stream_threshold 5m;
+```
+
+##### markdown_stream_precommit_buffer
+
+**Syntax:** `markdown_stream_precommit_buffer <size>;`
+**Default:** `256k`
+**Context:** http, server, location
+
+Size of the pre-commit replay buffer. During the streaming pre-commit phase, the
+module buffers converted output up to this size. If an error occurs before the
+commit boundary is crossed, the buffered content is discarded and the original
+HTML is replayed to the client (fail-open behavior controlled by
+`markdown_streaming_on_error`).
+
+Setting this to `0` disables the pre-commit HTML fallback capability — errors
+during the pre-commit phase immediately trigger the configured error policy
+without replay.
+
+**Valid Units:** `k` (kilobytes), `m` (megabytes)
+
+**Example:**
+```nginx
+# Default: 256 KB replay buffer
+markdown_stream_precommit_buffer 256k;
+
+# Larger buffer for more replay safety margin
+markdown_stream_precommit_buffer 512k;
+
+# Disable pre-commit replay (zero allowed)
+markdown_stream_precommit_buffer 0;
+```
+
+##### markdown_stream_flush_min
+
+**Syntax:** `markdown_stream_flush_min <size>;`
+**Default:** `16k`
+**Context:** http, server, location
+
+Minimum Markdown output batch size before the streaming engine flushes data
+downstream. The engine accumulates converted output until at least this many
+bytes are ready, then flushes the batch. This reduces per-byte overhead and
+backpressure amplification from many small writes.
+
+The value must be greater than zero; `0` is rejected by `nginx -t` to prevent
+pathological per-byte flushing.
+
+**Valid Units:** `k` (kilobytes), `m` (megabytes)
+
+**Example:**
+```nginx
+# Default: 16 KB flush minimum
+markdown_stream_flush_min 16k;
+
+# Smaller batches for lower latency
+markdown_stream_flush_min 4k;
+
+# Larger batches for higher throughput
+markdown_stream_flush_min 64k;
+```
+
+##### markdown_stream_excluded_types
+
+**Syntax:** `markdown_stream_excluded_types <type> [<type> ...];`
+**Default:** none (only built-in hard exclusions apply)
+**Context:** http, server, location
+
+Space-separated list of MIME types to exclude from streaming conversion. These
+types are added to the built-in hard exclusions and never enter the streaming
+path, regardless of `markdown_streaming_engine` setting.
+
+User-configured exclusions are **additive** to the built-in hard exclusions:
+
+- `text/event-stream`
+- `application/x-ndjson`
+- `application/stream+json`
+
+The built-in hard exclusions cannot be removed by user configuration. Matching
+is case-insensitive and ignores Content-Type parameters (e.g.,
+`text/event-stream; charset=utf-8` remains excluded).
+
+**Example:**
+```nginx
+# Exclude additional types from streaming
+markdown_stream_excluded_types text/csv application/xml;
+
+# Multiple custom exclusions
+markdown_stream_excluded_types text/csv application/xml application/rss+xml;
+```
+
+##### Configuration Examples (v0.8.0 Streaming)
+
+**Basic streaming enablement:**
+```nginx
+http {
+    markdown_filter on;
+    markdown_streaming_engine on;
+    markdown_stream_threshold 1m;
+
+    server {
+        listen 80;
+        server_name docs.example.com;
+
+        location / {
+            proxy_pass http://backend;
+        }
+    }
+}
+```
+
+**Threshold tuning for large responses:**
+```nginx
+location /large-docs {
+    # Only stream responses >= 2 MB
+    markdown_streaming_engine auto;
+    markdown_stream_threshold 2m;
+
+    # Larger pre-commit buffer for complex pages
+    markdown_stream_precommit_buffer 512k;
+
+    # Bigger flush batches for throughput
+    markdown_stream_flush_min 32k;
+
+    proxy_pass http://backend;
+}
+```
+
+**Adding custom excluded types:**
+```nginx
+location /api {
+    markdown_streaming_engine auto;
+
+    # Exclude CSV and XML feeds from streaming
+    markdown_stream_excluded_types text/csv application/atom+xml;
+
+    proxy_pass http://backend;
+}
+```
+
+**Disabling streaming for a specific location:**
+```nginx
+location /legacy {
+    # Force full-buffer path regardless of response size
+    markdown_streaming_engine off;
+    proxy_pass http://backend;
+}
+```
+
+##### Reserved Directive: `markdown_stream_flush_interval`
+
+> **Status:** Reserved for future 0.8.x releases. NOT accepted in the current
+> version.
+
+The `markdown_stream_flush_interval` directive is defined in RFC 0008 for
+time-based flush control but is **not implemented** in v0.8.0. It is not
+registered in the module command table.
+
+- Using `markdown_stream_flush_interval` in configuration causes `nginx -t` to
+  fail with `unknown directive "markdown_stream_flush_interval"`.
+- Do not include this directive in configuration files for v0.8.0 deployments.
+- A future 0.8.x release will register this directive when time-based flush
+  semantics are finalized.
+
 ---
 
 ### Dynamic Configuration (0.6.1+)


### PR DESCRIPTION
## Summary by Sourcery

Add v0.8.0 streaming configuration directives for the NGINX markdown module, including engine mode, thresholds, and exclusions, and document and test their behavior.

New Features:
- Introduce markdown_streaming_engine enum directive with off|auto|on modes for streaming availability control.
- Add streaming candidacy directives for size thresholds, precommit buffer sizing, minimum flush size, and excluded content types.

Enhancements:
- Wire new streaming config fields into module configuration creation and inheritance, including defaults and merge behavior.
- Implement content-type based streaming exclusion logic combining built-in and user-defined MIME types.

Documentation:
- Extend configuration guide with v0.8.0 streaming candidacy directives, examples, and notes about reserved directives.

Tests:
- Add streaming_config_contract unit test suite to validate directive parsing, defaults, inheritance, exclusions, and reserved directive behavior, and hook it into the test Makefile.