### PR TITLE
Implement Rule 39 atomicity with header rollback and version bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Full rule text, historical issues, and verification commands: `docs/harness/rule
 
 | Rule | Domain File | Summary |
 |------|-------------|---------|
-| 1 | streaming-backpressure | Persist unsent chain on NGX_AGAIN; never overwrite pending with terminal last_buf |
+| 1 | streaming-backpressure | Resume NGX_AGAIN according to chain ownership; never duplicate or overwrite pending data |
 | 2 | streaming-backpressure | Correct return codes in fail-open branches; don't advance unconsumed buffer positions; cross-ref Rule 38 for replay buffer |
 | 3 | memory-budget | Enforce all budgets; free auxiliary buffers on all exits; track peak memory |
 | 4 | encoding-charset | Preserve incomplete UTF-8 tails across chunks; flush decoders at EOF |
@@ -114,7 +114,7 @@ Full rule text, historical issues, and verification commands: `docs/harness/rule
 | 36 | harness-routing | Route recurring tooling fixes to focused security family |
 | 37 | e2e-runner | Rust-first E2E; no new Python e2e files; parity entries required |
 | 38 | streaming-backpressure | Replay buffer init/append failure → precommit_error; failopen_completed flag; delivery after downstream OK |
-| 39 | nginx-idioms | NGX_DONE terminal semantics; return immediately after finalize; multi-step header atomicity |
+| 39 | nginx-idioms | NGX_DONE terminal semantics; multi-step header atomicity; bounded snapshots fail before mutation |
 | 40 | nginx-idioms | Filter hash==0 (invalidated) headers in all lookup/iteration functions |
 | 41 | shell | Shell harness detect_*.sh scripts must use POSIX ERE ([[:space:]] not \s); grep -E for extended patterns |
 | 42 | c-safety | volatile only for single-threaded compiler barriers; direct aggregate __atomic_* usage is forbidden |
@@ -144,7 +144,7 @@ Full rule text, historical issues, and verification commands: `docs/harness/rule
 Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-converter, **S** = shell, **P** = python, **D** = docs
 
 **Streaming & Backpressure** (C)
-- Pending-chain preserved on NGX_AGAIN; last_buf not overwritten while pending [1]
+- NGX_AGAIN resume honors chain ownership: module-owned chains persist; downstream-owned chains drain with NULL; last_buf never overwrites pending data [1]
 - Fail-open return codes correct; replay buffer init/append failure → precommit_error [2,38]
 - failopen_completed prevents duplicate finalize; failopen_count after downstream OK [38]
 - UTF-8 tails preserved across chunk boundaries; flush at EOF [4]
@@ -186,6 +186,7 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
 - effective_conf NULL-safe access; cross-TU field visibility; sentinel consistency [45]
 - NGX_DONE terminal: return immediately after finalize_request; callers check NGX_DONE [39]
 - Multi-step header modification atomic: abort on first failure, no partial apply [39]
+- Bounded transaction snapshots: capacity overflow fails before mutation; never silently truncate rollback state [39]
 - Header lookup/iteration filters hash==0 (invalidated) entries [40]
 
 **HTML Sanitizer & Output Safety** (C, R, D)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2026-06-19
+## [0.8.1] - 2026-06-20
 
-Maintenance release on top of 0.8.0: streaming header commit atomicity
-(Rule 39), FFI handle ownership correctness, HTTP OWS compliance, and
-security hardening of the performance/coverage tooling.
+Maintenance, stability, and security-hardening release on top of 0.8.0:
+streaming header commit atomicity (Rule 39), FFI handle ownership correctness,
+HTTP OWS compliance, and performance/coverage tooling hardening.
 
 ### Fixed
 
@@ -20,21 +20,24 @@ security hardening of the performance/coverage tooling.
   the fallback/full-buffer path. Rollback restores original `hash`/`value`
   for modified entries, invalidates newly pushed entries (`hash=0`), and
   restores the typed `etag` pointer. No use-after-free or double-free under
-  the request-pool memory model.
-- **FFI handle consumption contract for `safe_finish`**: when
+  the request-pool memory model. Snapshot collection now fails before any
+  Phase 1 mutation when a header exceeds the fixed snapshot capacity, rather
+  than silently leaving entries outside the rollback set.
+- **Corrected FFI cleanup contract**: when
   `markdown_streaming_safe_finish` returns `ERROR_INVALID_INPUT` (validation
   failure), the handle is no longer consumed by Rust. The NGINX C module now
   calls `markdown_streaming_abort()` to free the unconsumed handle, preventing
-  a resource leak. See the breaking-change note below for external FFI
-  consumers.
+  a resource leak.
 - **Eligibility Content-Type OWS compliance (#149)**: Content-Type matching
   in `ngx_http_markdown_check_content_type()`, `ngx_http_markdown_is_streaming()`,
   and `ngx_http_markdown_stream_type_excluded()` now accepts HTAB as an
   optional whitespace separator per RFC 7230, in addition to SP. Trailing
   OWS stripping also handles HTAB.
-- **FFI invalid-input handle abort**: `ngx_http_markdown_stream_postcommit_finish_via_rust()`
-  aborts the Rust handle on `ERROR_INVALID_INPUT` before nulling the typed
-  pointer, matching the corrected consumption contract.
+- **Full-buffer backpressure tail duplication**: when the downstream NGINX
+  copy filter returns `NGX_AGAIN`, resume now drains the filter's retained
+  chain with a `NULL` input instead of resubmitting the original converted
+  body. This prevents duplicated response tails under concurrent large-body
+  traffic.
 
 ### Security
 
@@ -64,21 +67,18 @@ security hardening of the performance/coverage tooling.
   contract.
 - Improved docstrings for eligibility and auth cache-control helpers
   (Doxygen-style `@param`/`@return`).
-
-### Breaking Changes
-
-- **`markdown_streaming_safe_finish` FFI contract**: the handle is now
-  consumed only after validation succeeds. On `ERROR_INVALID_INPUT`, the
-  handle is **not** consumed and the caller must call
-  `markdown_streaming_abort()` (or otherwise free it). The bundled NGINX C
-  module already handles this; third-party FFI consumers that assumed the
-  handle was always consumed must update their cleanup path.
+- **FFI contract clarification**: `markdown_streaming_safe_finish` consumes
+  its handle only after validation succeeds. On `ERROR_INVALID_INPUT`, it is
+  not consumed and the caller must call `markdown_streaming_abort()` or
+  otherwise free it. The bundled NGINX C module already handles this cleanup;
+  third-party FFI consumers should align their invalid-input path.
 
 ### Tests
 
-- Added 5 rollback unit tests for `stream_commit` covering Vary/ETag/Cache-Control
-  failure rollback, cross-header rollback (ETag failure rolls back prior Vary
-  mutation), and typed ETag pointer restoration.
+- Added snapshot/rollback unit coverage for `stream_commit`, including
+  Vary/ETag/Cache-Control failure rollback, cross-header rollback, typed ETag
+  pointer restoration, and pre-mutation snapshot-capacity failure for each
+  matching header family.
 - Added trailing OWS exclusion and abort-contract assertions to streaming
   tests.
 - Added `hard_excluded_params_case_test.c` for eligibility hard-exclusion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-06-19
+
+Maintenance release on top of 0.8.0: streaming header commit atomicity
+(Rule 39), FFI handle ownership correctness, HTTP OWS compliance, and
+security hardening of the performance/coverage tooling.
+
+### Fixed
+
+- **Streaming header commit atomicity (Rule 39)**: `ngx_http_markdown_stream_commit_headers()`
+  now snapshots Vary, ETag, and Cache-Control header state before Phase 1
+  mutations and rolls back on any Phase 1 failure. Previously a Vary success
+  followed by an ETag failure left a partially mutated header set, polluting
+  the fallback/full-buffer path. Rollback restores original `hash`/`value`
+  for modified entries, invalidates newly pushed entries (`hash=0`), and
+  restores the typed `etag` pointer. No use-after-free or double-free under
+  the request-pool memory model.
+- **FFI handle consumption contract for `safe_finish`**: when
+  `markdown_streaming_safe_finish` returns `ERROR_INVALID_INPUT` (validation
+  failure), the handle is no longer consumed by Rust. The NGINX C module now
+  calls `markdown_streaming_abort()` to free the unconsumed handle, preventing
+  a resource leak. See the breaking-change note below for external FFI
+  consumers.
+- **Eligibility Content-Type OWS compliance (#149)**: Content-Type matching
+  in `ngx_http_markdown_check_content_type()`, `ngx_http_markdown_is_streaming()`,
+  and `ngx_http_markdown_stream_type_excluded()` now accepts HTAB as an
+  optional whitespace separator per RFC 7230, in addition to SP. Trailing
+  OWS stripping also handles HTAB.
+- **FFI invalid-input handle abort**: `ngx_http_markdown_stream_postcommit_finish_via_rust()`
+  aborts the Rust handle on `ERROR_INVALID_INPUT` before nulling the typed
+  pointer, matching the corrected consumption contract.
+
+### Security
+
+- **Path traversal hardening in tooling**: `validate_write_path_within_root()`
+  now rejects any path containing a `..` traversal component before resolving,
+  as defense-in-depth on top of the existing `resolve()` + `startswith` check.
+- **Taint sink guards (S8701/S8707)**: inlined denylist checks and
+  `abspath`+`startswith` validators added to performance and coverage
+  tooling path sinks.
+- **Removed threshold output path sink**: `threshold_engine.py` no longer
+  writes verdict reports to a caller-supplied file path; reports are emitted
+  to stdout, eliminating a path-escape vector.
+- **Closed perf tooling path escapes**: `run_corpus_benchmark.py` and
+  related helpers now validate read/write paths through the shared
+  `path_validation` module.
+- **CI supply-chain**: gitleaks is pinned by commit SHA in the security
+  workflow, and both header copies (`markdown_converter.h`) are checked for
+  consistency.
+
+### Changed
+
+- **Const-correctness**: removed unnecessary `(ngx_http_request_t *)` casts
+  in the auth Cache-Control streaming path;
+  `ngx_http_markdown_stream_commit_apply_auth_cache_control()` now takes a
+  non-const `ngx_http_request_t *` (annotated `NOSONAR` for the SonarCloud
+  false positive) matching `ngx_http_markdown_modify_cache_control_for_auth()`'s
+  contract.
+- Improved docstrings for eligibility and auth cache-control helpers
+  (Doxygen-style `@param`/`@return`).
+
+### Breaking Changes
+
+- **`markdown_streaming_safe_finish` FFI contract**: the handle is now
+  consumed only after validation succeeds. On `ERROR_INVALID_INPUT`, the
+  handle is **not** consumed and the caller must call
+  `markdown_streaming_abort()` (or otherwise free it). The bundled NGINX C
+  module already handles this; third-party FFI consumers that assumed the
+  handle was always consumed must update their cleanup path.
+
+### Tests
+
+- Added 5 rollback unit tests for `stream_commit` covering Vary/ETag/Cache-Control
+  failure rollback, cross-header rollback (ETag failure rolls back prior Vary
+  mutation), and typed ETag pointer restoration.
+- Added trailing OWS exclusion and abort-contract assertions to streaming
+  tests.
+- Added `hard_excluded_params_case_test.c` for eligibility hard-exclusion
+  parameter coverage.
+- Added `stream_postcommit_test.c` assertions for the corrected handle
+  consumption contract.
+- `stream_commit.c` unit coverage: 97.2% lines / 100% functions.
+
 ## [0.8.0] - 2026-06-16
 
 True streaming contract, fallback state machine, streaming observability,

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ release-gates-check-070:
 	@$(MAKE) harness-check
 	@echo "  Harness Rule Coverage Gate: ALL PASSED"
 
-# release-gates-check-080: comprehensive v0.8.0 release readiness gate.
+# release-gates-check-080: comprehensive v0.8.x release readiness gate.
 #
 # Coverage policy source: AGENTS.md Rule 25
 #   - 80% aggregate line+function coverage (programmatic gate via coverage_gate.py)
@@ -541,8 +541,10 @@ release-gates-check-070:
 #                                           when NGINX source or lcov/cargo-llvm-cov
 #                                           is unavailable
 
+RELEASE_GATE_080_ACTIVE_VERSION ?= 0.8.1
+
 release-gates-check-080:
-	@echo "=== v0.8.0 Release Gate: Starting ==="
+	@echo "=== v0.8.x Release Gate: Starting ($(RELEASE_GATE_080_ACTIVE_VERSION)) ==="
 	@echo "  [1/17] build + check-headers"
 	$(MAKE) build
 	$(MAKE) check-headers
@@ -609,15 +611,15 @@ release-gates-check-080:
 	@echo "  [13/17] validate_naming.py (artifact naming)"
 	python3 tools/release/gates/validate_naming.py
 	@echo "  [14/17] v0.8.0 gate validators (0.8-specific: compat bridge removal, new directives)"
-	python3 tools/release/gates/validate_release_gates_080.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_release_gates_080.py
 	python3 tools/release/gates/validate_config_directives_080.py
 	@echo "  [15/17] legacy/prior-version regression validators (0.7.0 gates remain active)"
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_release_gates_070.py --mode strict
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_metrics_070.py
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_reason_codes_070.py
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_package_metadata_070.py
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_k8s_manifests_070.py
-	RELEASE_GATE_EXPECTED_CARGO_VERSION=0.8.0 python3 tools/release/gates/validate_fuzz_packaging_070.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_release_gates_070.py --mode strict
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_metrics_070.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_reason_codes_070.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_package_metadata_070.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_k8s_manifests_070.py
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_fuzz_packaging_070.py
 	@echo "  [16/17] harness boundary: routing-manifest.json + risk-packs (Req 9)"
 	@test -f docs/harness/routing-manifest.json || { echo "FAIL: docs/harness/routing-manifest.json not found — release gates require repo-owned harness sources" >&2; exit 1; }
 	@test -d docs/harness/risk-packs || { echo "FAIL: docs/harness/risk-packs/ not found — release gates require repo-owned risk-pack inputs" >&2; exit 1; }
@@ -630,7 +632,7 @@ release-gates-check-080:
 	@if [ -d ".kiro/specs" ] && grep -r "\.kiro/" tools/release/ tools/harness/ 2>/dev/null | grep -v "\.kiro/steering" | grep -qv "^$$"; then \
 		echo "WARNING: potential .kiro/ reference found in gate validators (review needed)" >&2; \
 	fi
-	@echo "=== v0.8.0 Release Gate: ALL PASSED ==="
+	@echo "=== v0.8.x Release Gate: ALL PASSED ($(RELEASE_GATE_080_ACTIVE_VERSION)) ==="
 
 release-gates-check-legacy:
 	python3 tools/release/legacy/validate_release_gates.py
@@ -807,7 +809,7 @@ help:
 	@echo "  release-gates-check-055  - Validate 0.5.5 release gates (evidence, known-diffs, docs)"
 	@echo "  release-gates-check-060  - Validate 0.6.0 release gates (streaming default, pruning, budget)"
 	@echo "  release-gates-check-070  - Validate 0.7.0 release gates (runtime correctness, package compat, fuzz)"
-	@echo "  release-gates-check-080  - Validate 0.8.0 release gates (streaming, coverage, matrix, harness boundary)"
+	@echo "  release-gates-check-080  - Validate 0.8.x release gates (streaming, coverage, matrix, harness boundary)"
 	@echo "  release-gates-check-legacy - Validate 0.4.0 release gate documents"
 	@echo "  release-gates-check-strict - Validate all sub-specs #12-#18 for full compliance"
 	@echo "  release-notes            - Generate release notes from release-matrix.json"

--- a/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
@@ -1934,6 +1934,7 @@ ngx_http_markdown_body_filter_resume_pending(ngx_http_request_t *r,
 
     rc = ngx_http_next_body_filter(r, NULL);
     if (rc == NGX_AGAIN) {
+        r->buffered |= NGX_HTTP_MARKDOWN_BUFFERED;
         return NGX_AGAIN;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
@@ -1909,4 +1909,43 @@ ngx_http_markdown_send_conversion_output(ngx_http_request_t *r,
     return rc;
 }
 
+/*
+ * Resume a full-buffer response after downstream backpressure.
+ *
+ * The NGINX copy filter retains the unsent portion after returning NGX_AGAIN.
+ * Passing the original chain again would append a duplicate copy of that
+ * tail.  A NULL input asks the downstream filter chain to drain its existing
+ * buffered state.  The request-owned chain pointer remains only as a lifetime
+ * anchor and pending-state marker until the downstream chain finishes.
+ *
+ * Parameters:
+ *   r   - current request
+ *   ctx - request context with a pending full-buffer response
+ *
+ * Returns:
+ *   NGX_AGAIN while downstream remains blocked; otherwise the downstream
+ *   return code after clearing the module's pending state.
+ */
+static ngx_int_t
+ngx_http_markdown_body_filter_resume_pending(ngx_http_request_t *r,
+    ngx_http_markdown_ctx_t *ctx)
+{
+    ngx_int_t  rc;
+
+    rc = ngx_http_next_body_filter(r, NULL);
+    if (rc == NGX_AGAIN) {
+        return NGX_AGAIN;
+    }
+
+    if (rc == NGX_OK || rc == NGX_DONE) {
+        NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count);
+    }
+
+    ctx->fullbuffer.pending_output = NULL;
+    ctx->fullbuffer.pending_has_data = 0;
+    r->buffered &= ~NGX_HTTP_MARKDOWN_BUFFERED;
+
+    return rc;
+}
+
 #endif /* NGX_HTTP_MARKDOWN_CONVERSION_IMPL_H */

--- a/components/nginx-module/src/ngx_http_markdown_request_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_request_impl.h
@@ -1109,24 +1109,6 @@ ngx_http_markdown_body_filter_convert_and_output(ngx_http_request_t *r,
  * @return    NGX_OK on success, NGX_ERROR on error
  */
 static ngx_int_t
-ngx_http_markdown_body_filter_resume_pending(ngx_http_request_t *r,
-    ngx_http_markdown_ctx_t *ctx)
-{
-    ngx_int_t  rc;
-
-    rc = ngx_http_next_body_filter(r, ctx->fullbuffer.pending_output);
-    if (rc == NGX_AGAIN) {
-        return NGX_AGAIN;
-    }
-
-    ctx->fullbuffer.pending_output = NULL;
-    ctx->fullbuffer.pending_has_data = 0;
-    r->buffered &= ~NGX_HTTP_MARKDOWN_BUFFERED;
-
-    return rc;
-}
-
-static ngx_int_t
 ngx_http_markdown_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_http_markdown_ctx_t   *ctx;

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -81,6 +81,23 @@ typedef struct {
 /*  Snapshot helpers                                                   */
 /* ------------------------------------------------------------------ */
 
+static ngx_flag_t
+ngx_http_markdown_stream_commit_header_matches(
+    const ngx_table_elt_t *entry, const u_char *name, size_t name_len)
+{
+    if (entry->key.len != name_len) {
+        return 0;
+    }
+
+    for (ngx_uint_t i = 0; i < name_len; i++) {
+        if (ngx_tolower(entry->key.data[i]) != ngx_tolower(name[i])) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 /*
  * Snapshot all entries matching a header name in the headers_out list.
  * Records entry pointer, original value, and original hash for each.
@@ -93,7 +110,6 @@ ngx_http_markdown_stream_commit_snapshot_header(
 {
     ngx_list_part_t  *part;
     ngx_table_elt_t  *elts;
-    ngx_uint_t        i;
 
     snap->count = 0;
     snap->orig_nelts = 0;
@@ -102,23 +118,21 @@ ngx_http_markdown_stream_commit_snapshot_header(
 
     while (part != NULL) {
         elts = part->elts;
-        for (i = 0; i < part->nelts; i++) {
+        for (ngx_uint_t i = 0; i < part->nelts; i++) {
             snap->orig_nelts++;
 
             if (elts[i].hash == 0) {
                 continue;
             }
 
-            if (elts[i].key.len == name_len
-                && ngx_strncasecmp(elts[i].key.data,
-                                   (u_char *) name, name_len) == 0)
+            if (ngx_http_markdown_stream_commit_header_matches(
+                    &elts[i], name, name_len)
+                && snap->count < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX)
             {
-                if (snap->count < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX) {
-                    snap->entries[snap->count].entry = &elts[i];
-                    snap->entries[snap->count].orig_value = elts[i].value;
-                    snap->entries[snap->count].orig_hash = elts[i].hash;
-                    snap->count++;
-                }
+                snap->entries[snap->count].entry = &elts[i];
+                snap->entries[snap->count].orig_value = elts[i].value;
+                snap->entries[snap->count].orig_hash = elts[i].hash;
+                snap->count++;
             }
         }
         part = part->next;
@@ -136,10 +150,12 @@ ngx_http_markdown_stream_commit_rollback_header(
     const u_char *name, size_t name_len,
     ngx_http_markdown_hdr_snap_t *snap)
 {
-    ngx_uint_t  i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *elts;
+    ngx_uint_t        idx;
 
     /* Restore snapshotted entries */
-    for (i = 0; i < snap->count; i++) {
+    for (ngx_uint_t i = 0; i < snap->count; i++) {
         if (snap->entries[i].entry != NULL) {
             snap->entries[i].entry->value = snap->entries[i].orig_value;
             snap->entries[i].entry->hash = snap->entries[i].orig_hash;
@@ -147,29 +163,22 @@ ngx_http_markdown_stream_commit_rollback_header(
     }
 
     /* Invalidate newly-pushed entries (hash=0 per Rule 40) */
-    if (snap->orig_nelts > 0 || 1) {
-        ngx_list_part_t  *part;
-        ngx_table_elt_t  *elts;
-        ngx_uint_t        idx;
+    part = &r->headers_out.headers.part;
+    idx = 0;
 
-        part = &r->headers_out.headers.part;
-        idx = 0;
-
-        while (part != NULL) {
-            elts = part->elts;
-            for (i = 0; i < part->nelts; i++) {
-                if (idx >= snap->orig_nelts
-                    && elts[i].hash != 0
-                    && elts[i].key.len == name_len
-                    && ngx_strncasecmp(elts[i].key.data,
-                                       (u_char *) name, name_len) == 0)
-                {
-                    elts[i].hash = 0;
-                }
-                idx++;
+    while (part != NULL) {
+        elts = part->elts;
+        for (ngx_uint_t i = 0; i < part->nelts; i++) {
+            if (idx >= snap->orig_nelts
+                && elts[i].hash != 0
+                && ngx_http_markdown_stream_commit_header_matches(
+                    &elts[i], name, name_len))
+            {
+                elts[i].hash = 0;
             }
-            part = part->next;
+            idx++;
         }
+        part = part->next;
     }
 }
 

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -33,7 +33,190 @@
 #include "ngx_http_markdown_stream_commit.h"
 
 
-/* Function prototypes */
+/* ------------------------------------------------------------------ */
+/*  Snapshot / rollback structures for Rule 39 transactional atomicity */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Maximum number of header entries tracked per single header name
+ * (Vary, ETag, Cache-Control).  In practice each is 0 or 1 entry;
+ * the bound covers pathological multi-value headers.
+ */
+#define NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX  4
+
+/*
+ * Per-header snapshot: records the original state of a header entry
+ * that Phase 1 may mutate, so it can be restored on rollback.
+ */
+typedef struct {
+    ngx_table_elt_t  *entry;       /* pointer to the header in headers_out */
+    ngx_str_t         orig_value;  /* original value.data / value.len      */
+    ngx_uint_t        orig_hash;   /* original hash (0 = absent/invalid)   */
+} ngx_http_markdown_hdr_snap_entry_t;
+
+/*
+ * Snapshot for one named header (e.g. Vary).  Also records the
+ * headers list nelts before Phase 1 so newly-pushed entries can be
+ * invalidated on rollback.
+ */
+typedef struct {
+    ngx_http_markdown_hdr_snap_entry_t  entries[NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX];
+    ngx_uint_t                          count;       /* entries snapshotted */
+    ngx_uint_t                          orig_nelts;  /* list nelts before Phase 1 */
+} ngx_http_markdown_hdr_snap_t;
+
+/*
+ * Full Phase 1 snapshot: Vary, ETag, Cache-Control plus the typed
+ * ETag pointer from headers_out.
+ */
+typedef struct {
+    ngx_http_markdown_hdr_snap_t  vary;
+    ngx_http_markdown_hdr_snap_t  etag;
+    ngx_http_markdown_hdr_snap_t  cache_control;
+    ngx_table_elt_t              *orig_etag_ptr;  /* r->headers_out.etag */
+} ngx_http_markdown_commit_snap_t;
+
+
+/* ------------------------------------------------------------------ */
+/*  Snapshot helpers                                                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Snapshot all entries matching a header name in the headers_out list.
+ * Records entry pointer, original value, and original hash for each.
+ */
+static void
+ngx_http_markdown_stream_commit_snapshot_header(
+    ngx_http_request_t *r,
+    const u_char *name, size_t name_len,
+    ngx_http_markdown_hdr_snap_t *snap)
+{
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *elts;
+    ngx_uint_t        i;
+
+    snap->count = 0;
+    snap->orig_nelts = 0;
+
+    part = &r->headers_out.headers.part;
+
+    while (part != NULL) {
+        elts = part->elts;
+        for (i = 0; i < part->nelts; i++) {
+            snap->orig_nelts++;
+
+            if (elts[i].hash == 0) {
+                continue;
+            }
+
+            if (elts[i].key.len == name_len
+                && ngx_strncasecmp(elts[i].key.data,
+                                   (u_char *) name, name_len) == 0)
+            {
+                if (snap->count < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX) {
+                    snap->entries[snap->count].entry = &elts[i];
+                    snap->entries[snap->count].orig_value = elts[i].value;
+                    snap->entries[snap->count].orig_hash = elts[i].hash;
+                    snap->count++;
+                }
+            }
+        }
+        part = part->next;
+    }
+}
+
+/*
+ * Roll back a single header: restore original value/hash on snapshotted
+ * entries, then invalidate any entries that were pushed after the snapshot
+ * (i.e. entries with index >= orig_nelts that match the header name).
+ */
+static void
+ngx_http_markdown_stream_commit_rollback_header(
+    ngx_http_request_t *r,
+    const u_char *name, size_t name_len,
+    ngx_http_markdown_hdr_snap_t *snap)
+{
+    ngx_uint_t  i;
+
+    /* Restore snapshotted entries */
+    for (i = 0; i < snap->count; i++) {
+        if (snap->entries[i].entry != NULL) {
+            snap->entries[i].entry->value = snap->entries[i].orig_value;
+            snap->entries[i].entry->hash = snap->entries[i].orig_hash;
+        }
+    }
+
+    /* Invalidate newly-pushed entries (hash=0 per Rule 40) */
+    if (snap->orig_nelts > 0 || 1) {
+        ngx_list_part_t  *part;
+        ngx_table_elt_t  *elts;
+        ngx_uint_t        idx;
+
+        part = &r->headers_out.headers.part;
+        idx = 0;
+
+        while (part != NULL) {
+            elts = part->elts;
+            for (i = 0; i < part->nelts; i++) {
+                if (idx >= snap->orig_nelts
+                    && elts[i].hash != 0
+                    && elts[i].key.len == name_len
+                    && ngx_strncasecmp(elts[i].key.data,
+                                       (u_char *) name, name_len) == 0)
+                {
+                    elts[i].hash = 0;
+                }
+                idx++;
+            }
+            part = part->next;
+        }
+    }
+}
+
+/*
+ * Take a full Phase 1 snapshot: Vary, ETag, Cache-Control,
+ * and the typed ETag pointer.
+ */
+static void
+ngx_http_markdown_stream_commit_take_snapshot(
+    ngx_http_request_t *r, ngx_http_markdown_commit_snap_t *snap)
+{
+    ngx_http_markdown_stream_commit_snapshot_header(
+        r, (const u_char *) "Vary", 4, &snap->vary);
+
+    ngx_http_markdown_stream_commit_snapshot_header(
+        r, (const u_char *) "ETag", 4, &snap->etag);
+
+    ngx_http_markdown_stream_commit_snapshot_header(
+        r, (const u_char *) "Cache-Control", 13, &snap->cache_control);
+
+    snap->orig_etag_ptr = r->headers_out.etag;
+}
+
+/*
+ * Roll back all Phase 1 mutations using the snapshot.
+ */
+static void
+ngx_http_markdown_stream_commit_rollback(
+    ngx_http_request_t *r, ngx_http_markdown_commit_snap_t *snap)
+{
+    ngx_http_markdown_stream_commit_rollback_header(
+        r, (const u_char *) "Vary", 4, &snap->vary);
+
+    ngx_http_markdown_stream_commit_rollback_header(
+        r, (const u_char *) "ETag", 4, &snap->etag);
+
+    ngx_http_markdown_stream_commit_rollback_header(
+        r, (const u_char *) "Cache-Control", 13, &snap->cache_control);
+
+    /* Restore typed ETag pointer */
+    r->headers_out.etag = snap->orig_etag_ptr;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  Function prototypes                                                */
+/* ------------------------------------------------------------------ */
 
 static ngx_int_t
 ngx_http_markdown_stream_commit_remove_content_length(
@@ -82,7 +265,8 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
                                          ngx_http_markdown_ctx_t *ctx,
                                          const ngx_http_markdown_conf_t *conf)
 {
-    ngx_int_t  rc;
+    ngx_int_t                        rc;
+    ngx_http_markdown_commit_snap_t  snap;
 
     if (r == NULL || ctx == NULL) {
         return NGX_ERROR;
@@ -109,32 +293,19 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
     /*
      * --- Phase 1: Fallible header operations ---
      *
-     * These operations may fail (e.g. allocation failure in Vary).
-     * Order: Vary -> ETag -> auth Cache-Control.
-     * If any fails, headers have not been sent downstream.
-     *
-     * Note: Vary and ETag removal are ordered before Content-Type
-     * and Content-Length because they can fail.  Content-Type
-     * assignment and Content-Length removal are infallible and
-     * belong to Phase 2.
-     *
-     * Atomicity guarantee: if Vary succeeds but ETag fails, the
-     * Vary header HAS been added to the headers_out list.  However,
-     * the request is still in pre-commit state and headers have NOT
-     * been sent to the network.  The pre-commit failure path aborts
-     * to full-buffer processing without committing Markdown headers,
-     * so the extra Vary: Accept is harmless — it does not change
-     * content negotiation semantics for an HTML response.
-     * Similarly, a removed ETag in the headers list is not visible
-     * because the full-buffer path restores upstream headers before
-     * sending.
+     * Snapshot the original header state before any mutation.
+     * If any step fails, roll back all prior mutations so
+     * headers_out is restored to its pre-commit state.
      */
+
+    ngx_http_markdown_stream_commit_take_snapshot(r, &snap);
 
     rc = ngx_http_markdown_stream_commit_set_vary(r);
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "markdown stream commit: "
                       "failed to set Vary header");
+        ngx_http_markdown_stream_commit_rollback(r, &snap);
         return NGX_ERROR;
     }
 
@@ -143,6 +314,7 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "markdown stream commit: "
                       "failed to remove ETag");
+        ngx_http_markdown_stream_commit_rollback(r, &snap);
         return NGX_ERROR;
     }
 
@@ -152,6 +324,7 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "markdown stream commit: "
                       "failed to apply auth Cache-Control");
+        ngx_http_markdown_stream_commit_rollback(r, &snap);
         return NGX_ERROR;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -5,16 +5,23 @@
  * This is the single authoritative path for all streaming header
  * mutations.  No other code path may mutate streaming response headers.
  *
- * Two-phase design (Rule 39):
+ * Two-phase design with transactional rollback (Rule 39):
  *   Phase 1 (fallible): Vary: Accept, ETag removal, auth Cache-Control.
- *     If any step fails, NGX_ERROR is returned before headers are sent
- *     downstream.  Earlier Phase 1 mutations may be present in
- *     headers_out but are invisible because the pre-commit failure
- *     path aborts to full-buffer processing without committing
- *     Markdown headers.
+ *     Before Phase 1 begins, the original state of every header that
+ *     Phase 1 may touch is snapshotted.  If any Phase 1 step fails,
+ *     the snapshot is used to roll back all prior Phase 1 mutations
+ *     so headers_out is restored to its pre-commit state.  This
+ *     guarantees that the caller's fallback / fail-open path sees
+ *     the original upstream headers, not a partially-mutated set.
  *   Phase 2 (infallible): Content-Type, Content-Length, Content-Encoding.
  *     These are pointer/integer writes that cannot fail.
  *   Only after both phases complete are headers_committed and state set.
+ *
+ * Rollback scope (Rule 39 transactional guarantee):
+ *   The snapshot/rollback covers Vary, ETag, and Cache-Control.
+ *   Modified entries have value/hash restored; newly-pushed entries
+ *   are invalidated via hash=0 (Rule 40); typed ETag pointer restored.
+ *   No use-after-free/double-free/dangling pointer under pool model.
  *
  * Header commit safety invariant:
  *   Header decisions MUST be completed before outgoing headers are

--- a/components/nginx-module/src/ngx_http_markdown_stream_commit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_commit.c
@@ -39,8 +39,8 @@
 
 /*
  * Maximum number of header entries tracked per single header name
- * (Vary, ETag, Cache-Control).  In practice each is 0 or 1 entry;
- * the bound covers pathological multi-value headers.
+ * (Vary, ETag, Cache-Control).  Snapshot fails before Phase 1 mutation
+ * when a header has more matching entries, preserving Rule 39 atomicity.
  */
 #define NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX  4
 
@@ -98,11 +98,28 @@ ngx_http_markdown_stream_commit_header_matches(
     return 1;
 }
 
+static ngx_int_t
+ngx_http_markdown_stream_commit_snapshot_entry(
+    ngx_http_markdown_hdr_snap_t *snap, ngx_table_elt_t *entry)
+{
+    if (snap->count >= NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX) {
+        return NGX_ERROR;
+    }
+
+    snap->entries[snap->count].entry = entry;
+    snap->entries[snap->count].orig_value = entry->value;
+    snap->entries[snap->count].orig_hash = entry->hash;
+    snap->count++;
+
+    return NGX_OK;
+}
+
 /*
  * Snapshot all entries matching a header name in the headers_out list.
- * Records entry pointer, original value, and original hash for each.
+ * Records entry pointer, original value, and original hash for each.  Returns
+ * NGX_ERROR before mutation if the fixed snapshot capacity is exceeded.
  */
-static void
+static ngx_int_t
 ngx_http_markdown_stream_commit_snapshot_header(
     ngx_http_request_t *r,
     const u_char *name, size_t name_len,
@@ -125,24 +142,30 @@ ngx_http_markdown_stream_commit_snapshot_header(
                 continue;
             }
 
-            if (ngx_http_markdown_stream_commit_header_matches(
-                    &elts[i], name, name_len)
-                && snap->count < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX)
+            if (!ngx_http_markdown_stream_commit_header_matches(
+                    &elts[i], name, name_len))
             {
-                snap->entries[snap->count].entry = &elts[i];
-                snap->entries[snap->count].orig_value = elts[i].value;
-                snap->entries[snap->count].orig_hash = elts[i].hash;
-                snap->count++;
+                continue;
+            }
+
+            if (ngx_http_markdown_stream_commit_snapshot_entry(
+                    snap, &elts[i]) != NGX_OK)
+            {
+                return NGX_ERROR;
             }
         }
         part = part->next;
     }
+
+    return NGX_OK;
 }
 
 /*
  * Roll back a single header: restore original value/hash on snapshotted
  * entries, then invalidate any entries that were pushed after the snapshot
  * (i.e. entries with index >= orig_nelts that match the header name).
+ * orig_nelts is the total linear entry count across all list parts; rollback
+ * uses the same linear traversal index.
  */
 static void
 ngx_http_markdown_stream_commit_rollback_header(
@@ -186,20 +209,32 @@ ngx_http_markdown_stream_commit_rollback_header(
  * Take a full Phase 1 snapshot: Vary, ETag, Cache-Control,
  * and the typed ETag pointer.
  */
-static void
+static ngx_int_t
 ngx_http_markdown_stream_commit_take_snapshot(
     ngx_http_request_t *r, ngx_http_markdown_commit_snap_t *snap)
 {
-    ngx_http_markdown_stream_commit_snapshot_header(
-        r, (const u_char *) "Vary", 4, &snap->vary);
+    if (ngx_http_markdown_stream_commit_snapshot_header(
+            r, (const u_char *) "Vary", 4, &snap->vary) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
 
-    ngx_http_markdown_stream_commit_snapshot_header(
-        r, (const u_char *) "ETag", 4, &snap->etag);
+    if (ngx_http_markdown_stream_commit_snapshot_header(
+            r, (const u_char *) "ETag", 4, &snap->etag) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
 
-    ngx_http_markdown_stream_commit_snapshot_header(
-        r, (const u_char *) "Cache-Control", 13, &snap->cache_control);
+    if (ngx_http_markdown_stream_commit_snapshot_header(
+            r, (const u_char *) "Cache-Control", 13,
+            &snap->cache_control) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
 
     snap->orig_etag_ptr = r->headers_out.etag;
+
+    return NGX_OK;
 }
 
 /*
@@ -307,7 +342,13 @@ ngx_http_markdown_stream_commit_headers(ngx_http_request_t *r,
      * headers_out is restored to its pre-commit state.
      */
 
-    ngx_http_markdown_stream_commit_take_snapshot(r, &snap);
+    rc = ngx_http_markdown_stream_commit_take_snapshot(r, &snap);
+    if (rc != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "markdown stream commit: "
+                      "snapshot capacity exceeded before header mutation");
+        return NGX_ERROR;
+    }
 
     rc = ngx_http_markdown_stream_commit_set_vary(r);
     if (rc != NGX_OK) {

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -1859,6 +1859,7 @@ test_fullbuffer_resume_pending_lifecycle(void)
     TEST_ASSERT(rc == NGX_AGAIN,
                 "initial send should establish pending state");
 
+    r.buffered &= ~NGX_HTTP_MARKDOWN_BUFFERED;
     rc = ngx_http_markdown_body_filter_resume_pending(&r, &ctx);
     TEST_ASSERT(rc == NGX_AGAIN,
                 "persistent downstream backpressure should remain pending");
@@ -1869,7 +1870,7 @@ test_fullbuffer_resume_pending_lifecycle(void)
     TEST_ASSERT(ctx.fullbuffer.pending_has_data == 1,
                 "persistent backpressure should retain the pending latch");
     TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
-                "persistent backpressure should retain the buffered flag");
+                "persistent backpressure should reassert the buffered flag");
 
     g_next_body_filter_rc = NGX_ERROR;
     g_metric_inc_sink = 0;

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -83,6 +83,8 @@ static ngx_int_t g_update_headers_rc = 0;
 static ngx_int_t g_failopen_rc = 0;
 static ngx_uint_t g_failopen_call_count = 0;
 static ngx_int_t g_next_body_filter_rc = 0;
+static ngx_chain_t *g_next_body_filter_last_input = NULL;
+static ngx_uint_t g_next_body_filter_call_count = 0;
 static ngx_uint_t g_markdown_result_free_calls = 0;
 static ngx_uint_t g_pnalloc_fail_once = 0;
 static ngx_uint_t g_pcalloc_fail_once = 0;
@@ -763,7 +765,8 @@ static ngx_int_t
 test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     UNUSED(r);
-    UNUSED(in);
+    g_next_body_filter_last_input = in;
+    g_next_body_filter_call_count++;
     return g_next_body_filter_rc;
 }
 
@@ -785,6 +788,8 @@ reset_stub_state(void)
     g_failopen_rc = NGX_OK;
     g_failopen_call_count = 0;
     g_next_body_filter_rc = NGX_OK;
+    g_next_body_filter_last_input = NULL;
+    g_next_body_filter_call_count = 0;
     g_markdown_result_free_calls = 0;
     g_pnalloc_fail_once = 0;
     g_pcalloc_fail_once = 0;
@@ -1762,6 +1767,130 @@ test_send_conversion_output_paths(void)
 }
 
 /*
+ * Regression: the NGINX copy filter owns its unsent chain after returning
+ * NGX_AGAIN.  Resume must call the downstream filter with NULL so it drains
+ * that retained state instead of receiving the original chain a second time.
+ */
+static void
+test_fullbuffer_resume_does_not_resubmit_pending_chain(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+    ngx_chain_t              *original_chain;
+    ngx_int_t                 rc;
+    u_char                    out[] = "markdown";
+
+    TEST_SUBSECTION("full-buffer resume drains downstream-owned state");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    original_chain = ctx.fullbuffer.pending_output;
+
+    TEST_ASSERT(rc == NGX_AGAIN,
+                "initial full-buffer send should preserve NGX_AGAIN");
+    TEST_ASSERT(original_chain != NULL,
+                "initial full-buffer send should retain request state");
+    TEST_ASSERT(g_next_body_filter_last_input == original_chain,
+                "initial send should submit the converted body chain");
+    TEST_ASSERT(ctx.fullbuffer.pending_has_data == 1,
+                "initial NGX_AGAIN should set the pending latch");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
+                "initial NGX_AGAIN should set the module buffered flag");
+
+    g_next_body_filter_rc = NGX_OK;
+    g_metric_inc_sink = 0;
+    rc = ngx_http_markdown_body_filter_resume_pending(&r, &ctx);
+
+    TEST_ASSERT(rc == NGX_OK,
+                "full-buffer resume should return downstream success");
+    TEST_ASSERT(g_next_body_filter_call_count == 2,
+                "resume should make exactly one additional downstream call");
+    TEST_ASSERT(g_next_body_filter_last_input == NULL,
+                "resume must flush downstream state without resubmitting chain");
+    TEST_ASSERT(ctx.fullbuffer.pending_output == NULL,
+                "successful resume should clear the retained chain anchor");
+    TEST_ASSERT(ctx.fullbuffer.pending_has_data == 0,
+                "successful resume should clear the pending latch");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) == 0,
+                "successful resume should clear the module buffered flag");
+    TEST_ASSERT(g_metric_inc_sink == 1,
+                "successful resume should record full-buffer delivery");
+
+    TEST_PASS("Full-buffer resume does not duplicate downstream pending data");
+}
+
+/* Verify persistent backpressure keeps state and terminal failure clears it. */
+static void
+test_fullbuffer_resume_pending_lifecycle(void)
+{
+    ngx_http_request_t        r;
+    ngx_http_markdown_ctx_t   ctx;
+    ngx_http_markdown_conf_t  conf;
+    struct MarkdownResult     result;
+    ngx_chain_t              *original_chain;
+    ngx_int_t                 rc;
+    u_char                    out[] = "markdown";
+
+    TEST_SUBSECTION("full-buffer resume pending lifecycle");
+
+    reset_stub_state();
+    init_request(&r);
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown = out;
+    result.markdown_len = sizeof(out) - 1;
+
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_send_conversion_output(
+        &r, &ctx, &conf, &result, 1);
+    original_chain = ctx.fullbuffer.pending_output;
+    TEST_ASSERT(rc == NGX_AGAIN,
+                "initial send should establish pending state");
+
+    rc = ngx_http_markdown_body_filter_resume_pending(&r, &ctx);
+    TEST_ASSERT(rc == NGX_AGAIN,
+                "persistent downstream backpressure should remain pending");
+    TEST_ASSERT(g_next_body_filter_last_input == NULL,
+                "persistent resume should drain with NULL input");
+    TEST_ASSERT(ctx.fullbuffer.pending_output == original_chain,
+                "persistent backpressure should retain the chain anchor");
+    TEST_ASSERT(ctx.fullbuffer.pending_has_data == 1,
+                "persistent backpressure should retain the pending latch");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
+                "persistent backpressure should retain the buffered flag");
+
+    g_next_body_filter_rc = NGX_ERROR;
+    g_metric_inc_sink = 0;
+    rc = ngx_http_markdown_body_filter_resume_pending(&r, &ctx);
+    TEST_ASSERT(rc == NGX_ERROR,
+                "terminal downstream failure should propagate");
+    TEST_ASSERT(g_next_body_filter_last_input == NULL,
+                "failure resume should still use NULL input");
+    TEST_ASSERT(ctx.fullbuffer.pending_output == NULL,
+                "terminal failure should clear the chain anchor");
+    TEST_ASSERT(ctx.fullbuffer.pending_has_data == 0,
+                "terminal failure should clear the pending latch");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) == 0,
+                "terminal failure should clear the buffered flag");
+    TEST_ASSERT(g_metric_inc_sink == 0,
+                "terminal failure should not record delivery");
+
+    TEST_PASS("Full-buffer resume pending lifecycle is symmetric");
+}
+
+/*
  * Verify miscellaneous conversion helper branches:
  * record_conversion_latency, record_system_failure, and
  * record_token_savings_if_enabled with various token_estimate
@@ -1837,6 +1966,8 @@ main(void)
     test_handle_conversion_failure_paths();
     test_converter_not_initialized_path();
     test_send_conversion_output_paths();
+    test_fullbuffer_resume_does_not_resubmit_pending_chain();
+    test_fullbuffer_resume_pending_lifecycle();
     test_misc_conversion_helpers();
 
     printf("\n========================================\n");

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -77,6 +77,21 @@ typedef struct {
     ngx_log_t *log;
 } ngx_connection_impl_t;
 
+typedef struct ngx_list_part_s ngx_list_part_t;
+
+struct ngx_list_part_s {
+    void            *elts;
+    ngx_uint_t       nelts;
+    ngx_list_part_t *next;
+};
+
+typedef struct {
+    ngx_list_part_t  part;
+    size_t           size;
+    ngx_uint_t       nalloc;
+    void            *pool;
+} ngx_list_t;
+
 typedef struct ngx_table_elt_s {
     ngx_uint_t    hash;
     ngx_str_t     key;
@@ -91,6 +106,8 @@ typedef struct {
     ngx_uint_t         status;
     off_t              content_length_n;
     ngx_table_elt_t   *content_length;
+    ngx_table_elt_t   *etag;
+    ngx_list_t         headers;
 } ngx_http_headers_out_t;
 
 struct ngx_http_request_s {
@@ -182,9 +199,34 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log,
     UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);
 }
 
+/* Stub: ngx_list_push */
+ngx_table_elt_t *
+ngx_list_push(ngx_list_t *list)
+{
+    ngx_table_elt_t *elts;
+    if (list->part.elts == NULL) {
+        return NULL;
+    }
+    if (list->part.nelts >= list->nalloc) {
+        return NULL;
+    }
+    elts = (ngx_table_elt_t *) list->part.elts;
+    return &elts[list->part.nelts++];
+}
+
+/* Stub: ngx_pnalloc */
+void *
+ngx_pnalloc(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    return malloc(size);
+}
+
 /* Include the commit source after mocks */
 #include "../../src/ngx_http_markdown_stream_commit.c"
 
+
+static ngx_table_elt_t test_headers_storage[32];
 
 static void test_setup(void)
 {
@@ -193,6 +235,7 @@ static void test_setup(void)
     memset(&test_connection, 0, sizeof(test_connection));
     memset(&test_request, 0, sizeof(test_request));
     memset(&test_content_length_elt, 0, sizeof(test_content_length_elt));
+    memset(test_headers_storage, 0, sizeof(test_headers_storage));
 
     test_pool.log = &test_log;
     test_connection.log = &test_log;
@@ -202,6 +245,15 @@ static void test_setup(void)
     test_request.headers_out.content_length_n = 12345;
     test_content_length_elt.hash = 1;
     test_request.headers_out.content_length = &test_content_length_elt;
+
+    /* Initialize headers list with capacity 32 */
+    test_request.headers_out.headers.part.elts = test_headers_storage;
+    test_request.headers_out.headers.part.nelts = 0;
+    test_request.headers_out.headers.part.next = NULL;
+    test_request.headers_out.headers.size = sizeof(ngx_table_elt_t);
+    test_request.headers_out.headers.nalloc = 32;
+    test_request.headers_out.headers.pool = NULL;
+    test_request.headers_out.etag = NULL;
 
     test_vary_accept_called = 0;
     test_vary_accept_rc = NGX_OK;
@@ -617,6 +669,233 @@ static void test_commit_auth_cache_control_success(void)
 }
 
 
+/* Helper: push a header into the test request headers list */
+static ngx_table_elt_t *
+test_push_header(const char *key, const char *value)
+{
+    ngx_table_elt_t *h = ngx_list_push(&test_request.headers_out.headers);
+    TEST_ASSERT(h != NULL, "header list push failed");
+    h->hash = 1;
+    h->key.data = (u_char *) key;
+    h->key.len = strlen(key);
+    h->value.data = (u_char *) value;
+    h->value.len = strlen(value);
+    return h;
+}
+
+/* Helper: find a header in the test request headers list */
+static ngx_table_elt_t *
+test_find_header(const char *key)
+{
+    ngx_table_elt_t *elts = (ngx_table_elt_t *) test_request.headers_out.headers.part.elts;
+    size_t key_len = strlen(key);
+    for (ngx_uint_t i = 0; i < test_request.headers_out.headers.part.nelts; i++) {
+        if (elts[i].hash != 0 &&
+            elts[i].key.len == key_len &&
+            ngx_strncasecmp(elts[i].key.data, (const u_char *) key, key_len) == 0) {
+            return &elts[i];
+        }
+    }
+    return NULL;
+}
+
+/* --- Rollback: Vary failure restores pre-existing Vary header --- */
+
+static void test_rollback_vary_failure_restores_vary(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *orig_vary;
+    ngx_table_elt_t *found_vary;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    /* Pre-existing Vary: Cookie header */
+    orig_vary = test_push_header("Vary", "Cookie");
+    TEST_ASSERT(orig_vary != NULL, "pre-existing Vary pushed");
+
+    /* Make vary accept fail */
+    test_vary_accept_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit fails on vary error");
+    TEST_ASSERT(ctx.stream_sm.headers_committed == 0,
+                "headers_committed stays 0");
+
+    /* The original Vary header must still be present and unmodified */
+    found_vary = test_find_header("Vary");
+    TEST_ASSERT(found_vary != NULL, "Vary header still present after rollback");
+    TEST_ASSERT(found_vary == orig_vary,
+                "Vary header pointer unchanged after rollback");
+    TEST_ASSERT(found_vary->hash == 1,
+                "Vary header hash restored to 1");
+    TEST_ASSERT(found_vary->value.len == 6,
+                "Vary header value length restored");
+    TEST_ASSERT(memcmp(found_vary->value.data, "Cookie", 6) == 0,
+                "Vary header value restored to Cookie");
+
+    TEST_PASS("Rollback: Vary failure restores pre-existing Vary header");
+}
+
+/* --- Rollback: ETag failure restores pre-existing ETag header --- */
+
+static void test_rollback_etag_failure_restores_etag(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *orig_etag;
+    ngx_table_elt_t *found_etag;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    /* Pre-existing ETag header */
+    orig_etag = test_push_header("ETag", "\"abc123\"");
+    test_request.headers_out.etag = orig_etag;
+
+    /* Make etag removal fail */
+    test_set_etag_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit fails on etag error");
+    TEST_ASSERT(ctx.stream_sm.headers_committed == 0,
+                "headers_committed stays 0");
+
+    /* The original ETag header must still be present and unmodified */
+    found_etag = test_find_header("ETag");
+    TEST_ASSERT(found_etag != NULL, "ETag header still present after rollback");
+    TEST_ASSERT(found_etag == orig_etag,
+                "ETag header pointer unchanged after rollback");
+    TEST_ASSERT(found_etag->hash == 1,
+                "ETag header hash restored to 1");
+    TEST_ASSERT(test_request.headers_out.etag == orig_etag,
+                "typed ETag pointer restored");
+
+    TEST_PASS("Rollback: ETag failure restores pre-existing ETag header");
+}
+
+/* --- Rollback: Cache-Control failure restores pre-existing CC header --- */
+
+static void test_rollback_cc_failure_restores_cc(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
+    ngx_table_elt_t *orig_cc;
+    ngx_table_elt_t *found_cc;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    /* Pre-existing Cache-Control: public header */
+    orig_cc = test_push_header("Cache-Control", "public");
+
+    test_is_authenticated = 1;
+    test_auth_cache_control_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(
+        &test_request, &ctx, &conf);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit fails on auth CC error");
+    TEST_ASSERT(ctx.stream_sm.headers_committed == 0,
+                "headers_committed stays 0");
+
+    /* The original Cache-Control header must still be present and unmodified */
+    found_cc = test_find_header("Cache-Control");
+    TEST_ASSERT(found_cc != NULL, "CC header still present after rollback");
+    TEST_ASSERT(found_cc == orig_cc,
+                "CC header pointer unchanged after rollback");
+    TEST_ASSERT(found_cc->hash == 1,
+                "CC header hash restored to 1");
+    TEST_ASSERT(found_cc->value.len == 6,
+                "CC header value length restored");
+    TEST_ASSERT(memcmp(found_cc->value.data, "public", 6) == 0,
+                "CC header value restored to public");
+
+    TEST_PASS("Rollback: CC failure restores pre-existing Cache-Control header");
+}
+
+/* --- Rollback: ETag failure also rolls back Vary mutation --- */
+
+static void test_rollback_etag_failure_rolls_back_vary(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *orig_vary;
+    ngx_table_elt_t *found_vary;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    /* Pre-existing Vary: Cookie header */
+    orig_vary = test_push_header("Vary", "Cookie");
+
+    /* Vary succeeds, but ETag fails */
+    test_vary_accept_rc = NGX_OK;
+    test_set_etag_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit fails on etag error");
+    TEST_ASSERT(test_vary_accept_called == 1, "Vary was called");
+    TEST_ASSERT(test_set_etag_called == 1, "ETag was called");
+
+    /* The original Vary header must be restored despite Vary mutation succeeding */
+    found_vary = test_find_header("Vary");
+    TEST_ASSERT(found_vary != NULL, "Vary header still present after rollback");
+    TEST_ASSERT(found_vary == orig_vary,
+                "Vary header pointer unchanged after rollback");
+    TEST_ASSERT(found_vary->hash == 1,
+                "Vary header hash restored to 1");
+    TEST_ASSERT(found_vary->value.len == 6,
+                "Vary header value length restored");
+    TEST_ASSERT(memcmp(found_vary->value.data, "Cookie", 6) == 0,
+                "Vary header value restored to Cookie");
+
+    TEST_PASS("Rollback: ETag failure rolls back prior Vary mutation");
+}
+
+/* --- Rollback: typed ETag pointer restored after Vary failure --- */
+
+static void test_rollback_restores_typed_etag_pointer(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *orig_etag;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    /* Pre-existing typed ETag pointer */
+    orig_etag = test_push_header("ETag", "\"v1\"");
+    test_request.headers_out.etag = orig_etag;
+
+    /* Make vary fail (Phase 1 step 1) */
+    test_vary_accept_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit fails on vary error");
+    TEST_ASSERT(test_request.headers_out.etag == orig_etag,
+                "typed ETag pointer restored after rollback");
+
+    TEST_PASS("Rollback: typed ETag pointer restored after Vary failure");
+}
+
 int main(void)
 {
     TEST_SECTION("Stream Header Commit (streaming fallback state machine, header commit)");
@@ -636,6 +915,11 @@ int main(void)
     test_commit_vary_failure_no_content_type_leak();
     test_commit_auth_cache_control_failure_aborts();
     test_commit_auth_cache_control_success();
+    test_rollback_vary_failure_restores_vary();
+    test_rollback_etag_failure_restores_etag();
+    test_rollback_cc_failure_restores_cc();
+    test_rollback_etag_failure_rolls_back_vary();
+    test_rollback_restores_typed_etag_pointer();
 
     printf("\n  All stream commit tests passed\n\n");
     return 0;

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -1041,6 +1041,94 @@ static void test_rollback_restores_typed_etag_pointer(void)
     TEST_PASS("Rollback: typed ETag pointer restored after Vary failure");
 }
 
+/* --- Snapshot overflow fails before any Phase 1 mutation --- */
+
+static void
+test_snapshot_overflow_for_header(const char *name, const char *value)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *headers[NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX + 1];
+    ngx_table_elt_t *original_etag;
+    ngx_str_t values[NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX + 1];
+    ngx_str_t original_content_type;
+    ngx_uint_t hashes[NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX + 1];
+    ngx_uint_t original_nelts;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    test_request.headers_out.content_type.data = (u_char *) "text/html";
+    test_request.headers_out.content_type.len = sizeof("text/html") - 1;
+    original_content_type = test_request.headers_out.content_type;
+
+    for (ngx_uint_t i = 0;
+         i < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX + 1;
+         i++)
+    {
+        headers[i] = test_push_header(name, value);
+        values[i] = headers[i]->value;
+        hashes[i] = headers[i]->hash;
+    }
+
+    if (strcmp(name, "ETag") == 0) {
+        test_request.headers_out.etag = headers[0];
+    }
+    original_etag = test_request.headers_out.etag;
+    original_nelts = test_request.headers_out.headers.part.nelts;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR,
+                "snapshot overflow returns NGX_ERROR");
+    TEST_ASSERT(test_vary_accept_called == 0,
+                "Vary mutation not called after snapshot overflow");
+    TEST_ASSERT(test_set_etag_called == 0,
+                "ETag mutation not called after snapshot overflow");
+    TEST_ASSERT(test_auth_cache_control_called == 0,
+                "Cache-Control mutation not called after snapshot overflow");
+    TEST_ASSERT(ctx.stream_sm.headers_committed == 0,
+                "headers_committed remains clear after snapshot overflow");
+    TEST_ASSERT(ctx.stream_sm.state == NGX_HTTP_MD_STATE_PRE_COMMIT,
+                "state remains PRE_COMMIT after snapshot overflow");
+    TEST_ASSERT(test_request.headers_out.content_type.data
+                == original_content_type.data,
+                "Content-Type pointer remains unchanged");
+    TEST_ASSERT(test_request.headers_out.content_type.len
+                == original_content_type.len,
+                "Content-Type length remains unchanged");
+    TEST_ASSERT(test_request.headers_out.content_length_n == 12345,
+                "Content-Length remains unchanged after snapshot overflow");
+    TEST_ASSERT(test_request.headers_out.content_length
+                == &test_content_length_elt,
+                "Content-Length pointer remains unchanged");
+    TEST_ASSERT(test_request.headers_out.headers.part.nelts == original_nelts,
+                "snapshot overflow does not push a new header");
+    TEST_ASSERT(test_request.headers_out.etag == original_etag,
+                "typed ETag pointer remains unchanged");
+
+    for (ngx_uint_t i = 0;
+         i < NGX_HTTP_MARKDOWN_COMMIT_SNAPSHOT_MAX + 1;
+         i++)
+    {
+        TEST_ASSERT(headers[i]->hash == hashes[i],
+                    "original header hash remains unchanged");
+        TEST_ASSERT(headers[i]->value.data == values[i].data,
+                    "original header value pointer remains unchanged");
+        TEST_ASSERT(headers[i]->value.len == values[i].len,
+                    "original header value length remains unchanged");
+    }
+}
+
+static void test_snapshot_overflow_fails_before_mutation(void)
+{
+    test_snapshot_overflow_for_header("Vary", "Cookie");
+    test_snapshot_overflow_for_header("ETag", "\"original\"");
+    test_snapshot_overflow_for_header("Cache-Control", "public");
+
+    TEST_PASS("All snapshot overflows fail before Phase 1 mutation");
+}
+
 int main(void)
 {
     TEST_SECTION("Stream Header Commit (streaming fallback state machine, header commit)");
@@ -1065,6 +1153,7 @@ int main(void)
     test_rollback_cc_failure_restores_cc();
     test_rollback_etag_failure_rolls_back_vary();
     test_rollback_restores_typed_etag_pointer();
+    test_snapshot_overflow_fails_before_mutation();
 
     printf("\n  All stream commit tests passed\n\n");
     return 0;

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -144,23 +144,115 @@ static int test_is_authenticated;
 static int test_auth_cache_control_called;
 static int test_auth_cache_control_rc;
 
-/* Mock: ngx_http_markdown_add_vary_accept */
+/* Forward declarations for stubs defined later */
+ngx_table_elt_t *ngx_list_push(ngx_list_t *list);
+void *ngx_pnalloc(ngx_pool_t *pool, size_t size);
+#ifndef ngx_memcpy
+#define ngx_memcpy(dst, src, n)  memcpy((dst), (src), (n))
+#endif
+
+/* Mock: ngx_http_markdown_add_vary_accept
+ *
+ * Simulates real behavior: if no Vary header exists, pushes a new
+ * "Vary: Accept" entry; if Vary exists without "Accept", appends
+ * ", Accept" to the value.  This makes rollback tests meaningful.
+ */
 ngx_int_t
 ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
 {
-    UNUSED(r);
+    ngx_table_elt_t  *vary;
+    ngx_table_elt_t  *h;
+    u_char           *p;
+    size_t            len;
+    const char        suffix[] = ", Accept";
+
     test_vary_accept_called = 1;
-    return test_vary_accept_rc;
+    if (test_vary_accept_rc != NGX_OK) {
+        return test_vary_accept_rc;
+    }
+
+    /* Find existing Vary header */
+    vary = NULL;
+    {
+        ngx_table_elt_t *elts;
+        ngx_uint_t       i;
+        elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
+        for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
+            if (elts[i].hash != 0
+                && elts[i].key.len == 4
+                && ngx_strncasecmp(elts[i].key.data,
+                                   (const u_char *) "Vary", 4) == 0)
+            {
+                vary = &elts[i];
+                break;
+            }
+        }
+    }
+
+    if (vary == NULL) {
+        /* Push new Vary: Accept */
+        h = ngx_list_push(&r->headers_out.headers);
+        if (h == NULL) {
+            return NGX_ERROR;
+        }
+        h->hash = 1;
+        h->key.data = (u_char *) "Vary";
+        h->key.len = 4;
+        h->value.data = (u_char *) "Accept";
+        h->value.len = 6;
+        return NGX_OK;
+    }
+
+    /* Append ", Accept" to existing value */
+    len = vary->value.len + sizeof(suffix) - 1;
+    p = ngx_pnalloc(r->pool, len);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+    ngx_memcpy(p, vary->value.data, vary->value.len);
+    ngx_memcpy(p + vary->value.len, suffix, sizeof(suffix) - 1);
+    vary->value.data = p;
+    vary->value.len = len;
+    return NGX_OK;
 }
 
-/* Mock: ngx_http_markdown_set_etag */
+/* Mock: ngx_http_markdown_set_etag
+ *
+ * Simulates real behavior: when etag is NULL/0, invalidates all
+ * existing ETag entries (hash=0) and clears the typed pointer.
+ * This makes rollback tests meaningful.
+ */
 ngx_int_t
 ngx_http_markdown_set_etag(ngx_http_request_t *r,
                            const u_char *etag_value, size_t etag_len)
 {
-    UNUSED(r); UNUSED(etag_value); UNUSED(etag_len);
+    ngx_table_elt_t  *elts;
+    ngx_uint_t        i;
+
     test_set_etag_called = 1;
-    return test_set_etag_rc;
+    if (test_set_etag_rc != NGX_OK) {
+        return test_set_etag_rc;
+    }
+
+    if (etag_value != NULL && etag_len > 0) {
+        /* Not used by stream_commit_remove_etag, but keep for completeness */
+        return NGX_OK;
+    }
+
+    /* Invalidate all existing ETag entries (hash=0) */
+    elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
+    for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
+        if (elts[i].hash != 0
+            && elts[i].key.len == 4
+            && ngx_strncasecmp(elts[i].key.data,
+                               (const u_char *) "ETag", 4) == 0)
+        {
+            elts[i].hash = 0;
+        }
+    }
+
+    r->headers_out.etag = NULL;
+    return NGX_OK;
 }
 
 /* Mock: ngx_http_markdown_remove_content_encoding */
@@ -182,13 +274,66 @@ ngx_http_markdown_is_authenticated(const ngx_http_request_t *r,
     return test_is_authenticated;
 }
 
-/* Mock: ngx_http_markdown_modify_cache_control_for_auth */
+/* Mock: ngx_http_markdown_modify_cache_control_for_auth
+ *
+ * Simulates real behavior: modifies the existing Cache-Control
+ * header value (e.g. appends ", private").  This makes rollback
+ * tests meaningful.
+ */
 ngx_int_t
 ngx_http_markdown_modify_cache_control_for_auth(ngx_http_request_t *r)
 {
-    UNUSED(r);
+    ngx_table_elt_t  *cc;
+    ngx_table_elt_t  *elts;
+    u_char           *p;
+    size_t            len;
+    ngx_uint_t        i;
+    const char        suffix[] = ", private";
+
     test_auth_cache_control_called = 1;
-    return test_auth_cache_control_rc;
+    if (test_auth_cache_control_rc != NGX_OK) {
+        return test_auth_cache_control_rc;
+    }
+
+    /* Find existing Cache-Control header */
+    cc = NULL;
+    elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
+    for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
+        if (elts[i].hash != 0
+            && elts[i].key.len == 13
+            && ngx_strncasecmp(elts[i].key.data,
+                               (const u_char *) "Cache-Control", 13) == 0)
+        {
+            cc = &elts[i];
+            break;
+        }
+    }
+
+    if (cc == NULL) {
+        /* If no CC header, push a new one */
+        cc = ngx_list_push(&r->headers_out.headers);
+        if (cc == NULL) {
+            return NGX_ERROR;
+        }
+        cc->hash = 1;
+        cc->key.data = (u_char *) "Cache-Control";
+        cc->key.len = 13;
+        cc->value.data = (u_char *) "private";
+        cc->value.len = 7;
+        return NGX_OK;
+    }
+
+    /* Append ", private" to existing value */
+    len = cc->value.len + sizeof(suffix) - 1;
+    p = ngx_pnalloc(r->pool, len);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+    ngx_memcpy(p, cc->value.data, cc->value.len);
+    ngx_memcpy(p + cc->value.len, suffix, sizeof(suffix) - 1);
+    cc->value.data = p;
+    cc->value.len = len;
+    return NGX_OK;
 }
 
 /* Stub: ngx_log_error_core */

--- a/components/rust-converter/Cargo.lock
+++ b/components/rust-converter/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "brotli",

--- a/components/rust-converter/Cargo.toml
+++ b/components/rust-converter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nginx-markdown-converter"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["NGINX Markdown for Agents Contributors"]

--- a/components/rust-converter/fuzz/Cargo.lock
+++ b/components/rust-converter/fuzz/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "brotli",

--- a/docs/harness/rules/nginx-idioms.md
+++ b/docs/harness/rules/nginx-idioms.md
@@ -162,6 +162,10 @@ Required:
   step fails (allocation failure, header set failure), abort the entire
   operation and return `NGX_ERROR`.  Do not log the error and continue with
   partially applied headers — downstream consumers will see inconsistent state.
+- Fixed-capacity transaction snapshots must detect capacity overflow before
+  the first mutation and return `NGX_ERROR`.  Never silently omit matching
+  state from a rollback snapshot; a rollback set that does not cover every
+  mutable entry cannot satisfy the atomicity contract.
 
 Verification:
 - `grep -rn 'ngx_http_finalize_request' components/nginx-module/src/`

--- a/docs/harness/rules/streaming-backpressure.md
+++ b/docs/harness/rules/streaming-backpressure.md
@@ -12,10 +12,23 @@ paths:
 Historical issues: `5649890`, `23165d9`, `cfd4bd8`, `f97be3f`.
 
 Required:
-- If downstream filter returns `NGX_AGAIN`, persist the unsent chain in context and resume it later.
+- Determine ownership at the filter boundary before handling `NGX_AGAIN`.
+  Persist and resubmit a chain only while this module still owns the unsent
+  data.  If a downstream filter such as the NGINX copy filter has retained
+  the chain, keep only a request-lifetime anchor/pending latch and resume the
+  downstream filter with `NULL`; resubmitting the original chain duplicates
+  its unsent tail.
+- On resume, preserve the pending latch and buffered flag while downstream
+  returns `NGX_AGAIN`; clear both on terminal success or failure.
 - Never overwrite pending output with terminal empty `last_buf` while data is still pending.
 - On fallback from streaming to full-buffer path, reset state flags that gate conversion flow (for example conversion-attempt flags).
 - Fail-open paths must still honor header/body ordering and deferred-header forwarding.
+
+Verification:
+- `grep -rn 'pending_output\|resume_pending' components/nginx-module/src/`
+- For each resume path, verify whether downstream retained the original chain.
+  A copy-filter-owned chain must be resumed with
+  `ngx_http_next_body_filter(r, NULL)`, not with the original chain pointer.
 
 ---
 
@@ -136,6 +149,9 @@ For each code change you are about to produce, mentally (or explicitly in a thin
 3. No blocking calls, no raw malloc/free, no global mutable state. (Baseline)
 4. Return codes (`NGX_OK`, `NGX_AGAIN`, `NGX_DECLINED`, `NGX_ERROR`, `NGX_DONE`) used with correct semantics. (Baseline, Rule 2)
 5. Backpressure: if the change touches body-filter output, confirm pending-chain and `last_buf` ordering are preserved. (Rule 1)
+   At every `NGX_AGAIN` boundary, identify who owns the unsent chain. Module-owned
+   chains are resubmitted; downstream-owned chains are drained with a `NULL`
+   input and must never receive the original chain twice.
 6. Memory budgets enforced on every allocation path; auxiliary buffers freed on all exits. (Rule 3)
 7. UTF-8 chunk-boundary safety if touching streaming text paths. (Rule 4)
 8. **No unguarded operations on values that may be NULL/uninitialized/invalid** — this includes dereference, relational comparison (`>`, `<`), arithmetic, or field access through pointers. Use explicit guards or boolean flags set at the production site. (Baseline C style)
@@ -159,7 +175,7 @@ For each code change you are about to produce, mentally (or explicitly in a thin
 26. Residual code integrity: after merge or >500-line change in a single file, verify compilation, `git diff --check`, function count, and no duplicate adjacent blocks. For >30-line changes, verify the file is not truncated (closing brace present). (Rule 31)
 27. Snapshot race elimination: in `header_filter`, `ngx_http_markdown_dynconf_watcher.active_snapshot` must be read exactly once at function entry into a function-lifetime `snap_copy`; `early_eff` is built from that once. Both variables must have function-lifetime scope. ctx binding must copy from these function-level variables (via `ngx_http_markdown_bind_request_snapshot()`), never re-read the global `active_snapshot` or re-invoke `build_effective_conf()`. `handle_ctx_alloc_failure()` must receive `eff` (not NULL). (Rule 34)
 28. Fail-open replay buffer integrity: if the change touches fail-open or streaming pre-commit paths, verify (a) replay buffer init failure triggers `precommit_error`, (b) replay buffer append failure triggers `precommit_error` (not just a warning), (c) `failopen_completed` flag prevents duplicate `finalize_request` after terminal-buffer passthrough, (d) `results.failopen_count` is incremented only after downstream `NGX_OK` (not at decision point). (Rule 38)
-29. NGX_DONE terminal semantics: after `ngx_http_finalize_request()`, the function must return immediately. Callers receiving `NGX_DONE` must treat it as terminal success — no further filter calls or body sends. Multi-step header modifications must be atomic (abort on first failure). (Rule 39)
+29. NGX_DONE terminal semantics: after `ngx_http_finalize_request()`, the function must return immediately. Callers receiving `NGX_DONE` must treat it as terminal success — no further filter calls or body sends. Multi-step header modifications must be atomic (abort on first failure). Fixed-capacity rollback snapshots must fail before mutation when capacity is exceeded; they must never silently omit mutable entries. (Rule 39)
 30. Invalidated header filtering: all header lookup/iteration functions must skip entries where `hash == 0`. NGINX marks deleted headers by zeroing hash; reading such entries returns stale data. (Rule 40)
 31. Format string argument matching: when adding metrics to text/JSON renderers using `ngx_snprintf`, verify specifier count and types match the argument list exactly. (Rule 8)
 

--- a/tools/corpus/test-corpus-conversion/Cargo.lock
+++ b/tools/corpus/test-corpus-conversion/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "brotli",


### PR DESCRIPTION
## Summary by Sourcery

Ensure streaming header commit is transactional with rollback and bump the converter to version 0.8.1.

Bug Fixes:
- Snapshot and rollback Vary, ETag, and Cache-Control headers on any Phase 1 failure in ngx_http_markdown_stream_commit_headers(), restoring original header state and typed ETag pointers to prevent partial mutations leaking into fallback paths.

Enhancements:
- Document the Rule 39 transactional rollback semantics for streaming header commits in the NGINX module source comments.

Build:
- Bump the Rust converter crate version from 0.8.0 to 0.8.1 in Cargo metadata.

Documentation:
- Add a 0.8.1 changelog entry covering streaming header commit atomicity, FFI contract fixes, HTTP OWS compliance, security hardening, and related testing changes.

Tests:
- Extend stream_commit unit tests with helper stubs and five rollback-focused test cases covering Vary/ETag/Cache-Control failure rollback, cross-header rollback, and typed ETag pointer restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured atomic streaming header commits with pre-mutation snapshot/rollback for `Vary`, typed `ETag`, and `Cache-Control`, including fixed-capacity overflow failing before changes.
  * Fixed streaming “safe finish” cleanup so invalid inputs abort without consuming the handle.
  * Improved HTTP OWS handling (now treats `HTAB` as whitespace) and corrected full-buffer backpressure resume behavior.

* **Security**
  * Hardened release tooling (path traversal rejection, taint-sink protections, and CI supply-chain pinning).

* **Tests**
  * Added/updated unit tests covering rollback correctness, snapshot overflow, abort-contract behavior, and backpressure resume.

* **Documentation / Chores**
  * Refreshed streaming/backpressure and NGINX idioms rules; updated 0.8.1 changelog and 0.8.x release gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->