### PR TITLE
fix(ffi,eligibility): abort handle on invalid input and accept HTAB as OWS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,7 +27,6 @@
 **/*.dylib
 
 # Test artifacts
-components/rust-converter/fuzz/
 components/nginx-module/tests/build/
 
 # Documentation (if not needed for build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,9 @@ jobs:
           make rust-lib
           make copy-headers
           make check-headers
-          git diff --exit-code -- components/rust-converter/include/markdown_converter.h
+          git diff --exit-code -- \
+            components/rust-converter/include/markdown_converter.h \
+            components/nginx-module/src/markdown_converter.h
 
   rust-quality:
     name: Rust Quality Gate

--- a/.github/workflows/security-static.yml
+++ b/.github/workflows/security-static.yml
@@ -105,7 +105,8 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          go install github.com/zricethezav/gitleaks/v8@v8.30.1
+          # v8.30.1
+          go install github.com/zricethezav/gitleaks/v8@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Scan current tree for secrets

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ security-shellcheck:
 	fi
 
 security-gitleaks:
-	@command -v gitleaks >/dev/null 2>&1 || { echo "ERROR: gitleaks not found. Install with: go install github.com/zricethezav/gitleaks/v8@v8.30.1" >&2; exit 127; }
+	@command -v gitleaks >/dev/null 2>&1 || { echo "ERROR: gitleaks not found. Install with: go install github.com/zricethezav/gitleaks/v8@83d9cd684c87d95d656c1458ef04895a7f1cbd8e # v8.30.1" >&2; exit 127; }
 	gitleaks detect --source . --no-git --redact --config .gitleaks.toml --verbose
 
 security-semgrep:

--- a/components/nginx-module/src/markdown_converter.h
+++ b/components/nginx-module/src/markdown_converter.h
@@ -1431,8 +1431,12 @@ void markdown_streaming_abort(struct StreamingConverterHandle *handle);
  * discard or truncate the partial output. **C MUST NOT infer or synthesize
  * Markdown closure for Rust-owned parser/emitter state** (safety invariant: C must not infer Markdown closure).
  *
- * This call always consumes the handle; after this function returns the
- * handle is invalid and must not be passed to any other function.
+ * This call consumes the handle after validation succeeds (the handle and
+ * output pointers are non-NULL). If validation fails, `ERROR_INVALID_INPUT`
+ * is returned and the handle is not consumed; the caller remains responsible
+ * for aborting or freeing it. All other return codes consume the handle. In
+ * particular, a caught panic (`ERROR_INTERNAL`) can only occur after
+ * `Box::from_raw` has taken ownership, so the handle is consumed in that case.
  *
  * # Safety
  *

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -224,20 +224,17 @@ ngx_http_markdown_check_size_limit(const ngx_http_request_t *r,
     return 1;
 }
 
-/*
- * Check if Content-Type indicates unbounded streaming
+/**
+ * Detects unbounded streaming responses.
  *
- * Checks if the response is an unbounded streaming type that should not
- * be converted per FR-02.8. This includes Server-Sent Events and other
- * streaming content types configured in stream_types.
+ * Determines whether the response Content-Type indicates an unbounded streaming
+ * type. Checks for the built-in text/event-stream type and configured streaming
+ * type exclusions.
  *
- * Parameters:
- *   r    - NGINX request structure
- *   conf - Module configuration
+ * @param r    The HTTP request structure.
+ * @param conf Module configuration.
  *
- * Returns:
- *   1 if response is unbounded streaming (ineligible)
- *   0 if response is not streaming (eligible)
+ * @return 1 if the response is an unbounded streaming type, 0 otherwise.
  */
 static ngx_int_t
 ngx_http_markdown_is_streaming(const ngx_http_request_t *r,
@@ -380,27 +377,20 @@ ngx_http_markdown_check_eligibility(const ngx_http_request_t *r,
     return NGX_HTTP_MARKDOWN_ELIGIBLE;
 }
 
-/*
- * Check whether a content type is excluded from streaming conversion.
+/**
+ * Determines whether a content type is excluded from streaming conversion.
  *
- * Returns the union of built-in hard exclusions (text/event-stream,
- * application/x-ndjson, application/stream+json) and the user-configured
- * conf->stream.excluded_types array.
+ * Checks for built-in hard exclusions (text/event-stream,
+ * application/x-ndjson, application/stream+json) and any
+ * user-configured excluded types. Content-Type parameters (after `;`)
+ * are ignored. Matching is case-insensitive and exact.
  *
- * Matching is case-insensitive and ignores Content-Type parameters
- * (anything after the first ';').  NULL or empty content_type is
- * treated as not excluded.
+ * A NULL or empty content_type is treated as not excluded (returns 0),
+ * so callers without a Content-Type header will not be short-circuited.
  *
- * Acceptance criteria: built-in hard exclusions (SSE, NDJSON, stream+json)
- * and user-configured exclusion array with case-insensitive exact matching
- *
- * Parameters:
- *   content_type - Content-Type string to check (may be NULL)
- *   conf         - Module location configuration
- *
- * Returns:
- *   1 if the content type is excluded from streaming
- *   0 if the content type is not excluded
+ * @param content_type Content-Type string to check; may be NULL or empty.
+ * @param conf Module location configuration.
+ * @returns 1 if the content type is excluded, 0 otherwise.
  */
 ngx_int_t
 ngx_http_markdown_stream_type_excluded(const ngx_str_t *content_type,

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -128,7 +128,8 @@ ngx_http_markdown_check_content_type(const ngx_http_request_t *r,
                                    ct_entry[i].len) == 0
                 && (content_type->len == ct_entry[i].len
                     || content_type->data[ct_entry[i].len] == ';'
-                    || content_type->data[ct_entry[i].len] == ' '))
+                    || content_type->data[ct_entry[i].len] == ' '
+                    || content_type->data[ct_entry[i].len] == '\t'))
             {
                 return 1;
             }
@@ -142,7 +143,8 @@ ngx_http_markdown_check_content_type(const ngx_http_request_t *r,
                            text_html, 9) == 0
         && (content_type->len == 9
             || content_type->data[9] == ';'
-            || content_type->data[9] == ' '))
+            || content_type->data[9] == ' '
+            || content_type->data[9] == '\t'))
     {
         return 1;
     }
@@ -258,7 +260,8 @@ ngx_http_markdown_is_streaming(const ngx_http_request_t *r,
                            text_event_stream, 17) == 0
         && (content_type->len == 17
             || content_type->data[17] == ';'
-            || content_type->data[17] == ' '))
+            || content_type->data[17] == ' '
+            || content_type->data[17] == '\t'))
     {
         return 1;
     }
@@ -274,7 +277,8 @@ ngx_http_markdown_is_streaming(const ngx_http_request_t *r,
                                stream_type[i].len) == 0 &&
                 (content_type->len == stream_type[i].len
                  || content_type->data[stream_type[i].len] == ';'
-                 || content_type->data[stream_type[i].len] == ' '))
+                 || content_type->data[stream_type[i].len] == ' '
+                 || content_type->data[stream_type[i].len] == '\t'))
             {
                 return 1;
             }
@@ -428,8 +432,11 @@ ngx_http_markdown_stream_type_excluded(const ngx_str_t *content_type,
         type_len = (size_t) (p - content_type->data);
     }
 
-    /* Strip trailing whitespace from the type portion */
-    while (type_len > 0 && content_type->data[type_len - 1] == ' ') {
+    /* Strip HTTP optional whitespace (SP / HTAB) from the type portion. */
+    while (type_len > 0
+           && (content_type->data[type_len - 1] == ' '
+               || content_type->data[type_len - 1] == '\t'))
+    {
         type_len--;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -315,7 +315,8 @@ ngx_http_markdown_stream_commit_remove_etag(
  */
 static ngx_int_t
 ngx_http_markdown_stream_commit_apply_auth_cache_control(
-    ngx_http_request_t *r, const ngx_http_markdown_conf_t *conf)
+    ngx_http_request_t *r, /* NOSONAR: r passed to non-const modify_cache_control_for_auth */
+    const ngx_http_markdown_conf_t *conf)
 {
 #if NGX_HTTP_MARKDOWN_ENABLE_AUTH_CACHE_CONTROL
     ngx_int_t  rc;

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -298,20 +298,20 @@ ngx_http_markdown_stream_commit_remove_etag(
 }
 
 
-/*
- * Apply authenticated content Cache-Control protection.
+/**
+ * Applies Cache-Control protection for authenticated requests.
  *
- * When the request is authenticated and auth_policy allows
- * conversion, upgrade Cache-Control to at least "private" to prevent
- * shared caches from storing authenticated Markdown content.  This
- * matches the full-buffer path's behavior.
+ * When the NGX_HTTP_MARKDOWN_ENABLE_AUTH_CACHE_CONTROL compile-time gate
+ * is enabled and the request is authenticated (as determined by the active
+ * auth_policy via ngx_http_markdown_is_authenticated), this upgrades the
+ * response Cache-Control to at least "private": a "public" directive is
+ * rewritten to "private", and a missing/private-less header gets "private"
+ * appended. "no-store" is preserved and never downgraded. This mirrors
+ * the full-buffer path so streaming and buffered responses behave identically.
  *
- * Guarded by NGX_HTTP_MARKDOWN_ENABLE_AUTH_CACHE_CONTROL compile-time
- * gate for parity with the full-buffer path.
- *
- * Returns:
- *   NGX_OK on success (or when compile-time gate is off)
- *   NGX_ERROR on Cache-Control modification failure
+ * @param r HTTP request.
+ * @param conf Module location configuration (used for auth_policy check).
+ * @return NGX_OK on success or when not applicable; NGX_ERROR on modification failure.
  */
 static ngx_int_t
 ngx_http_markdown_stream_commit_apply_auth_cache_control(

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -50,7 +50,7 @@ ngx_http_markdown_stream_commit_remove_etag(
 
 static ngx_int_t
 ngx_http_markdown_stream_commit_apply_auth_cache_control(
-    const ngx_http_request_t *r, const ngx_http_markdown_conf_t *conf);
+    ngx_http_request_t *r, const ngx_http_markdown_conf_t *conf);
 
 
 /*
@@ -315,7 +315,7 @@ ngx_http_markdown_stream_commit_remove_etag(
  */
 static ngx_int_t
 ngx_http_markdown_stream_commit_apply_auth_cache_control(
-    const ngx_http_request_t *r, const ngx_http_markdown_conf_t *conf)
+    ngx_http_request_t *r, const ngx_http_markdown_conf_t *conf)
 {
 #if NGX_HTTP_MARKDOWN_ENABLE_AUTH_CACHE_CONTROL
     ngx_int_t  rc;
@@ -325,8 +325,7 @@ ngx_http_markdown_stream_commit_apply_auth_cache_control(
     }
 
     if (ngx_http_markdown_is_authenticated(r, conf)) {
-        rc = ngx_http_markdown_modify_cache_control_for_auth(
-            (ngx_http_request_t *) r);
+        rc = ngx_http_markdown_modify_cache_control_for_auth(r);
         if (rc != NGX_OK) {
             return rc;
         }

--- a/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
@@ -181,7 +181,10 @@ ngx_http_markdown_stream_postcommit_finish_via_rust(
         ctx->streaming.handle,
         &close_data, &close_len);
 
-    /* Handle is consumed by safe_finish regardless of outcome */
+    /* Only validation failure leaves the handle unconsumed. */
+    if (finish_rc == ERROR_INVALID_INPUT) {
+        markdown_streaming_abort(ctx->streaming.handle);
+    }
     ctx->streaming.handle = NULL;
 
     if (finish_rc == POST_COMMIT_ABORT) {
@@ -673,7 +676,7 @@ ngx_http_markdown_stream_postcommit_has_html_signature(
     const u_char       *p;
     const u_char       *last;
     const u_char       *scan_last;
-    static u_char       doctype[] = {
+    static const u_char doctype[] = {
         'D', 'O', 'C', 'T', 'Y', 'P', 'E'
     };
     static const u_char tag_names[] =

--- a/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
@@ -157,15 +157,15 @@ ngx_http_markdown_stream_postcommit_safe_finish(
 
 
 #ifdef MARKDOWN_STREAMING_ENABLED
-/*
- * Internal helper: invoke Rust streaming safe_finish and handle
- * the result.  Extracted to reduce cognitive complexity and nesting
- * depth of the top-level safe_finish function.
+/**
+ * Invoke the Rust safe_finish handler and transmit response closure.
  *
- * Returns:
- *   NGX_OK    - Rust finish completed, response closed
- *   NGX_AGAIN - Downstream backpressure, caller must retry
- *   NGX_ERROR - Rust finish failed, caller should follow abort path
+ * Calls markdown_streaming_safe_finish to obtain closing bytes. On validation
+ * failure, aborts the Rust handle. Sends closing bytes if provided, otherwise
+ * sends an empty terminal chain.
+ *
+ * @return NGX_OK if closure completed, NGX_AGAIN on downstream backpressure,
+ *         NGX_ERROR if Rust failed or send operation failed.
  */
 static ngx_int_t
 ngx_http_markdown_stream_postcommit_finish_via_rust(

--- a/components/nginx-module/tests/unit/eligibility_impl_test.c
+++ b/components/nginx-module/tests/unit/eligibility_impl_test.c
@@ -140,6 +140,11 @@ test_check_content_type_default(void)
         ngx_http_markdown_check_content_type(&r, &conf) == 1,
         "text/html with space separator should match");
 
+    set_str(&r.headers_out.content_type, "text/html\t;charset=utf-8");
+    TEST_ASSERT(
+        ngx_http_markdown_check_content_type(&r, &conf) == 1,
+        "text/html with HTAB separator should match");
+
     set_str(&r.headers_out.content_type, "text/htmlx");
     TEST_ASSERT(
         ngx_http_markdown_check_content_type(&r, &conf) == 0,
@@ -192,6 +197,12 @@ test_check_content_type_custom_allowlist(void)
         ngx_http_markdown_check_content_type(&r, &conf) == 1,
         "application/xhtml+xml matches custom allowlist");
 
+    set_str(&r.headers_out.content_type,
+            "application/xhtml+xml\t;charset=utf-8");
+    TEST_ASSERT(
+        ngx_http_markdown_check_content_type(&r, &conf) == 1,
+        "custom allowlist should accept HTAB separator");
+
     set_str(&r.headers_out.content_type, "application/json");
     TEST_ASSERT(
         ngx_http_markdown_check_content_type(&r, &conf) == 0,
@@ -221,6 +232,12 @@ test_is_streaming_detection(void)
     TEST_ASSERT(
         ngx_http_markdown_is_streaming(&r, &conf) == 1,
         "text/event-stream with charset should be detected");
+
+    set_str(&r.headers_out.content_type,
+            "text/event-stream\t;charset=utf-8");
+    TEST_ASSERT(
+        ngx_http_markdown_is_streaming(&r, &conf) == 1,
+        "text/event-stream with HTAB separator should be detected");
 
     set_str(&r.headers_out.content_type, "text/html");
     TEST_ASSERT(
@@ -261,6 +278,12 @@ test_is_streaming_configured_types(void)
     TEST_ASSERT(
         ngx_http_markdown_is_streaming(&r, &conf) == 1,
         "configured stream type should be detected");
+
+    set_str(&r.headers_out.content_type,
+            "application/x-ndjson\t;charset=utf-8");
+    TEST_ASSERT(
+        ngx_http_markdown_is_streaming(&r, &conf) == 1,
+        "configured stream type should accept HTAB separator");
 
     set_str(&r.headers_out.content_type, "text/html");
     TEST_ASSERT(

--- a/components/nginx-module/tests/unit/hard_excluded_params_case_test.c
+++ b/components/nginx-module/tests/unit/hard_excluded_params_case_test.c
@@ -252,6 +252,48 @@ test_htab_before_parameters_exclusions(void)
     TEST_PASS("HTAB parameter separators cannot bypass exclusions");
 }
 
+/*
+ * Security: trailing HTAB/OWS without parameters.
+ * The type portion OWS-stripping logic must handle content types
+ * followed only by whitespace (no semicolon, no parameters).
+ */
+static void
+test_trailing_ows_no_parameters(void)
+{
+    ngx_http_markdown_conf_t conf;
+    ngx_str_t                ct;
+
+    TEST_SUBSECTION("Trailing OWS without parameters");
+    init_conf(&conf);
+
+    /* Single trailing HTAB */
+    set_ct(&ct, "application/x-ndjson\t");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "trailing HTAB must not bypass x-ndjson exclusion");
+
+    /* Single trailing SP */
+    set_ct(&ct, "text/event-stream ");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "trailing SP must not bypass event-stream exclusion");
+
+    /* Mixed SP + HTAB */
+    set_ct(&ct, "application/stream+json \t");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "trailing SP+HTAB must not bypass stream+json exclusion");
+
+    /* Multiple tabs and spaces */
+    set_ct(&ct, "application/x-ndjson \t \t");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "multiple trailing OWS must not bypass x-ndjson exclusion");
+
+    /* Only whitespace (should not match anything) */
+    set_ct(&ct, "  \t  ");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 0,
+        "pure OWS must not match any exclusion");
+
+    TEST_PASS("Trailing OWS without parameters correctly handled");
+}
+
 /* ══════════════════════════════════════════════════════════════════
  * Security: combined case + parameters
  *
@@ -377,6 +419,7 @@ main(void)
     test_mixed_case_exclusions();
     test_parameter_stripping_exclusions();
     test_htab_before_parameters_exclusions();
+    test_trailing_ows_no_parameters();
     test_combined_case_and_params();
     test_partial_match_not_excluded();
     test_non_excluded_types();

--- a/components/nginx-module/tests/unit/hard_excluded_params_case_test.c
+++ b/components/nginx-module/tests/unit/hard_excluded_params_case_test.c
@@ -213,6 +213,45 @@ test_parameter_stripping_exclusions(void)
     TEST_PASS("Parameter stripping correctly blocks bypass attempts");
 }
 
+
+/*
+ * Security: HTTP OWS before parameters includes both SP and HTAB.
+ * HTAB must not bypass built-in or configured streaming exclusions.
+ */
+static void
+test_htab_before_parameters_exclusions(void)
+{
+    ngx_http_markdown_conf_t conf;
+    ngx_array_t              excluded_types;
+    ngx_str_t                configured_type;
+    ngx_str_t                ct;
+
+    TEST_SUBSECTION("HTAB before Content-Type parameters");
+    init_conf(&conf);
+
+    set_ct(&ct, "application/x-ndjson\t;charset=utf-8");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "HTAB must not bypass application/x-ndjson exclusion");
+
+    set_ct(&ct, "application/stream+json\t; charset=utf-8");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "HTAB must not bypass application/stream+json exclusion");
+
+    set_ct(&configured_type, "text/x-stream");
+    excluded_types.elts = &configured_type;
+    excluded_types.nelts = 1;
+    excluded_types.size = sizeof(ngx_str_t);
+    excluded_types.nalloc = 1;
+    excluded_types.pool = NULL;
+    conf.stream.excluded_types = &excluded_types;
+
+    set_ct(&ct, "text/x-stream\t;charset=utf-8");
+    TEST_ASSERT(ngx_http_markdown_stream_type_excluded(&ct, &conf) == 1,
+        "HTAB must not bypass configured stream exclusion");
+
+    TEST_PASS("HTAB parameter separators cannot bypass exclusions");
+}
+
 /* ══════════════════════════════════════════════════════════════════
  * Security: combined case + parameters
  *
@@ -337,6 +376,7 @@ main(void)
 
     test_mixed_case_exclusions();
     test_parameter_stripping_exclusions();
+    test_htab_before_parameters_exclusions();
     test_combined_case_and_params();
     test_partial_match_not_excluded();
     test_non_excluded_types();

--- a/components/nginx-module/tests/unit/stream_e2e_test.c
+++ b/components/nginx-module/tests/unit/stream_e2e_test.c
@@ -324,6 +324,13 @@ markdown_streaming_safe_finish(struct StreamingConverterHandle *handle,
     return e2e_safe_finish_rc;
 }
 
+/* Stub: markdown_streaming_abort */
+void
+markdown_streaming_abort(struct StreamingConverterHandle *handle)
+{
+    UNUSED(handle);
+}
+
 /* Stub: markdown_streaming_output_free */
 void
 markdown_streaming_output_free(u_char *data, uintptr_t len)

--- a/components/nginx-module/tests/unit/stream_error_test.c
+++ b/components/nginx-module/tests/unit/stream_error_test.c
@@ -239,6 +239,12 @@ markdown_streaming_safe_finish(struct StreamingConverterHandle *handle,
 }
 
 void
+markdown_streaming_abort(struct StreamingConverterHandle *handle)
+{
+    UNUSED(handle);
+}
+
+void
 markdown_streaming_output_free(u_char *data, uintptr_t len)
 {
     UNUSED(data);

--- a/components/nginx-module/tests/unit/stream_postcommit_test.c
+++ b/components/nginx-module/tests/unit/stream_postcommit_test.c
@@ -215,6 +215,7 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log,
 static uint32_t test_safe_finish_rc;
 static u_char *test_safe_finish_data;
 static uintptr_t test_safe_finish_len;
+static int test_streaming_abort_called;
 static int test_output_free_called;
 static u_char *test_output_free_data;
 static uintptr_t test_output_free_len;
@@ -228,6 +229,14 @@ markdown_streaming_safe_finish(struct StreamingConverterHandle *handle,
     if (out_data != NULL) *out_data = test_safe_finish_data;
     if (out_len != NULL) *out_len = test_safe_finish_len;
     return test_safe_finish_rc;
+}
+
+/* Stub: markdown_streaming_abort */
+void
+markdown_streaming_abort(struct StreamingConverterHandle *handle)
+{
+    UNUSED(handle);
+    test_streaming_abort_called++;
 }
 
 /* Stub: markdown_streaming_output_free */
@@ -298,6 +307,7 @@ static void test_setup(void)
     test_safe_finish_rc = POST_COMMIT_ABORT;
     test_safe_finish_data = NULL;
     test_safe_finish_len = 0;
+    test_streaming_abort_called = 0;
     test_output_free_called = 0;
     test_output_free_data = NULL;
     test_output_free_len = 0;
@@ -871,6 +881,32 @@ static void test_safe_finish_send_terminal_fails(void)
     TEST_PASS("safe_finish send_terminal failure propagates");
 }
 
+
+static void test_safe_finish_invalid_input_aborts_handle(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    struct StreamingConverterHandle *handle;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_COMMITTED;
+    handle = (struct StreamingConverterHandle *) (uintptr_t) 0x1;
+    ctx.streaming.handle = handle;
+    test_safe_finish_rc = ERROR_INVALID_INPUT;
+
+    rc = ngx_http_markdown_stream_postcommit_safe_finish(
+        &test_request, &ctx);
+
+    TEST_ASSERT(rc == NGX_ERROR,
+                "invalid FFI input should propagate as NGX_ERROR");
+    TEST_ASSERT(test_streaming_abort_called == 1,
+                "invalid FFI input must explicitly abort the handle");
+    TEST_ASSERT(ctx.streaming.handle == NULL,
+                "aborted handle must be cleared");
+    TEST_PASS("safe_finish invalid input aborts Rust handle");
+}
+
 /* --- abort tests --- */
 
 static void test_abort_happy_path(void)
@@ -1388,6 +1424,7 @@ int main(void)
     test_safe_finish_invalid_state();
     test_safe_finish_null_params();
     test_safe_finish_send_terminal_fails();
+    test_safe_finish_invalid_input_aborts_handle();
 
     TEST_SECTION("Post-commit abort (abort)");
     test_abort_happy_path();

--- a/components/nginx-module/tests/unit/stream_postcommit_test.c
+++ b/components/nginx-module/tests/unit/stream_postcommit_test.c
@@ -672,6 +672,8 @@ static void test_safe_finish_happy_path(void)
                 "state = POST_COMMIT_SAFE_FINISH");
     TEST_ASSERT(test_output_filter_called == 1,
                 "send_terminal called output_filter");
+    TEST_ASSERT(test_streaming_abort_called == 0,
+                "streaming abort must not be called on success");
     TEST_PASS("safe_finish happy path");
 }
 
@@ -701,6 +703,8 @@ static void test_safe_finish_empty_rust_output_sends_terminal(void)
                 "empty safe_finish should not free a NULL output");
     TEST_ASSERT(ctx.streaming.handle == NULL,
                 "safe_finish consumes the streaming handle");
+    TEST_ASSERT(test_streaming_abort_called == 0,
+                "streaming abort must not be called on empty output success");
     TEST_PASS("safe_finish empty Rust output sends terminal");
 }
 
@@ -741,6 +745,8 @@ static void test_safe_finish_copies_rust_output_before_free(void)
                 "Rust free should use original output pointer");
     TEST_ASSERT(test_output_free_len == sizeof(closing) - 1,
                 "Rust free should use original output length");
+    TEST_ASSERT(test_streaming_abort_called == 0,
+                "streaming abort must not be called on successful copy path");
     TEST_PASS("safe_finish copies Rust output before free");
 }
 
@@ -775,6 +781,8 @@ static void test_safe_finish_backpressure_preserves_pending_chain(void)
                 "request should be marked buffered on backpressure");
     TEST_ASSERT(test_output_free_called == 1,
                 "Rust output should still be freed after pool copy");
+    TEST_ASSERT(test_streaming_abort_called == 0,
+                "streaming abort must not be called on backpressure");
     TEST_PASS("safe_finish backpressure preserves pending chain");
 }
 
@@ -878,6 +886,8 @@ static void test_safe_finish_send_terminal_fails(void)
 
     TEST_ASSERT(rc == NGX_ERROR,
                 "safe_finish send_terminal fails -> NGX_ERROR");
+    TEST_ASSERT(test_streaming_abort_called == 0,
+                "streaming abort must not be called when send_terminal fails");
     TEST_PASS("safe_finish send_terminal failure propagates");
 }
 

--- a/components/rust-converter/include/markdown_converter.h
+++ b/components/rust-converter/include/markdown_converter.h
@@ -1431,8 +1431,12 @@ void markdown_streaming_abort(struct StreamingConverterHandle *handle);
  * discard or truncate the partial output. **C MUST NOT infer or synthesize
  * Markdown closure for Rust-owned parser/emitter state** (safety invariant: C must not infer Markdown closure).
  *
- * This call always consumes the handle; after this function returns the
- * handle is invalid and must not be passed to any other function.
+ * This call consumes the handle after validation succeeds (the handle and
+ * output pointers are non-NULL). If validation fails, `ERROR_INVALID_INPUT`
+ * is returned and the handle is not consumed; the caller remains responsible
+ * for aborting or freeing it. All other return codes consume the handle. In
+ * particular, a caught panic (`ERROR_INTERNAL`) can only occur after
+ * `Box::from_raw` has taken ownership, so the handle is consumed in that case.
  *
  * # Safety
  *

--- a/components/rust-converter/src/ffi/streaming.rs
+++ b/components/rust-converter/src/ffi/streaming.rs
@@ -731,8 +731,12 @@ pub unsafe extern "C" fn markdown_streaming_abort(handle: *mut StreamingConverte
 /// discard or truncate the partial output. **C MUST NOT infer or synthesize
 /// Markdown closure for Rust-owned parser/emitter state** (safety invariant: C must not infer Markdown closure).
 ///
-/// This call always consumes the handle; after this function returns the
-/// handle is invalid and must not be passed to any other function.
+/// This call consumes the handle after validation succeeds (the handle and
+/// output pointers are non-NULL). If validation fails, `ERROR_INVALID_INPUT`
+/// is returned and the handle is not consumed; the caller remains responsible
+/// for aborting or freeing it. All other return codes consume the handle. In
+/// particular, a caught panic (`ERROR_INTERNAL`) can only occur after
+/// `Box::from_raw` has taken ownership, so the handle is consumed in that case.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
## Summary by Sourcery

Handle HTTP optional whitespace correctly in content-type parsing and streaming exclusions, and ensure invalid streaming finish inputs are safely aborted, while keeping headers in sync and tightening CI/security tooling.

Bug Fixes:
- Treat horizontal tab characters as optional whitespace when matching content-types for eligibility, streaming detection, and streaming exclusion checks so HTAB separators cannot bypass rules.
- Abort and clear streaming converter handles when the Rust safe-finish FFI reports invalid input, instead of leaving ownership ambiguous.
- Allow authenticated cache-control modification to operate directly on the request object without unsafe casts.

Enhancements:
- Clarify FFI documentation for markdown_streaming_safe_finish ownership semantics around validation failures and error codes.
- Make HTML signature detection data immutable by declaring the doctype buffer as const.

Build:
- Update the Makefile gitleaks installation hint to match the pinned commit used in CI.

CI:
- Extend CI header-drift checks to cover both the Rust and NGINX markdown_converter headers.
- Pin gitleaks installation in security workflows to a specific commit hash for reproducible scans.

Tests:
- Expand unit tests for content-type eligibility, streaming detection, and exclusion logic to cover HTAB-separated parameters and configured stream types.
- Add post-commit tests verifying that invalid FFI input triggers handle abort and that aborted streaming handles are cleared.
- Stub markdown_streaming_abort in existing streaming tests to exercise new abort paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Content-Type boundary parsing to treat tab (`\t`) as a valid separator after matched media types, including correct handling for trailing whitespace.
  * Improved streaming markdown safe-finish cleanup by aborting the streaming handle on `ERROR_INVALID_INPUT`.
* **Documentation**
  * Clarified streaming conversion handle-consumption and panic/ownership behavior.
* **Tests**
  * Added/expanded unit and security regression tests for HTAB boundary edge cases and trailing OWS, including assertions around abort behavior.
* **Chores**
  * Expanded CI header drift checks, pinned gitleaks to a commit hash, and adjusted the Docker build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->