### PR TITLE
Standardize GA channel terminology and clarify pre-commit fallback

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -709,6 +709,8 @@ jobs:
           # legacy local-spec validators here; tag release CI checkouts do not
           # include user-local Kiro spec directories.
           python3 tools/release/gates/validate_naming.py
+          python3 tools/release/gates/validate_release_gates_080.py
+          python3 tools/release/gates/validate_config_directives_080.py
           python3 tools/release/gates/validate_release_gates_070.py --mode strict
           python3 tools/release/gates/validate_config_directives_070.py
           python3 tools/release/gates/validate_metrics_070.py

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -9,8 +9,9 @@
  *   Phase 1 (fallible): Vary: Accept, ETag removal, auth Cache-Control.
  *     If any step fails, NGX_ERROR is returned before headers are sent
  *     downstream.  Earlier Phase 1 mutations may be present in
- *     headers_out but are invisible because the caller's fallback sends
- *     the original upstream headers.
+ *     headers_out but are invisible because the pre-commit failure
+ *     path aborts to full-buffer processing without committing
+ *     Markdown headers.
  *   Phase 2 (infallible): Content-Type, Content-Length, Content-Encoding.
  *     These are pointer/integer writes that cannot fail.
  *   Only after both phases complete are headers_committed and state set.
@@ -113,13 +114,13 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
      * Atomicity guarantee: if Vary succeeds but ETag fails, the
      * Vary header HAS been added to the headers_out list.  However,
      * the request is still in pre-commit state and headers have NOT
-     * been sent to the network.  The caller's fallback path sends
-     * the original upstream headers (Content-Type: text/html), so
-     * the extra Vary: Accept is harmless — it does not change
+     * been sent to the network.  The pre-commit failure path aborts
+     * to full-buffer processing without committing Markdown headers,
+     * so the extra Vary: Accept is harmless — it does not change
      * content negotiation semantics for an HTML response.
      * Similarly, a removed ETag in the headers list is not visible
-     * because the full-buffer/fallback path restores upstream
-     * headers before sending.
+     * because the full-buffer path restores upstream headers before
+     * sending.
      */
 
     rc = ngx_http_markdown_stream_commit_set_vary(r);

--- a/docs/guides/GPG_KEY_MANAGEMENT.md
+++ b/docs/guides/GPG_KEY_MANAGEMENT.md
@@ -51,7 +51,7 @@ gpg --edit-key <KEY_ID>
 
 ### Future Repository Signing Key Template
 
-The current 0.8.0 public package channel uses GitHub Release artifacts plus
+The current public package channel uses GitHub Release artifacts plus
 `SHA256SUMS`. Fill this table only when a public repository signing key is
 generated for a future APT/YUM repository channel.
 
@@ -98,9 +98,9 @@ gpg --keyserver keys.openpgp.org --send-keys <KEY_ID>
 
 ## 3. Key Import Instructions
 
-Public APT/YUM repositories are not part of the 0.8.0 GA channel. The examples
+Public APT/YUM repositories are not part of the current GA channel. The examples
 below are for self-hosted repository publication after the repository URL and
-signing key are real. For current v0.7.0+ package artifacts, download the package and
+signing key are real. For current package artifacts, download the package and
 `SHA256SUMS` file from the same GitHub Release and follow
 `PACKAGE_INSTALLATION.md`.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -173,7 +173,7 @@ If you need deterministic control over compiler flags or local patching, use [Ma
 
 Starting with v0.7.0, release workflows build DEB and RPM artifacts for
 supported Linux distributions and attach them to GitHub Releases. APT/YUM repository publishing is planned, but public APT/YUM repository publishing is not
-part of the 0.8.0 GA channel. Do not use `apt-get install
+part of the current GA channel. Do not use `apt-get install
 nginx-module-markdown` or `yum install nginx-module-markdown` unless you
 operate your own package repository.
 

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -7,9 +7,9 @@ official NGINX repository packages.
 ## Repository Publishing Status
 
 GitHub Releases are the current distribution channel for DEB and RPM package
-artifacts, including the 0.8.0 GA channel.
+artifacts.
 Public APT/YUM repositories are planned but not available yet.
-They are not part of the 0.8.0 GA channel.
+They are not part of the current GA channel.
 
 Bare package-manager installation commands only work after an operator
 publishes and configures a real APT or YUM repository. Until then, download the


### PR DESCRIPTION
## Summary by Sourcery

Clarify markdown stream pre-commit failure behavior and standardize GA/release channel terminology across installation and GPG key management docs.

Documentation:
- Clarify that pre-commit failures in markdown streaming fall back to full-buffer processing without committing markdown headers in the nginx module documentation comments.
- Standardize references to the current GA channel and GitHub Releases as the active package distribution channel across installation and GPG key management guides.