### PR TITLE
Synchronize 0.8.x documentation and finalize RFC-0008 status

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -698,7 +698,7 @@ jobs:
 
       - name: Run tag release gates
         env:
-          RELEASE_GATE_EXPECTED_CARGO_VERSION: "0.8.1"
+          RELEASE_GATE_EXPECTED_CARGO_VERSION: "0.8.2"
         run: |
           # Run the v0.8.0 release gate validators that are not already covered
           # by the build/package/smoke-test jobs above. The full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,7 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
 Follow evidence-first verification (no completion claim without fresh command output):
 - Docs/tools changes: `make docs-check`
 - Release-gate tooling: `make release-gates-check`
-- Release gates 0.8.0: `make release-gates-check-080` (comprehensive v0.8.0 release readiness gate)
+- Release gates 0.8.x: `make release-gates-check-08x` (canonical 0.8.x patch-line entry; `release-gates-check-080` is the compatible original name)
 - Rust converter/streaming changes: `make test-rust`
 - Rust example/benchmark changes: `cargo check --all-targets` in the crate
   directory to catch edition-specific errors (examples are only compiled
@@ -498,3 +498,4 @@ remediation:
 | 0.8.2 | 2026-06-12 | Kang | Added Rules 44–47: streaming deflate semantics (44), effective_conf NULL-safe access (45), FFI NULL/empty boundary guards (46), terminal-sent latch NGX_AGAIN semantics (47); strengthened Rules 13 (verified-rustup), 30 (cross-TU visibility, sentinel consistency) |
 | 0.8.3 | 2026-06-13 | Codex | Added Rule 48 for supplemental static security and supply-chain gates with focused Semgrep, secret scanning, cargo-deny, Trivy/SBOM/Scorecard, and local Make targets |
 | 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.2 patch release closeout: release-gates-check-08x alias, RFC-0008 Accepted, markdown_stream_flush_interval commitment narrowed, multipart header rollback regression tests |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,12 +524,12 @@ remediation:
 | 0.7.15 | 2026-06-03 | Codex | Strengthened Rule 13 for package smoke job-container checkout prerequisites |
 | 0.7.16 | 2026-06-03 | Codex | Strengthened Rule 13 for tag release gates avoiding user-local spec dependencies in clean CI checkouts |
 | 0.7.17 | 2026-06-04 | Codex | Strengthened Rule 6 for streaming code-block fence state across split text events |
-| 0.8.0 | 2026-06-16 | Kang | 0.8.0 release gate target (release-gates-check-080) with streaming, coverage, matrix, and clean-checkout gates |
 | 0.8.1 | 2026-06-10 | Codex | Strengthened Rule 13 for newer release gates that reuse prior-version validators with caller-parameterized active version assertions and current release-matrix schema consumers |
 | 0.8.2 | 2026-06-12 | Kang | Added Rules 44–47: streaming deflate semantics (44), effective_conf NULL-safe access (45), FFI NULL/empty boundary guards (46), terminal-sent latch NGX_AGAIN semantics (47); strengthened Rules 13 (verified-rustup), 30 (cross-TU visibility, sentinel consistency) |
-| 0.8.3 | 2026-06-13 | Codex | Added Rule 48 for supplemental static security and supply-chain gates with focused Semgrep, secret scanning, cargo-deny, Trivy/SBOM/Scorecard, and local Make targets |
-| 0.8.4 | 2026-06-21 | Codex | Strengthened Rule 48 so local secret scans cover tracked release content without inheriting ignored adapter state |
-| 0.8.5 | 2026-06-22 | Codex | Strengthened Rules 6 and 48 for inner-to-outer structural closure ordering and deletion-safe tracked-worktree secret scans |
-| 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
+| 0.8.2 | 2026-06-13 | Kang | Added Rule 48 for supplemental static security and supply-chain gates with focused Semgrep, secret scanning, cargo-deny, Trivy/SBOM/Scorecard, and local Make targets |
+| 0.8.0 | 2026-06-16 | Kang | 0.8.0 release gate target (release-gates-check-080) with streaming, coverage, matrix, and clean-checkout gates |
+| 0.8.2 | 2026-06-16 | Kang | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
+| 0.8.2 | 2026-06-21 | Kang | Strengthened Rule 48 so local secret scans cover tracked release content without inheriting ignored adapter state |
+| 0.8.2 | 2026-06-22 | Kang | Strengthened Rules 6 and 48 for inner-to-outer structural closure ordering and deletion-safe tracked-worktree secret scans |
 | 0.8.2 | 2026-06-23 | Kang | 0.8.2 release: streaming decompression hardening, implied-closure correctness, FFI panic safety, decompression budget enforcement, security scan scoping, release-line documentation closeout |
-| 0.8.6 | 2026-06-23 | Codex | Added general workflow safeguards for checkable outcomes, request-scoped diffs, Git operation safety, and deletion safety |
+| 0.8.2 | 2026-06-23 | Kang | Added general workflow safeguards for checkable outcomes, request-scoped diffs, Git operation safety, and deletion safety |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,10 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
   secret scanning, high-confidence Semgrep rules, and Rust dependency/license
   policy; keep third-party actions pinned to immutable SHAs and keep PR checks
   lightweight [48]
+- Local secret scans must cover Git-tracked worktree content, including tracked
+  edits, while excluding ignored adapter state, caches, and other files that
+  cannot enter a clean release checkout. Preserve NUL-safe filename handling
+  when materializing the tracked scan scope [48]
 - Supply-chain visibility workflows such as Trivy, SBOM generation, and
   OpenSSF Scorecard may run on PR, push, schedule, and manual triggers, but
   remain report-oriented unless a specific blocking threshold is adopted. Do
@@ -497,5 +501,6 @@ remediation:
 | 0.8.1 | 2026-06-10 | Codex | Strengthened Rule 13 for newer release gates that reuse prior-version validators with caller-parameterized active version assertions and current release-matrix schema consumers |
 | 0.8.2 | 2026-06-12 | Kang | Added Rules 44–47: streaming deflate semantics (44), effective_conf NULL-safe access (45), FFI NULL/empty boundary guards (46), terminal-sent latch NGX_AGAIN semantics (47); strengthened Rules 13 (verified-rustup), 30 (cross-TU visibility, sentinel consistency) |
 | 0.8.3 | 2026-06-13 | Codex | Added Rule 48 for supplemental static security and supply-chain gates with focused Semgrep, secret scanning, cargo-deny, Trivy/SBOM/Scorecard, and local Make targets |
+| 0.8.4 | 2026-06-21 | Codex | Strengthened Rule 48 so local secret scans cover tracked release content without inheriting ignored adapter state |
 | 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
 | 0.8.2 | 2026-06-21 | Kang | 0.8.2 patch release closeout: release-gates-check-08x alias, RFC-0008 Accepted, markdown_stream_flush_interval commitment narrowed, multipart header rollback regression tests |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Full rule text, historical issues, and verification commands: `docs/harness/rule
 | 3 | memory-budget | Enforce all budgets; free auxiliary buffers on all exits; track peak memory |
 | 4 | encoding-charset | Preserve incomplete UTF-8 tails across chunks; flush decoders at EOF |
 | 5 | html-sanitizer | Void elements self-closing; skip-mode name-aware; nesting-depth saturation-safe |
-| 6 | html-sanitizer | In-link markers accumulated; code-block raw/fence state preserved across text-event boundaries; blockquote consistent; URL extraction includes media elements |
+| 6 | html-sanitizer | In-link markers accumulated; structural closures unwind inner-to-outer; code-block raw/fence state preserved across text-event boundaries; blockquote consistent; URL extraction includes media elements |
 | 7 | observability-metrics | Explicit skip-reason mapping; reason-code tests aligned; new reason codes need log_decision() callsite |
 | 8 | observability-metrics | Fail on truncation; SHM layout version; non-overlapping Prometheus families; every metric has runtime write; delivery counters after success; format string argument matching |
 | 8b | observability-metrics | Config nesting matches code; consumer accepts both key names; combined report reads streaming_metrics first |
@@ -193,6 +193,7 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
 **HTML Sanitizer & Output Safety** (C, R, D)
 - Void elements self-closing; skip-mode name-aware [5]
 - In-link markers accumulated; code-block raw/fence state preserved across text-event boundaries; media URL extraction [6]
+- Implied or batched structural closures unwind inner-to-outer before enclosing block state [6]
 - Link/URL escaping at every emission site; reject control chars [27]
 
 **Testing & Coverage** (C, T, R)
@@ -322,8 +323,9 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
   lightweight [48]
 - Local secret scans must cover Git-tracked worktree content, including tracked
   edits, while excluding ignored adapter state, caches, and other files that
-  cannot enter a clean release checkout. Preserve NUL-safe filename handling
-  when materializing the tracked scan scope [48]
+  cannot enter a clean release checkout. Omit tracked paths that are absent due
+  to worktree deletions, and preserve NUL-safe filename handling when
+  materializing the tracked scan scope [48]
 - Supply-chain visibility workflows such as Trivy, SBOM generation, and
   OpenSSF Scorecard may run on PR, push, schedule, and manual triggers, but
   remain report-oriented unless a specific blocking threshold is adopted. Do
@@ -502,5 +504,6 @@ remediation:
 | 0.8.2 | 2026-06-12 | Kang | Added Rules 44–47: streaming deflate semantics (44), effective_conf NULL-safe access (45), FFI NULL/empty boundary guards (46), terminal-sent latch NGX_AGAIN semantics (47); strengthened Rules 13 (verified-rustup), 30 (cross-TU visibility, sentinel consistency) |
 | 0.8.3 | 2026-06-13 | Codex | Added Rule 48 for supplemental static security and supply-chain gates with focused Semgrep, secret scanning, cargo-deny, Trivy/SBOM/Scorecard, and local Make targets |
 | 0.8.4 | 2026-06-21 | Codex | Strengthened Rule 48 so local secret scans cover tracked release content without inheriting ignored adapter state |
+| 0.8.5 | 2026-06-22 | Codex | Strengthened Rules 6 and 48 for inner-to-outer structural closure ordering and deletion-safe tracked-worktree secret scans |
 | 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
 | 0.8.2 | 2026-06-21 | Kang | 0.8.2 patch release closeout: release-gates-check-08x alias, RFC-0008 Accepted, markdown_stream_flush_interval commitment narrowed, multipart header rollback regression tests |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,33 @@ Full rule text, historical issues, and verification commands: `docs/harness/rule
 - Identify invariants likely to break (header ordering, backpressure, reason codes, buffer bounds).
 - List boundary surfaces up front when the change crosses layers (NGINX C, Rust core, FFI/header, docs, scripts, CI).
 - Identify minimum verification commands before writing code.
+- Define the checkable outcome before editing: failing case and expected
+  behavior for bugs, observable behavior for features, unchanged behavior for
+  refactors, or concrete risk list for reviews.
+- Confirm the current repository and branch before coding tasks. Use the
+  current branch unless the user explicitly asks to create, switch, or choose
+  another branch.
 - When remediating SonarCloud findings for a PR, fetch findings from
   `api/issues/search` with explicit `componentKeys`, `pullRequest`,
   and `statuses=OPEN,CONFIRMED`; do not rely solely on dashboard
   "top issues" summaries, which may include already-closed items.
+
+### Repository operation safety
+- Keep diffs tied to the current request. Do not mix behavior changes with
+  unrelated formatting sweeps, renames, broad reorganization, new dependencies,
+  or abstractions for one caller unless they are required for correctness or
+  verification.
+- Mention unrelated dead code, cleanup opportunities, or design concerns
+  separately instead of fixing them inside the current patch.
+- Commit only changes tied to the current request. Before each commit, review
+  the staged diff and summarize what changed.
+- Run the relevant checks before pushing when practical. Use normal push
+  access only; do not force-push, rewrite history, change remotes, change
+  repository settings, manage collaborators, alter branch protection, or
+  delete branches unless the user explicitly requested that operation.
+- Do not use wildcard cleanup deletes, scripted deletion loops, or broad
+  recursive deletion commands. Delete only literal named paths required by the
+  task; ask first when multiple deletions or recursive cleanup are necessary.
 
 ### Pre-output Checklist (domain-grouped)
 
@@ -357,6 +380,8 @@ Applies-to codes: **C** = nginx-module/src, **T** = tests/unit, **R** = rust-con
 - Preserve NGINX event-driven semantics; no hidden blocking calls.
 - Add/adjust tests in the same change set for each fixed behavior.
 - Keep docs and validators synced when user-facing or SOP behavior changes.
+- Clean up imports, variables, helpers, and docs references made unused by the
+  current change.
 - For Sonar-driven fixes, map each change to an open issue key and
   file/line from the current API response, and skip already-closed items.
 
@@ -507,3 +532,4 @@ remediation:
 | 0.8.5 | 2026-06-22 | Codex | Strengthened Rules 6 and 48 for inner-to-outer structural closure ordering and deletion-safe tracked-worktree secret scans |
 | 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
 | 0.8.2 | 2026-06-23 | Kang | 0.8.2 release: streaming decompression hardening, implied-closure correctness, FFI panic safety, decompression budget enforcement, security scan scoping, release-line documentation closeout |
+| 0.8.6 | 2026-06-23 | Codex | Added general workflow safeguards for checkable outcomes, request-scoped diffs, Git operation safety, and deletion safety |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,4 +506,4 @@ remediation:
 | 0.8.4 | 2026-06-21 | Codex | Strengthened Rule 48 so local secret scans cover tracked release content without inheriting ignored adapter state |
 | 0.8.5 | 2026-06-22 | Codex | Strengthened Rules 6 and 48 for inner-to-outer structural closure ordering and deletion-safe tracked-worktree secret scans |
 | 0.8.4 | 2026-06-16 | Codex | Strengthened Rule 13 for release Dockerfile script interpreter prerequisites in minimal images |
-| 0.8.2 | 2026-06-21 | Kang | 0.8.2 patch release closeout: release-gates-check-08x alias, RFC-0008 Accepted, markdown_stream_flush_interval commitment narrowed, multipart header rollback regression tests |
+| 0.8.2 | 2026-06-23 | Kang | 0.8.2 release: streaming decompression hardening, implied-closure correctness, FFI panic safety, decompression budget enforcement, security scan scoping, release-line documentation closeout |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ Patch release closeout for the 0.8.x line before 0.9.0 spec execution.
 
 - Synchronized "current release line" wording across project status, README,
   installation, compatibility, and package distribution docs to reference 0.8.x
-  (latest patch 0.8.1) rather than 0.8.0.
+  (latest patch 0.8.2) rather than 0.8.0.
 - Updated package artifact examples in `PACKAGE_DISTRIBUTION.md` and
-  `COMPATIBILITY.md` from 0.8.0 to 0.8.1 to avoid guiding users toward
+  `COMPATIBILITY.md` from 0.8.1 to 0.8.2 to avoid guiding users toward
   outdated artifacts.
 - Finalized RFC-0008 status from `Draft` to `Accepted / Implemented in 0.8.0`,
   with an implementation note covering 0.8.0 streaming contract and 0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-06-21
+
+Patch release closeout for the 0.8.x line before 0.9.0 spec execution.
+
+### Changed
+
+- Synchronized "current release line" wording across project status, README,
+  installation, compatibility, and package distribution docs to reference 0.8.x
+  (latest patch 0.8.1) rather than 0.8.0.
+- Updated package artifact examples in `PACKAGE_DISTRIBUTION.md` and
+  `COMPATIBILITY.md` from 0.8.0 to 0.8.1 to avoid guiding users toward
+  outdated artifacts.
+- Finalized RFC-0008 status from `Draft` to `Accepted / Implemented in 0.8.0`,
+  with an implementation note covering 0.8.0 streaming contract and 0.8.1
+  Rule 39 / FFI cleanup / OWS / backpressure hardening.
+- Narrowed `markdown_stream_flush_interval` commitment from "future 0.8.x
+  release" to "future release" so the 0.8.x patch line is not bound to
+  delivering it.
+- Added `make release-gates-check-08x` as the canonical 0.8.x patch-line
+  entry point, reusing the 0.8.0 gate logic without duplicating it.
+  `release-gates-check-080` remains as the compatible original name.
+
+### Tests
+
+- Added stream commit multipart header-list rollback regression tests covering
+  cross-part `orig_nelts` semantics (Rule 39 / Rule 40): Vary in part2
+  restoration, target and non-target headers in part2, cross-header rollback
+  across parts (ETag failure rolls back Vary in p1 and ETag in p2), new-push
+  entry invalidation, Cache-Control failure cross-part rollback, and explicit
+  `orig_nelts` cross-part linear count verification.
+
 ## [0.8.1] - 2026-06-20
 
 Maintenance, stability, and security-hardening release on top of 0.8.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.2] - 2026-06-21
+## [0.8.2] - 2026-06-23
 
-Patch release closeout for the 0.8.x line before 0.9.0 spec execution.
+Patch release for the 0.8.x line: streaming decompression hardening, FFI
+safety, implied-closure correctness, decompression budget enforcement, and
+release-line documentation closeout.
+
+### Added
+
+- **Parser working-set estimation and overflow-safe budget** (FFI): the FFI
+  boundary now estimates the parser working set and enforces an overflow-safe
+  budget before conversion, preventing unbounded memory use on pathological
+  inputs (Rule 43).
+- **Streaming decompression budget and memory accounting**: the streaming
+  decompression path now enforces the configured decompression budget and
+  tracks streaming memory consumption against the module memory budget
+  (Rule 3, Rule 44).
+- **Rule 49 (THIRD-PARTY-NOTICES sync)**: `THIRD-PARTY-NOTICES` must stay in
+  sync with resolved dependency versions; add/remove/update entries in the
+  same changeset as `Cargo.lock` changes.
+- `make release-gates-check-08x` as the canonical 0.8.x patch-line entry
+  point, reusing the 0.8.0 gate logic without duplicating it.
+  `release-gates-check-080` remains as the compatible original name.
 
 ### Changed
 
@@ -23,9 +42,51 @@ Patch release closeout for the 0.8.x line before 0.9.0 spec execution.
 - Narrowed `markdown_stream_flush_interval` commitment from "future 0.8.x
   release" to "future release" so the 0.8.x patch line is not bound to
   delivering it.
-- Added `make release-gates-check-08x` as the canonical 0.8.x patch-line
-  entry point, reusing the 0.8.0 gate logic without duplicating it.
-  `release-gates-check-080` remains as the compatible original name.
+- Extracted zlib finish buffer-expansion helper to reduce duplication across
+  streaming decompression error paths.
+- Unified streaming decompression free-heap pattern: `ngx_alloc`/`ngx_free`
+  used exclusively for resizable buffer backing stores (Rule 43).
+- Simplified code language class prefix matching in the Rust converter.
+- Extracted duplicated `workflow:release-version` literal into a shared Python
+  constant.
+- Scoped gitleaks to tracked worktree content, excluding ignored adapter state
+  and caches (Rule 48).
+- Updated `THIRD-PARTY-NOTICES` with current dependency versions.
+- Clarified header plan safety contract in C headers.
+
+### Fixed
+
+- **Implied closure ordering (Rule 6)**: structural closures now unwind
+  inner-to-outer before enclosing block state; the Rust converter consumes
+  implied closures before the sanitizer Skip decision, and mirrors implied
+  closures to the state machine.
+- **Streaming decompression heap leaks**: eliminated heap leaks in
+  `finish_zlib()` across all exit paths; buffer pointers are now set to NULL
+  after free to prevent double-free.
+- **Pool vs heap memory safety**: `apply_limits()` no longer calls `ngx_free`
+  on pool-allocated memory; the finish workspace uses `ngx_alloc` exclusively
+  (Rule 43).
+- **Streaming decompression buffer expansion**: hardened error paths in buffer
+  expansion with proper overflow checks and fallback behavior.
+- **Code fence language handling**: the streaming converter now supports the
+  `lang-` prefix in code fence language identifiers and sanitizes code fence
+  language strings against malformed input.
+- **FFI header plan panic safety**: centralized FFI header plan reset so that
+  panic-safe cleanup always restores a consistent state.
+- **Header validation and buffer sizing**: improved header validation, buffer
+  sizing, and config initialization in the NGINX C module.
+- **`parse_size` hardening**: `parse_size()` now correctly handles empty,
+  whitespace-only, and malformed size directive input.
+- **Forward declaration**: added missing forward declaration for `apply_limits`
+  to fix an implicit declaration error.
+- **Security scan**: gitleaks now skips deleted paths in tracked worktree scans
+  and guards against empty scan roots after tar extraction.
+- **Build**: injected `RELEASE_GATE_EXPECTED_CARGO_VERSION` into
+  `release-gates-check-strict` for consistent version validation.
+- **Dependencies**: regenerated stale `Cargo.lock` files for fuzz and
+  test-corpus-conversion workspaces.
+- **Tests**: removed unused typedef, corrected `snapshot_header` call
+  signatures, and fixed multipart rollback test scenarios.
 
 ### Tests
 
@@ -35,6 +96,10 @@ Patch release closeout for the 0.8.x line before 0.9.0 spec execution.
   across parts (ETag failure rolls back Vary in p1 and ETag in p2), new-push
   entry invalidation, Cache-Control failure cross-part rollback, and explicit
   `orig_nelts` cross-part linear count verification.
+- Added regression tests for implied closure on Skip decision and streaming
+  language prefix handling.
+- Added metadata traversal timeout regression test.
+- Added `assert buf NULL` on `finish_zlib` error paths.
 
 ## [0.8.1] - 2026-06-20
 

--- a/Makefile
+++ b/Makefile
@@ -648,7 +648,7 @@ release-gates-check-070-docker:
 release-gates-check-strict:
 	python3 tools/release/gates/validate_release_gates.py --mode strict
 	python3 tools/release/gates/validate_naming.py
-	python3 tools/release/gates/validate_release_gates_070.py --mode strict
+	RELEASE_GATE_EXPECTED_CARGO_VERSION=$(RELEASE_GATE_080_ACTIVE_VERSION) python3 tools/release/gates/validate_release_gates_070.py --mode strict
 	python3 tools/release/gates/validate_fuzz_packaging_070.py
 	@echo "=== Strict: Release Workflow Gate ==="
 	@test -f .github/workflows/release-packages.yml || { echo "FAIL: .github/workflows/release-packages.yml not found" >&2; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ test-harness:
 	bash tools/harness/tests/test_detect_ffi_struct_init.sh
 	bash tools/harness/tests/test_detect_c_pure_logic.sh
 	bash tools/harness/tests/test_detect_volatile_atomic.sh
+	bash tools/harness/tests/test_security_gitleaks_scope.sh
 	python3 -m pytest tools/harness/tests/ -q --tb=short -k "not check_harness_sync"
 
 license-check:
@@ -284,7 +285,7 @@ security-shellcheck:
 
 security-gitleaks:
 	@command -v gitleaks >/dev/null 2>&1 || { echo "ERROR: gitleaks not found. Install with: go install github.com/zricethezav/gitleaks/v8@83d9cd684c87d95d656c1458ef04895a7f1cbd8e # v8.30.1" >&2; exit 127; }
-	gitleaks detect --source . --no-git --redact --config .gitleaks.toml --verbose
+	bash tools/security/run_gitleaks_tracked.sh
 
 security-semgrep:
 	@command -v semgrep >/dev/null 2>&1 || { echo "ERROR: semgrep not found. Install with: python3 -m pip install --user semgrep==1.166.0" >&2; exit 127; }

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ LICENSE_INSTALL_DIR := $(PREFIX)/share/licenses/nginx-markdown-for-agents
         harness-check harness-check-full harness-security-checks test-harness \
         security-static security-actionlint security-shellcheck security-gitleaks security-semgrep security-cargo-deny \
         supply-chain supply-chain-trivy supply-chain-sbom \
-	docs-check license-check release-notes release-gates-check release-gates-check-055 release-gates-check-060 release-gates-check-070 release-gates-check-070-docker release-gates-check-080 release-gates-check-legacy release-gates-check-strict \
+	docs-check license-check release-notes release-gates-check release-gates-check-055 release-gates-check-060 release-gates-check-070 release-gates-check-070-docker release-gates-check-080 release-gates-check-08x release-gates-check-legacy release-gates-check-strict \
         verify-large-e2e verify-huge-native-e2e verify-huge-allowed-native-e2e \
         verify-chunked-native-e2e verify-chunked-native-e2e-smoke verify-chunked-native-e2e-stress \
         verify-streaming-failure-cache-e2e \
@@ -634,6 +634,9 @@ release-gates-check-080:
 	fi
 	@echo "=== v0.8.x Release Gate: ALL PASSED ($(RELEASE_GATE_080_ACTIVE_VERSION)) ==="
 
+release-gates-check-08x: release-gates-check-080
+	@echo "  (release-gates-check-08x is an alias for release-gates-check-080, the 0.8.x patch-line gate)"
+
 release-gates-check-legacy:
 	python3 tools/release/legacy/validate_release_gates.py
 
@@ -810,6 +813,7 @@ help:
 	@echo "  release-gates-check-060  - Validate 0.6.0 release gates (streaming default, pruning, budget)"
 	@echo "  release-gates-check-070  - Validate 0.7.0 release gates (runtime correctness, package compat, fuzz)"
 	@echo "  release-gates-check-080  - Validate 0.8.x release gates (streaming, coverage, matrix, harness boundary)"
+	@echo "  release-gates-check-08x  - Alias for release-gates-check-080 (0.8.x patch-line canonical entry)"
 	@echo "  release-gates-check-legacy - Validate 0.4.0 release gate documents"
 	@echo "  release-gates-check-strict - Validate all sub-specs #12-#18 for full compliance"
 	@echo "  release-notes            - Generate release notes from release-matrix.json"

--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ release-gates-check-070:
 #                                           when NGINX source or lcov/cargo-llvm-cov
 #                                           is unavailable
 
-RELEASE_GATE_080_ACTIVE_VERSION ?= 0.8.1
+RELEASE_GATE_080_ACTIVE_VERSION ?= 0.8.2
 
 release-gates-check-080:
 	@echo "=== v0.8.x Release Gate: Starting ($(RELEASE_GATE_080_ACTIVE_VERSION)) ==="

--- a/README.md
+++ b/README.md
@@ -493,13 +493,13 @@ Additional changes:
 
 ## Roadmap
 
-Current release (0.8.0):
+Current release line (0.8.x; latest patch 0.8.1):
 
 - Dual-engine streaming model: full-buffer default + streaming engine for large/chunked responses
 - `auto` mode as the default `markdown_streaming_engine` setting
 - Bounded-memory streaming conversion with size-based flush (`markdown_stream_flush_min`)
 - Pre-commit safety: fallback to HTML if conversion error occurs before output is committed
-- Streaming release gate: `make release-gates-check-080` validates the 0.8.0 release contract
+- Streaming release gate: `make release-gates-check-08x` (alias of `release-gates-check-080`) validates the 0.8.x release contract
 - Static security gate: `.github/workflows/security-static.yml` runs actionlint,
   shellcheck, gitleaks, focused Semgrep, and cargo-deny for workflow, script,
   secret, and Rust dependency policy changes
@@ -549,6 +549,7 @@ BSD 2-Clause "Simplified" License. See [LICENSE](LICENSE).
 |---------|------|--------|---------|
 | 0.8.0 | 2026-06-16 | Codex | Synchronized English and Chinese README structure, Quick Start examples, local test commands, platform support heading, and v0.8.0 roadmap wording |
 | 0.8.0 | 2026-06-16 | Kang | v0.8.0 streaming release readiness: dual-engine model, auto mode default, bounded-memory conversion, pre-commit safety, 0.6.x compatibility removal, release-gates-check-080, migration guide, and rollout cookbook links |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: synced "current release line" wording to 0.8.x (latest patch 0.8.1), finalized RFC-0008 status, narrowed `markdown_stream_flush_interval` commitment, added stream commit multipart rollback regression tests, added `release-gates-check-08x` alias |
 | 0.7.0 | 2026-06-03 | Kang | P0 correctness, Rust-first architecture, independent decompression budget, Accept negotiation, parse timeout/budget, DEB/RPM packaging, K8s examples, runtime diagnostics, dynconf dry-run/rollback |
 | 0.6.3 | 2026-05-14 | Kang | Version bump to 0.6.3, release-matrix refresh, and final hardening notes |
 | 0.6.2 | 2026-05-08 | Kang | Version bump to 0.6.2 for release |

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Additional changes:
 
 ## Roadmap
 
-Current release line (0.8.x; latest patch 0.8.1):
+Current release line (0.8.x; latest patch 0.8.2):
 
 - Dual-engine streaming model: full-buffer default + streaming engine for large/chunked responses
 - `auto` mode as the default `markdown_streaming_engine` setting
@@ -549,7 +549,7 @@ BSD 2-Clause "Simplified" License. See [LICENSE](LICENSE).
 |---------|------|--------|---------|
 | 0.8.0 | 2026-06-16 | Codex | Synchronized English and Chinese README structure, Quick Start examples, local test commands, platform support heading, and v0.8.0 roadmap wording |
 | 0.8.0 | 2026-06-16 | Kang | v0.8.0 streaming release readiness: dual-engine model, auto mode default, bounded-memory conversion, pre-commit safety, 0.6.x compatibility removal, release-gates-check-080, migration guide, and rollout cookbook links |
-| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: synced "current release line" wording to 0.8.x (latest patch 0.8.1), finalized RFC-0008 status, narrowed `markdown_stream_flush_interval` commitment, added stream commit multipart rollback regression tests, added `release-gates-check-08x` alias |
+| 0.8.2 | 2026-06-23 | Kang | 0.8.2 release: streaming decompression hardening, implied-closure correctness, FFI panic safety, decompression budget enforcement, security scan scoping, release-line documentation closeout |
 | 0.7.0 | 2026-06-03 | Kang | P0 correctness, Rust-first architecture, independent decompression budget, Accept negotiation, parse timeout/budget, DEB/RPM packaging, K8s examples, runtime diagnostics, dynconf dry-run/rollback |
 | 0.6.3 | 2026-05-14 | Kang | Version bump to 0.6.3, release-matrix refresh, and final hardening notes |
 | 0.6.2 | 2026-05-08 | Kang | Version bump to 0.6.2 for release |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -484,7 +484,7 @@ v0.7.0 是一个正确性、分发和可运维性版本：
 
 ## 路线方向
 
-当前版本线 (0.8.x；最新 patch 0.8.1)：
+当前版本线 (0.8.x；最新 patch 0.8.2)：
 
 - 双引擎流式模型：全缓冲默认路径 + 面向大响应/chunked 响应的流式引擎
 - `auto` 模式作为默认 `markdown_streaming_engine` 设置
@@ -540,7 +540,7 @@ BSD 2-Clause "Simplified" License。详见 [LICENSE](LICENSE)。
 |---------|------|--------|---------|
 | 0.8.0 | 2026-06-16 | Codex | 同步中英文 README 结构、Quick Start 示例、本地测试命令、平台支持标题和 v0.8.0 路线说明 |
 | 0.8.0 | 2026-06-16 | Kang | 0.8.0 正式发布文档就绪：双引擎流式转换（auto 默认）、有界内存增量处理、提交前安全回退、旧阈值指令兼容、新流式指令、可观测性与 release-gates-check-080 |
-| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch 线收口：同步“当前版本线”措辞为 0.8.x（最新 patch 0.8.1），收口 RFC-0008 状态，收窄 `markdown_stream_flush_interval` 承诺，补充 stream commit 多 part header list rollback 回归测试，新增 `release-gates-check-08x` 别名 |
+| 0.8.2 | 2026-06-23 | Kang | 0.8.2 发布：流式解压加固、隐式闭合正确性、FFI panic 安全、解压预算强制执行、安全扫描范围限定、版本线文档收口 |
 | 0.7.0 | 2026-06-03 | Kang | P0 正确性修复、Rust-first 架构、独立解压预算、Accept 协商、解析超时/预算、DEB/RPM 包分发、K8s 示例、运行时诊断、dynconf dry-run/回滚 |
 | 0.6.3 | 2026-05-14 | Kang | 版本号更新至 0.6.3，并补充 release matrix 与发布前最终加固说明 |
 | 0.6.2 | 2026-05-08 | Kang | 版本号更新至 0.6.2 以配合发布 |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -484,13 +484,13 @@ v0.7.0 是一个正确性、分发和可运维性版本：
 
 ## 路线方向
 
-当前版本 (0.8.0)：
+当前版本线 (0.8.x；最新 patch 0.8.1)：
 
 - 双引擎流式模型：全缓冲默认路径 + 面向大响应/chunked 响应的流式引擎
 - `auto` 模式作为默认 `markdown_streaming_engine` 设置
 - 基于 `markdown_stream_flush_min` 的有界内存流式转换与按大小 flush
 - 提交前安全回退：输出提交前发生转换错误时回退到 HTML
-- 流式发布门禁：`make release-gates-check-080` 验证 0.8.0 发布合约
+- 流式发布门禁：`make release-gates-check-08x`（`release-gates-check-080` 的别名）验证 0.8.x 发布合约
 - 静态安全门禁：`.github/workflows/security-static.yml` 针对 workflow、脚本、
   secret、Semgrep 规则与 Rust 依赖策略运行 actionlint、shellcheck、
   gitleaks、聚焦 Semgrep 和 cargo-deny
@@ -540,6 +540,7 @@ BSD 2-Clause "Simplified" License。详见 [LICENSE](LICENSE)。
 |---------|------|--------|---------|
 | 0.8.0 | 2026-06-16 | Codex | 同步中英文 README 结构、Quick Start 示例、本地测试命令、平台支持标题和 v0.8.0 路线说明 |
 | 0.8.0 | 2026-06-16 | Kang | 0.8.0 正式发布文档就绪：双引擎流式转换（auto 默认）、有界内存增量处理、提交前安全回退、旧阈值指令兼容、新流式指令、可观测性与 release-gates-check-080 |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch 线收口：同步“当前版本线”措辞为 0.8.x（最新 patch 0.8.1），收口 RFC-0008 状态，收窄 `markdown_stream_flush_interval` 承诺，补充 stream commit 多 part header list rollback 回归测试，新增 `release-gates-check-08x` 别名 |
 | 0.7.0 | 2026-06-03 | Kang | P0 正确性修复、Rust-first 架构、独立解压预算、Accept 协商、解析超时/预算、DEB/RPM 包分发、K8s 示例、运行时诊断、dynconf dry-run/回滚 |
 | 0.6.3 | 2026-05-14 | Kang | 版本号更新至 0.6.3，并补充 release matrix 与发布前最终加固说明 |
 | 0.6.2 | 2026-05-08 | Kang | 版本号更新至 0.6.2 以配合发布 |

--- a/charts/nginx-markdown/Chart.yaml
+++ b/charts/nginx-markdown/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nginx-markdown
 description: NGINX module that converts HTML responses to Markdown for AI agents
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.2
+appVersion: "0.8.2"
 home: https://github.com/cnkang/nginx-markdown-for-agents
 keywords:
   - nginx

--- a/components/nginx-module/src/markdown_converter.h
+++ b/components/nginx-module/src/markdown_converter.h
@@ -823,16 +823,12 @@ void markdown_make_decision(uint8_t enabled,
 
 /**
  * Build a header plan for a successful Markdown conversion.
- *
  * The returned plan contains Rust-owned buffers. The C caller must release
  * the plan via `markdown_header_plan_free`.
- *
  * This function treats `result` as uninitialized output storage and never
  * reads its previous fields. Callers that already own a plan in the same
  * storage must call `markdown_header_plan_free` before rebuilding it.
- *
  * # Safety
- *
  * The caller must ensure that:
  * - `content_type` points to readable UTF-8 bytes of `content_type_len`
  * - `result` points to writable storage for a `FFIHeaderPlan`; its previous

--- a/components/nginx-module/src/markdown_converter.h
+++ b/components/nginx-module/src/markdown_converter.h
@@ -827,11 +827,17 @@ void markdown_make_decision(uint8_t enabled,
  * The returned plan contains Rust-owned buffers. The C caller must release
  * the plan via `markdown_header_plan_free`.
  *
+ * This function treats `result` as uninitialized output storage and never
+ * reads its previous fields. Callers that already own a plan in the same
+ * storage must call `markdown_header_plan_free` before rebuilding it.
+ *
  * # Safety
  *
  * The caller must ensure that:
  * - `content_type` points to readable UTF-8 bytes of `content_type_len`
- * - `result` points to writable storage for a `FFIHeaderPlan`
+ * - `result` points to writable storage for a `FFIHeaderPlan`; its previous
+ *   bytes may be uninitialized, but any previously-owned plan must have been
+ *   released before this call
  */
 void markdown_build_header_plan(const uint8_t *content_type,
                                 uintptr_t content_type_len,

--- a/components/nginx-module/src/ngx_http_markdown_auth.c
+++ b/components/nginx-module/src/ngx_http_markdown_auth.c
@@ -560,7 +560,9 @@ ngx_http_markdown_cookie_matches_any_pattern(const ngx_str_t *cookie_name,
 static ngx_int_t
 ngx_http_markdown_has_authorization_header(const ngx_http_request_t *r)
 {
-    if (r == NULL || r->headers_in.authorization == NULL) {
+    if (r == NULL || r->headers_in.authorization == NULL
+        || r->headers_in.authorization->hash == 0)
+    {
         return 0;
     }
 
@@ -816,7 +818,9 @@ ngx_http_markdown_cache_control_has_directive(const ngx_str_t *value,
 static ngx_flag_t
 ngx_http_markdown_is_cache_control_header(const ngx_table_elt_t *header)
 {
-    if (header->key.len != sizeof(ngx_http_markdown_hdr_cache_control) - 1) {
+    if (header->hash == 0
+        || header->key.len != sizeof(ngx_http_markdown_hdr_cache_control) - 1)
+    {
         return 0;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_buffer.c
+++ b/components/nginx-module/src/ngx_http_markdown_buffer.c
@@ -49,9 +49,9 @@ ngx_http_markdown_buffer_init(ngx_http_markdown_buffer_t *buf,
         return NGX_ERROR;
     }
 
-    /* Validate max_size is reasonable (must be > 0) */
+    /* A zero directive value is the public unlimited-size sentinel. */
     if (max_size == 0) {
-        return NGX_ERROR;
+        max_size = NGX_HTTP_MARKDOWN_CONF_UNSET_SIZE;
     }
 
     /*

--- a/components/nginx-module/src/ngx_http_markdown_conditional.c
+++ b/components/nginx-module/src/ngx_http_markdown_conditional.c
@@ -323,26 +323,14 @@ ngx_http_markdown_send_304(ngx_http_request_t *r,
     r->headers_out.content_length_n = -1;
 
     if (result != NULL && result->etag != NULL && result->etag_len > 0) {
-        h = ngx_list_push(&r->headers_out.headers);
-        if (h == NULL) {
+        rc = ngx_http_markdown_set_etag(r, result->etag, result->etag_len);
+        if (rc != NGX_OK) {
             return NGX_ERROR;
         }
-
-        h->hash = 1;
-        ngx_str_set(&h->key, "ETag");
-
-        h->value.data = ngx_pnalloc(r->pool, result->etag_len);
-        if (h->value.data == NULL) {
-            return NGX_ERROR;
-        }
-
-        ngx_memcpy(h->value.data, result->etag, result->etag_len);
-        h->value.len = result->etag_len;
-
-        r->headers_out.etag = h;
 
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                      "markdown: 304 response with ETag: \"%V\"", &h->value);
+                      "markdown: 304 response with ETag: \"%V\"",
+                      &r->headers_out.etag->value);
     }
 
     h = ngx_list_push(&r->headers_out.headers);

--- a/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_core_impl.h
@@ -177,6 +177,7 @@ ngx_http_markdown_create_main_conf(ngx_conf_t *cf)
     conf->dynconf_path_configured = 0;
     conf->dynconf_first_path.data = NULL;
     conf->dynconf_first_path.len = 0;
+    conf->dynconf_owner_conf = NULL;
     conf->metrics_per_path_cardinality = NGX_CONF_UNSET_UINT;
 
     return conf;

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -62,7 +62,7 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
 {
     char                 buf[64];
     char                *endptr;
-    char                *number;
+    const char          *number;
     size_t               len;
     size_t               value;
     size_t               scale;
@@ -88,7 +88,7 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
         number++;
     }
 
-    if (*number == '-') {
+    if (*number == '\0' || *number == '-') {
         return (size_t) NGX_ERROR;
     }
 
@@ -111,7 +111,7 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
 
     errno = 0;
     raw = strtoull(number, &endptr, 10);
-    if (errno == ERANGE || *endptr != '\0'
+    if (errno == ERANGE || endptr == number || *endptr != '\0'
         || raw > (unsigned long long) NGX_MAX_SIZE_T_VALUE)
     {
         return (size_t) NGX_ERROR;

--- a/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_config_handlers_impl.h
@@ -62,6 +62,7 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
 {
     char                 buf[64];
     char                *endptr;
+    char                *number;
     size_t               len;
     size_t               value;
     size_t               scale;
@@ -79,6 +80,17 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
 
     memcpy(buf, line->data, len);
     buf[len] = '\0';
+
+    number = buf;
+    while (*number == ' ' || *number == '\t' || *number == '\r'
+           || *number == '\n' || *number == '\f' || *number == '\v')
+    {
+        number++;
+    }
+
+    if (*number == '-') {
+        return (size_t) NGX_ERROR;
+    }
 
     suffix = '\0';
     if (len > 1) {
@@ -98,7 +110,7 @@ ngx_http_markdown_parse_size(const ngx_str_t *line)
     }
 
     errno = 0;
-    raw = strtoull(buf, &endptr, 10);
+    raw = strtoull(number, &endptr, 10);
     if (errno == ERANGE || *endptr != '\0'
         || raw > (unsigned long long) NGX_MAX_SIZE_T_VALUE)
     {
@@ -841,8 +853,9 @@ ngx_http_markdown_diagnostics_directive(ngx_conf_t *cf, ngx_command_t *cmd, void
  * to reject the configuration immediately — before nginx -t or
  * worker startup — preventing ambiguous multi-location dynconf.
  *
- * Dynconf supports only a single global instance; the operator must
- * place the directive at http/server level or in only one location.
+ * Dynconf supports only a single global instance; the operator may
+ * place the directive at http, server, or location level, but only
+ * one configuration object may own the global watcher.
  *
  * Duplicate detection reads from ngx_http_markdown_main_conf_t
  * (config-parse scope) rather than a file-scope static, so the flag
@@ -899,6 +912,7 @@ ngx_http_markdown_set_dynconf_path(ngx_conf_t *cf, ngx_command_t *cmd,
     mcf->advanced.dynconf_path = value[1];
     mmcf->dynconf_path_configured = 1;
     mmcf->dynconf_first_path = value[1];
+    mmcf->dynconf_owner_conf = mcf;
 
     return NGX_CONF_OK;
 }

--- a/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_conversion_impl.h
@@ -141,8 +141,9 @@ ngx_http_markdown_scheme_is_http_family(const ngx_str_t *scheme)
 /*
  * Validate characters in an extracted host value.
  *
- * Rejects control characters (0x00-0x1F, 0x7F), spaces, commas, and
- * path separators (/,\).  For non-IPv6 hosts, enforces digit-only
+ * Rejects control characters (0x00-0x1F, 0x7F), spaces, commas, URI
+ * authority delimiters (@, #, ?), and path separators (/,\).  For
+ * non-IPv6 hosts, enforces digit-only
  * port after the first ':'.  For IPv6 bracket literals, only rejects
  * the structural danger characters (port is validated separately
  * after bracket matching).
@@ -173,7 +174,9 @@ ngx_http_markdown_validate_host_chars(const u_char *host_data,
             continue;
         }
 
-        if (c == '/' || c == '\\' || c == ' ' || c == ',') {
+        if (c == '/' || c == '\\' || c == ' ' || c == ','
+            || c == '@' || c == '#' || c == '?')
+        {
             return 0;
         }
 

--- a/components/nginx-module/src/ngx_http_markdown_eligibility.c
+++ b/components/nginx-module/src/ngx_http_markdown_eligibility.c
@@ -182,39 +182,14 @@ ngx_http_markdown_check_size_limit(const ngx_http_request_t *r,
     }
 
     /*
-     * markdown_max_size 0 means unlimited — preserve backward-compatible
-     * semantics where a zero value disables the size check entirely.
+     * markdown_max_size 0 means unlimited, but a finite memory_budget still
+     * bounds the full-buffer path.  Use the shared resolver so eligibility
+     * and buffering apply the same precedence for both static and effective
+     * request configuration.
      */
-    if (conf->max_size == 0) {
+    body_limit = ngx_http_markdown_effective_body_buffer_limit(eff, conf);
+    if (body_limit == 0) {
         return 1;
-    }
-
-    body_limit = conf->max_size;
-
-    /*
-     * If the effective memory budget is set (non-zero, non-sentinel)
-     * and is stricter than max_size, use it as the body limit.
-     * A zero memory_budget also means unlimited (no constraint).
-     *
-     * Mirror ngx_http_markdown_effective_body_buffer_limit(): when
-     * eff is NULL fall back to conf->advanced.memory_budget so the
-     * eligibility gate agrees with the buffering path.
-     */
-    {
-        size_t  budget;
-
-        if (eff != NULL) {
-            budget = eff->memory_budget;
-        } else {
-            budget = conf->advanced.memory_budget;
-        }
-
-        if (budget != 0
-            && budget != (size_t) -1
-            && budget < body_limit)
-        {
-            body_limit = budget;
-        }
     }
 
     if ((size_t) content_length > body_limit) {

--- a/components/nginx-module/src/ngx_http_markdown_filter_chain_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_chain_impl.h
@@ -1,0 +1,17 @@
+/*
+ * NGINX Markdown Filter Module - Filter Chain Delegation
+ *
+ * This implementation stays in the main translation unit so it can use the
+ * body filter pointer captured when the module is inserted into the chain.
+ */
+
+#ifndef NGX_HTTP_MARKDOWN_FILTER_CHAIN_IMPL_H
+#define NGX_HTTP_MARKDOWN_FILTER_CHAIN_IMPL_H
+
+ngx_int_t
+ngx_http_markdown_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    return ngx_http_next_body_filter(r, in);
+}
+
+#endif /* NGX_HTTP_MARKDOWN_FILTER_CHAIN_IMPL_H */

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.c
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.c
@@ -15,6 +15,7 @@
 #include "ngx_http_markdown_dynconf_impl.h"
 #include "ngx_http_markdown_otel_impl.h"
 #include "ngx_http_markdown_module_state_impl.h"
+#include "ngx_http_markdown_filter_chain_impl.h"
 #include "ngx_http_markdown_config_impl.h"
 #include "ngx_http_markdown_lifecycle_impl.h"
 #include "ngx_http_markdown_decision_log_impl.h"

--- a/components/nginx-module/src/ngx_http_markdown_filter_module.h
+++ b/components/nginx-module/src/ngx_http_markdown_filter_module.h
@@ -69,6 +69,10 @@ struct ngx_http_markdown_effective_conf_s {
 typedef struct ngx_http_markdown_effective_conf_s
     ngx_http_markdown_effective_conf_t;
 
+/* Delegate body output to the downstream filter saved during module init. */
+ngx_int_t ngx_http_markdown_next_body_filter(ngx_http_request_t *r,
+    ngx_chain_t *in);
+
 /*
  * Forward declaration for OTel span type.
  * Full definition is in ngx_http_markdown_otel_impl.h.
@@ -565,6 +569,10 @@ ngx_http_markdown_effective_body_buffer_limit(
         return conf->max_size;
     }
 
+    if (conf->max_size == 0) {
+        return budget;
+    }
+
     return (budget < conf->max_size) ? budget : conf->max_size;
 }
 
@@ -618,20 +626,28 @@ ngx_http_markdown_merge_stream_values(ngx_http_markdown_conf_t *conf,
  * Holds process-wide shared state that is initialized once during
  * configuration parsing and then reused by all worker processes.
  *
- * dynconf_path_configured and dynconf_first_path track whether a
- * markdown_dynamic_config_path directive has already been set in
- * any configuration context, so duplicate detection lives in
- * config-parse scope (per nginx -t / reload) rather than in a
- * process-lifetime file-scope static variable that survives across
- * reloads.
+ * The dynconf fields track the unique markdown_dynamic_config_path
+ * directive and the location configuration that owns it.  The owner
+ * pointer lets worker startup bind the single global watcher to an
+ * http, server, or location configuration after inheritance merges.
  */
 typedef struct {
     ngx_shm_zone_t *metrics_shm_zone;  /* Shared-memory zone for cross-worker metrics */
     size_t          metrics_shm_size;  /* Configured metrics SHM size (default: 8 pages) */
     ngx_flag_t      dynconf_path_configured; /* 1 after first markdown_dynamic_config_path directive */
     ngx_str_t       dynconf_first_path;      /* Path value from the first directive (for diagnostics) */
+    /* Merged config that owns the unique dynconf path. */
+    ngx_http_markdown_conf_t *dynconf_owner_conf;
     ngx_uint_t      metrics_per_path_cardinality; /* markdown_metrics_per_path_cardinality (default: 100, global) */
 } ngx_http_markdown_main_conf_t;
+
+/* Return the merged config selected to own the per-worker dynconf watcher. */
+static ngx_inline ngx_http_markdown_conf_t *
+ngx_http_markdown_dynconf_owner(
+    const ngx_http_markdown_main_conf_t *main_conf)
+{
+    return main_conf != NULL ? main_conf->dynconf_owner_conf : NULL;
+}
 
 /*
  * Response buffer structure

--- a/components/nginx-module/src/ngx_http_markdown_headers_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_headers_impl.h
@@ -195,6 +195,11 @@ ngx_http_markdown_invalidate_headers_in_part(const ngx_http_request_t *r,
         headers = part->elts;
         i = 0;
         while (i < part->nelts) {
+            if (headers[i].hash == 0) {
+                i++;
+                continue;
+            }
+
             if (headers[i].key.len != name_len
                 || ngx_http_markdown_strncasecmp_const(headers[i].key.data,
                                                        name,

--- a/components/nginx-module/src/ngx_http_markdown_lifecycle_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_lifecycle_impl.h
@@ -55,8 +55,9 @@ ngx_http_markdown_filter_init(ngx_conf_t *cf)
 static ngx_int_t
 ngx_http_markdown_init_worker(ngx_cycle_t *cycle)
 {
-    const ngx_http_conf_ctx_t       *http_ctx;
-    ngx_http_markdown_conf_t  *lcf;
+    const ngx_http_conf_ctx_t              *http_ctx;
+    const ngx_http_markdown_main_conf_t    *mcf;
+    ngx_http_markdown_conf_t               *dynconf_conf;
 
     if (ngx_http_markdown_metrics_shm_zone == NULL
         || ngx_http_markdown_metrics_shm_zone->data == NULL)
@@ -106,13 +107,18 @@ ngx_http_markdown_init_worker(ngx_cycle_t *cycle)
     http_ctx = (const ngx_http_conf_ctx_t *)
         ngx_get_conf(cycle->conf_ctx, ngx_http_module);
     if (http_ctx != NULL) {
-        lcf = (ngx_http_markdown_conf_t *)
-            http_ctx->loc_conf[ngx_http_markdown_filter_module.ctx_index];
-        if (lcf != NULL && lcf->advanced.dynconf_enabled
-            && lcf->advanced.dynconf_path.len > 0
+        mcf = (const ngx_http_markdown_main_conf_t *)
+            http_ctx->main_conf[
+                ngx_http_markdown_filter_module.ctx_index];
+        dynconf_conf = ngx_http_markdown_dynconf_owner(mcf);
+
+        if (dynconf_conf != NULL
+            && dynconf_conf->advanced.dynconf_enabled
+            && dynconf_conf->advanced.dynconf_path.len > 0
             && ngx_http_markdown_dynconf_start(
                    &ngx_http_markdown_dynconf_watcher,
-                   cycle, &lcf->advanced.dynconf_path, lcf, cycle->log)
+                   cycle, &dynconf_conf->advanced.dynconf_path,
+                   dynconf_conf, cycle->log)
                != NGX_OK)
         {
             ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
@@ -126,12 +132,6 @@ ngx_http_markdown_init_worker(ngx_cycle_t *cycle)
          * setting because the SHM metrics struct is process-wide.
          */
         if (ngx_http_markdown_metrics != NULL) {
-            const ngx_http_markdown_main_conf_t  *mcf;
-
-            mcf = (const ngx_http_markdown_main_conf_t *)
-                http_ctx->main_conf[
-                    ngx_http_markdown_filter_module.ctx_index];
-
             if (mcf != NULL)
             {
                 ngx_http_markdown_metrics->per_path.cardinality_limit =

--- a/components/nginx-module/src/ngx_http_markdown_lifecycle_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_lifecycle_impl.h
@@ -131,12 +131,9 @@ ngx_http_markdown_init_worker(ngx_cycle_t *cycle)
          * into the shared metrics struct.  This is a global (http-level)
          * setting because the SHM metrics struct is process-wide.
          */
-        if (ngx_http_markdown_metrics != NULL) {
-            if (mcf != NULL)
-            {
-                ngx_http_markdown_metrics->per_path.cardinality_limit =
-                    mcf->metrics_per_path_cardinality;
-            }
+        if (ngx_http_markdown_metrics != NULL && mcf != NULL) {
+            ngx_http_markdown_metrics->per_path.cardinality_limit =
+                mcf->metrics_per_path_cardinality;
         }
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_payload_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_payload_impl.h
@@ -552,11 +552,15 @@ ngx_http_markdown_handle_buffer_append_failure(ngx_http_request_t *r,
     }
 
     rc = ngx_http_markdown_fail_open_with_buffered_prefix(r, ctx, cl);
-    if (rc != NGX_OK) {
-        return rc;
-    }
 
-    return NGX_DONE;
+    /*
+     * Preserve the downstream result.  The oversized chain may not be the
+     * terminal upstream chain when the response is chunked.  Returning
+     * NGX_DONE after a successful replay would stop later body-filter calls
+     * and truncate the original response.  With eligible cleared, subsequent
+     * chunks take the ordinary pass-through path.
+     */
+    return rc;
 }
 
 /*

--- a/components/nginx-module/src/ngx_http_markdown_stream_error.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_error.c
@@ -191,7 +191,7 @@ ngx_http_markdown_stream_on_error(ngx_http_request_t *r,
  * Steps (pre-commit pass-through HTML replay):
  *   1. Build replay chain from ngx_http_markdown_stream_replay_chain()
  *   2. Restore original Content-Type to text/html
- *   3. Send the replay chain downstream via ngx_http_output_filter()
+ *   3. Send the replay chain via the saved downstream body filter
  *   4. State already transitioned to PASSTHROUGH by decision engine
  *
  * Returns:
@@ -236,7 +236,7 @@ ngx_http_markdown_stream_error_pass_html(ngx_http_request_t *r,
                    ctx->stream_sm.replay_buf.size);
 
     /* Send the replayed HTML downstream */
-    rc = ngx_http_output_filter(r, chain);
+    rc = ngx_http_markdown_next_body_filter(r, chain);
     if (rc == NGX_AGAIN) {
         if (ctx->streaming.pending_output != NULL) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
+++ b/components/nginx-module/src/ngx_http_markdown_stream_postcommit.c
@@ -456,7 +456,7 @@ ngx_http_markdown_stream_postcommit_log(
  * Send a terminal chain (empty last_buf=1) to close the response.
  *
  * Allocates a buffer and chain link from the request pool, sets
- * last_buf=1, and sends via ngx_http_output_filter.  This closes
+ * last_buf=1, and sends via the saved downstream body filter.  This closes
  * the HTTP response without sending any additional content bytes.
  *
  * Returns:
@@ -498,7 +498,7 @@ ngx_http_markdown_stream_postcommit_send_terminal(
     out->buf = b;
     out->next = NULL;
 
-    rc = ngx_http_output_filter(r, out);
+    rc = ngx_http_markdown_next_body_filter(r, out);
 
     if (rc == NGX_AGAIN) {
 #ifdef MARKDOWN_STREAMING_ENABLED
@@ -571,7 +571,7 @@ ngx_http_markdown_stream_postcommit_send_closing(
     out->buf = b;
     out->next = NULL;
 
-    rc = ngx_http_output_filter(r, out);
+    rc = ngx_http_markdown_next_body_filter(r, out);
 
     if (rc == NGX_AGAIN) {
 #ifdef MARKDOWN_STREAMING_ENABLED

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -1057,6 +1057,61 @@ ngx_http_markdown_streaming_decomp_apply_limits(
 
 
 static ngx_int_t
+ngx_http_markdown_streaming_decomp_finish_zlib_expand(
+    ngx_http_markdown_streaming_decomp_t *decomp,
+    u_char **heap_buf_ptr,
+    u_char **buf_ptr,
+    size_t *buf_size_ptr,
+    ngx_flag_t *using_heap_ptr,
+    ngx_log_t *log)
+{
+    size_t   old_size;
+    uInt     expand_out;
+
+    old_size = *buf_size_ptr;
+    if (decomp->max_decompressed_size > 0
+        && old_size >= decomp->max_decompressed_size
+                       - decomp->total_decompressed)
+    {
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
+        return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
+    }
+    /*
+     * expand_buf() frees any previous heap buffer if expansion fails,
+     * so we can safely return directly on NGX_ERROR here.
+     */
+    if (ngx_http_markdown_streaming_decomp_expand_buf(
+            heap_buf_ptr, buf_ptr, buf_size_ptr,
+            decomp->max_decompressed_size > 0
+            ? decomp->max_decompressed_size
+              - decomp->total_decompressed
+            : 0,
+            log)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    *using_heap_ptr = 1;
+    decomp->state.zlib.next_out = *buf_ptr + old_size;
+    if (ngx_http_markdown_streaming_decomp_size_to_uint(
+            *buf_size_ptr - old_size, &expand_out))
+    {
+        ngx_log_error(NGX_LOG_ERR, log, 0,
+            "markdown: "
+            "finish expand %uz exceeds "
+            "zlib uInt max",
+            *buf_size_ptr - old_size);
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
+        return NGX_ERROR;
+    }
+    decomp->state.zlib.avail_out = expand_out;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_markdown_streaming_decomp_finish_zlib(
     ngx_http_markdown_streaming_decomp_t *decomp,
     u_char **buf_ptr,
@@ -1068,6 +1123,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
     u_char      *heap_buf;
     ngx_flag_t   using_heap;
     int          zrc;
+    ngx_int_t    rc;
 
     heap_buf = NULL;
     using_heap = 0;
@@ -1135,53 +1191,11 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
             continue;
         }
 
-        {
-            size_t  old_size;
-
-            old_size = *buf_size_ptr;
-            if (decomp->max_decompressed_size > 0
-                && old_size >= decomp->max_decompressed_size
-                               - decomp->total_decompressed)
-            {
-                ngx_http_markdown_streaming_decomp_free_heap(
-                    &heap_buf);
-                return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
-            }
-            /*
-             * expand_buf() frees any previous heap buffer if expansion fails,
-             * so we can safely return directly on NGX_ERROR here.
-             */
-            if (ngx_http_markdown_streaming_decomp_expand_buf(
-                    &heap_buf, buf_ptr, buf_size_ptr,
-                    decomp->max_decompressed_size > 0
-                    ? decomp->max_decompressed_size
-                      - decomp->total_decompressed
-                    : 0,
-                    log)
-                != NGX_OK)
-            {
-                return NGX_ERROR;
-            }
-
-            using_heap = 1;
-            decomp->state.zlib.next_out = *buf_ptr + old_size;
-            {
-                uInt  expand_out;
-
-                if (ngx_http_markdown_streaming_decomp_size_to_uint(
-                        *buf_size_ptr - old_size, &expand_out))
-                {
-                    ngx_log_error(NGX_LOG_ERR, log, 0,
-                        "markdown: "
-                        "finish expand %uz exceeds "
-                        "zlib uInt max",
-                        *buf_size_ptr - old_size);
-                    ngx_http_markdown_streaming_decomp_free_heap(
-                        &heap_buf);
-                    return NGX_ERROR;
-                }
-                decomp->state.zlib.avail_out = expand_out;
-            }
+        rc = ngx_http_markdown_streaming_decomp_finish_zlib_expand(
+                 decomp, &heap_buf, buf_ptr, buf_size_ptr,
+                 &using_heap, log);
+        if (rc != NGX_OK) {
+            return rc;
         }
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -991,8 +991,12 @@ ngx_http_markdown_streaming_decomp_feed(
 
     /*
      * Post-decode size validation: check for overflow and budget limits.
-     * Returns NGX_OK on success, or the appropriate error code after
-     * freeing the heap buffer. On success, total_decompressed is updated.
+     * Returns NGX_OK on success, or the appropriate error code.
+     * On success, total_decompressed is updated.
+     *
+     * Ownership: the decode loop's finalize_buf() has already transferred
+     * the heap workspace to pool memory. apply_limits() validates only
+     * and does not free the buffer — pool reclaim handles its lifetime.
      */
     {
         ngx_int_t  limit_rc;
@@ -1013,8 +1017,15 @@ ngx_http_markdown_streaming_decomp_feed(
 /*
  * Validate decompressed size against overflow and budget limits after
  * a decode pass. On success, updates decomp->total_decompressed and
- * returns NGX_OK. On failure, frees the heap buffer and returns the
- * appropriate error code (NGX_ERROR or NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED).
+ * returns NGX_OK. On failure, returns the appropriate error code
+ * (NGX_ERROR or NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED) without
+ * freeing the buffer.
+ *
+ * Ownership note: when called from ngx_http_markdown_streaming_decomp_feed,
+ * the decode loop has already called finalize_buf() which transferred
+ * the heap workspace to pool memory. The buffer at *buf_ptr is
+ * therefore pool-allocated and must NOT be freed here — the pool
+ * reclaim handles its lifetime.
  */
 static ngx_int_t
 ngx_http_markdown_streaming_decomp_apply_limits(
@@ -1023,18 +1034,14 @@ ngx_http_markdown_streaming_decomp_apply_limits(
     u_char **buf_ptr,
     ngx_log_t *log)
 {
+    (void) buf_ptr;
+
     if (decomp->total_decompressed > NGX_MAX_SIZE_T_VALUE - produced) {
         ngx_log_error(NGX_LOG_WARN, log, 0,
             "markdown: "
             "decompressed size overflow, total=%uz produced=%uz",
             decomp->total_decompressed,
             produced);
-        /*
-         * buf holds a freshly allocated heap buffer that the decode
-         * loop did not transfer to pool memory on this error path;
-         * release it and keep the output slots cleared.
-         */
-        ngx_http_markdown_streaming_decomp_free_heap(buf_ptr);
         return NGX_ERROR;
     }
 
@@ -1048,7 +1055,6 @@ ngx_http_markdown_streaming_decomp_apply_limits(
             "decompressed size %uz exceeds limit %uz",
             decomp->total_decompressed,
             decomp->max_decompressed_size);
-        ngx_http_markdown_streaming_decomp_free_heap(buf_ptr);
         return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -854,6 +854,12 @@ ngx_http_markdown_streaming_decomp_feed_case_brotli(
  *   NGX_ERROR    - decompression error or size limit exceeded
  *   NGX_DECLINED - unsupported format
  */
+static ngx_int_t ngx_http_markdown_streaming_decomp_apply_limits(
+    ngx_http_markdown_streaming_decomp_t *decomp,
+    size_t produced,
+    u_char **buf_ptr,
+    ngx_log_t *log);
+
 static ngx_int_t
 ngx_http_markdown_streaming_decomp_feed(
     ngx_http_markdown_streaming_decomp_t *decomp,

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -1257,7 +1257,7 @@ ngx_http_markdown_streaming_decomp_finish(
     }
 
     buf_size = 4096;
-    buf = ngx_palloc(pool, buf_size);
+    buf = ngx_alloc(buf_size, log);
     if (buf == NULL) {
         return NGX_ERROR;
     }

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -1131,8 +1131,15 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
     int          zrc;
     ngx_int_t    rc;
 
-    heap_buf = NULL;
-    using_heap = 0;
+    /*
+     * Track the caller-supplied buffer (allocated via ngx_alloc in
+     * finish()) as the initial heap workspace.  This ensures
+     * finalize_buf() always transfers produced bytes to pool memory
+     * and releases the heap allocation, regardless of whether
+     * expansion occurred.
+     */
+    heap_buf = *buf_ptr;
+    using_heap = 1;
 
     decomp->state.zlib.next_in = Z_NULL;
     decomp->state.zlib.avail_in = 0;
@@ -1144,6 +1151,8 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
             "markdown: "
             "finish buffer %uz exceeds zlib uInt max",
             *buf_size_ptr);
+        ngx_http_markdown_streaming_decomp_free_heap(&heap_buf);
+        *buf_ptr = NULL;
         return NGX_ERROR;
     }
 
@@ -1158,6 +1167,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                 "finish inflate error %d", zrc);
             ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
+            *buf_ptr = NULL;
             return NGX_ERROR;
         }
 
@@ -1174,6 +1184,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                 decomp->max_decompressed_size);
             ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
+            *buf_ptr = NULL;
             return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
         }
 
@@ -1190,6 +1201,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                 "finish inflate incomplete stream");
             ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
+            *buf_ptr = NULL;
             return NGX_ERROR;
         }
 
@@ -1201,19 +1213,23 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                  decomp, &heap_buf, buf_ptr, buf_size_ptr,
                  &using_heap, log);
         if (rc != NGX_OK) {
+            *buf_ptr = NULL;
             return rc;
         }
     }
 
-    if (!using_heap) {
-        return NGX_OK;
-    }
-
+    /*
+     * Always finalize: transfer produced bytes to pool memory (or
+     * free the heap buffer if nothing was produced).  This guarantees
+     * the caller receives either a pool-owned buffer or NULL/0, never
+     * a leaked raw heap pointer.
+     */
     if (ngx_http_markdown_streaming_decomp_finalize_buf(
             &heap_buf, buf_ptr, buf_size_ptr,
             *produced_ptr, pool)
         != NGX_OK)
     {
+        *buf_ptr = NULL;
         return NGX_ERROR;
     }
 
@@ -1224,12 +1240,20 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
 /*
  * Finish decompression (handle last_buf).
  *
+ * Allocates a transient heap workspace via ngx_alloc, then delegates to
+ * the format-specific finish path.  On success the workspace is either
+ * transferred to pool memory (via finalize_buf) or freed when no output
+ * is produced; the caller always receives a pool-owned buffer or
+ * NULL/0, never a raw heap pointer.
+ *
  * For zlib, flushes remaining data with Z_FINISH.
- * For brotli, checks stream completeness.
+ * For brotli, checks stream completeness (no tail output).
+ *
+ * All error paths free the heap workspace before returning.
  *
  * Returns:
- *   NGX_OK    - success
- *   NGX_ERROR - decompression error
+ *   NGX_OK    - success (*out_data is pool-owned or NULL)
+ *   NGX_ERROR - decompression error (heap workspace freed)
  */
 static ngx_int_t
 ngx_http_markdown_streaming_decomp_finish(
@@ -1276,6 +1300,11 @@ ngx_http_markdown_streaming_decomp_finish(
                 decomp, &buf, &buf_size,
                 &produced, pool, log);
         if (finish_rc != NGX_OK) {
+            /*
+             * finish_zlib frees the heap buffer on all error paths
+             * and clears *buf_ptr, so buf is already NULL here.
+             */
+            buf = NULL;
             return finish_rc;
         }
         break;
@@ -1289,13 +1318,24 @@ ngx_http_markdown_streaming_decomp_finish(
             ngx_log_error(NGX_LOG_WARN, log, 0,
                 "markdown: "
                 "brotli stream not finished");
+            ngx_free(buf);
+            buf = NULL;
             return NGX_ERROR;
         }
         decomp->finished = 1;
+        /*
+         * Brotli finish produces no tail output; free the heap
+         * workspace and return NULL/0 to the caller.
+         */
+        ngx_free(buf);
+        buf = NULL;
+        produced = 0;
         break;
 #endif
 
     default:
+        ngx_free(buf);
+        buf = NULL;
         return NGX_ERROR;
     }
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -280,6 +280,24 @@ ngx_http_markdown_streaming_decomp_check_limit(
 
 
 /*
+ * Free a heap-allocated buffer through a pointer-to-pointer,
+ * guarding against NULL pointer and setting the pointer to NULL
+ * after release to prevent dangling references.
+ *
+ * Used consistently across inflate, brotli, feed, and finish
+ * paths to enforce a single defensive free pattern.
+ */
+static void
+ngx_http_markdown_streaming_decomp_free_heap(u_char **heap_buf_ptr)
+{
+    if (heap_buf_ptr != NULL && *heap_buf_ptr != NULL) {
+        ngx_free(*heap_buf_ptr);
+        *heap_buf_ptr = NULL;
+    }
+}
+
+
+/*
  * Expand a heap-backed working buffer to double its size.
  *
  * On success, *heap_buf_ptr is updated to the new allocation
@@ -310,10 +328,7 @@ ngx_http_markdown_streaming_decomp_expand_buf(
             "markdown: "
             "expand_buf size overflow, old_size=%uz",
             old_size);
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-            *heap_buf_ptr = NULL;
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return NGX_ERROR;
     }
 
@@ -324,18 +339,13 @@ ngx_http_markdown_streaming_decomp_expand_buf(
 
     new_buf = ngx_alloc(new_size, log);
     if (new_buf == NULL) {
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-            *heap_buf_ptr = NULL;
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return NGX_ERROR;
     }
 
     ngx_memcpy(new_buf, *buf_ptr, old_size);
 
-    if (*heap_buf_ptr != NULL) {
-        ngx_free(*heap_buf_ptr);
-    }
+    ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
 
     *heap_buf_ptr = new_buf;
     *buf_ptr = new_buf;
@@ -415,9 +425,7 @@ ngx_http_markdown_streaming_decomp_inflate_step(
         ngx_log_error(NGX_LOG_ERR, log, 0,
             "markdown: "
             "inflate error %d", zrc);
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return -1;
     }
 
@@ -432,9 +440,7 @@ ngx_http_markdown_streaming_decomp_inflate_step(
             "decompressed size %uz exceeds limit %uz",
             decomp->total_decompressed + *out_produced,
             decomp->max_decompressed_size);
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return -2;  /* budget exceeded */
     }
 
@@ -455,8 +461,7 @@ ngx_http_markdown_streaming_decomp_inflate_step(
             remaining = decomp->max_decompressed_size
                         - decomp->total_decompressed;
             if (*buf_size_ptr >= remaining) {
-                ngx_free(*heap_buf_ptr);
-                *heap_buf_ptr = NULL;
+                ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
                 return -2;
             }
         }
@@ -483,9 +488,7 @@ ngx_http_markdown_streaming_decomp_inflate_step(
                     "expanded buffer half %uz exceeds "
                     "zlib uInt max",
                     *buf_size_ptr / 2);
-                if (*heap_buf_ptr != NULL) {
-                    ngx_free(*heap_buf_ptr);
-                }
+                ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
                 return -1;
             }
             decomp->state.zlib.avail_out = half_out;
@@ -612,9 +615,7 @@ ngx_http_markdown_streaming_decomp_brotli_step(
         ngx_log_error(NGX_LOG_ERR, log, 0,
             "markdown: "
             "brotli decode error");
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return -1;
     }
 
@@ -628,9 +629,7 @@ ngx_http_markdown_streaming_decomp_brotli_step(
             "decompressed size %uz exceeds limit %uz",
             decomp->total_decompressed + *out_produced,
             decomp->max_decompressed_size);
-        if (*heap_buf_ptr != NULL) {
-            ngx_free(*heap_buf_ptr);
-        }
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return -2;  /* budget exceeded */
     }
 
@@ -649,8 +648,7 @@ ngx_http_markdown_streaming_decomp_brotli_step(
             remaining = decomp->max_decompressed_size
                         - decomp->total_decompressed;
             if (old_size >= remaining) {
-                ngx_free(*heap_buf_ptr);
-                *heap_buf_ptr = NULL;
+                ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
                 return -2;
             }
         }
@@ -763,8 +761,7 @@ ngx_http_markdown_streaming_decomp_feed_zlib(
             "markdown: "
             "buffer size %uz exceeds zlib uInt max",
             *buf_size_ptr);
-        ngx_free(*buf_ptr);
-        *buf_ptr = NULL;
+        ngx_http_markdown_streaming_decomp_free_heap(buf_ptr);
         return NGX_ERROR;
     }
 
@@ -801,8 +798,7 @@ ngx_http_markdown_streaming_decomp_feed_case_zlib(
             "markdown: "
             "input length %uz exceeds zlib uInt max",
             in_len);
-        ngx_free(*ctx->buf_ptr);
-        *ctx->buf_ptr = NULL;
+        ngx_http_markdown_streaming_decomp_free_heap(ctx->buf_ptr);
         return NGX_ERROR;
     }
 
@@ -953,6 +949,7 @@ ngx_http_markdown_streaming_decomp_feed(
 
     default:
         ngx_free(buf);
+        buf = NULL;
         return NGX_DECLINED;
     }
 
@@ -982,17 +979,6 @@ ngx_http_markdown_streaming_decomp_feed(
     *out_data = buf;
     *out_len = produced;
     return NGX_OK;
-}
-
-
-static void
-ngx_http_markdown_streaming_decomp_finish_free_heap(
-    u_char **heap_buf_ptr)
-{
-    if (*heap_buf_ptr != NULL) {
-        ngx_free(*heap_buf_ptr);
-        *heap_buf_ptr = NULL;
-    }
 }
 
 
@@ -1034,7 +1020,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
             ngx_log_error(NGX_LOG_ERR, log, 0,
                 "markdown: "
                 "finish inflate error %d", zrc);
-            ngx_http_markdown_streaming_decomp_finish_free_heap(
+            ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
             return NGX_ERROR;
         }
@@ -1050,7 +1036,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                 "decompressed size %uz exceeds limit %uz",
                 decomp->total_decompressed + *produced_ptr,
                 decomp->max_decompressed_size);
-            ngx_http_markdown_streaming_decomp_finish_free_heap(
+            ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
             return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
         }
@@ -1066,7 +1052,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
             ngx_log_error(NGX_LOG_ERR, log, 0,
                 "markdown: "
                 "finish inflate incomplete stream");
-            ngx_http_markdown_streaming_decomp_finish_free_heap(
+            ngx_http_markdown_streaming_decomp_free_heap(
                 &heap_buf);
             return NGX_ERROR;
         }
@@ -1083,7 +1069,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                 && old_size >= decomp->max_decompressed_size
                                - decomp->total_decompressed)
             {
-                ngx_http_markdown_streaming_decomp_finish_free_heap(
+                ngx_http_markdown_streaming_decomp_free_heap(
                     &heap_buf);
                 return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
             }
@@ -1116,7 +1102,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
                         "finish expand %uz exceeds "
                         "zlib uInt max",
                         *buf_size_ptr - old_size);
-                    ngx_http_markdown_streaming_decomp_finish_free_heap(
+                    ngx_http_markdown_streaming_decomp_free_heap(
                         &heap_buf);
                     return NGX_ERROR;
                 }

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -357,13 +357,19 @@ ngx_http_markdown_streaming_decomp_expand_buf(
 /*
  * Copy heap working buffer back to pool memory and free it.
  *
+ * Takes the heap buffer by pointer-to-pointer so the release path
+ * stays consistent with free_heap/expand_buf: on every exit the
+ * heap allocation is released and *heap_buf_ptr is cleared, which
+ * prevents callers from accidentally double-freeing or leaking the
+ * old workspace.
+ *
  * Returns:
  *   NGX_OK    - success (*buf_ptr updated to pool allocation)
  *   NGX_ERROR - pool allocation failure (heap buffer freed)
  */
 static ngx_int_t
 ngx_http_markdown_streaming_decomp_finalize_buf(
-    u_char *heap_buf,
+    u_char **heap_buf_ptr,
     u_char **buf_ptr,
     size_t *buf_size_ptr,
     size_t produced,
@@ -372,7 +378,7 @@ ngx_http_markdown_streaming_decomp_finalize_buf(
     u_char  *pool_buf;
 
     if (produced == 0) {
-        ngx_free(heap_buf);
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         *buf_ptr = NULL;
         *buf_size_ptr = 0;
         return NGX_OK;
@@ -380,12 +386,17 @@ ngx_http_markdown_streaming_decomp_finalize_buf(
 
     pool_buf = ngx_palloc(pool, produced);
     if (pool_buf == NULL) {
-        ngx_free(heap_buf);
+        ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
         return NGX_ERROR;
     }
 
-    ngx_memcpy(pool_buf, heap_buf, produced);
-    ngx_free(heap_buf);
+    /*
+     * free_heap() performs NULL-guarded release; safe to dereference
+     * *heap_buf_ptr for the copy because produced > 0 here implies
+     * heap_buf_ptr is non-NULL and non-empty.
+     */
+    ngx_memcpy(pool_buf, *heap_buf_ptr, produced);
+    ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
 
     *buf_ptr = pool_buf;
     *buf_size_ptr = produced;
@@ -455,6 +466,7 @@ ngx_http_markdown_streaming_decomp_inflate_step(
 
     if (decomp->state.zlib.avail_out == 0) {
         size_t  remaining;
+        size_t  old_size;
 
         remaining = 0;
         if (decomp->max_decompressed_size > 0) {
@@ -466,6 +478,8 @@ ngx_http_markdown_streaming_decomp_inflate_step(
             }
         }
 
+        old_size = *buf_size_ptr;
+
         if (ngx_http_markdown_streaming_decomp_expand_buf(
                 heap_buf_ptr, buf_ptr, buf_size_ptr, remaining, log)
             != NGX_OK)
@@ -475,23 +489,27 @@ ngx_http_markdown_streaming_decomp_inflate_step(
 
         *using_heap_ptr = 1;
 
-        decomp->state.zlib.next_out =
-            *buf_ptr + (*buf_size_ptr / 2);
+        /*
+         * Expansion may cap growth at max_size, so resume at the old
+         * end (already-produced bytes remain intact at [0, old_size))
+         * and expose the actually-available space as avail_out.
+         */
+        decomp->state.zlib.next_out = *buf_ptr + old_size;
         {
-            uInt  half_out;
+            uInt  avail_out;
 
             if (ngx_http_markdown_streaming_decomp_size_to_uint(
-                    *buf_size_ptr / 2, &half_out))
+                    *buf_size_ptr - old_size, &avail_out))
             {
                 ngx_log_error(NGX_LOG_ERR, log, 0,
                     "markdown: "
-                    "expanded buffer half %uz exceeds "
+                    "expanded buffer free space %uz exceeds "
                     "zlib uInt max",
-                    *buf_size_ptr / 2);
+                    *buf_size_ptr - old_size);
                 ngx_http_markdown_streaming_decomp_free_heap(heap_buf_ptr);
                 return -1;
             }
-            decomp->state.zlib.avail_out = half_out;
+            decomp->state.zlib.avail_out = avail_out;
         }
     }
 
@@ -547,7 +565,7 @@ ngx_http_markdown_streaming_decomp_inflate_loop(
 
     if (using_heap
         && ngx_http_markdown_streaming_decomp_finalize_buf(
-               heap_buf, buf_ptr, buf_size_ptr,
+               &heap_buf, buf_ptr, buf_size_ptr,
                *out_produced, pool)
            != NGX_OK)
     {
@@ -719,7 +737,7 @@ ngx_http_markdown_streaming_decomp_brotli_loop(
 
     if (using_heap) {
         if (ngx_http_markdown_streaming_decomp_finalize_buf(
-                heap_buf, buf_ptr, buf_size_ptr,
+                &heap_buf, buf_ptr, buf_size_ptr,
                 *out_produced, pool)
             != NGX_OK)
         {
@@ -857,16 +875,21 @@ ngx_http_markdown_streaming_decomp_feed(
         return NGX_ERROR;
     }
 
+    /*
+     * Defensive baseline: clear the caller-facing output slots before
+     * any work begins so every error path (including the budget/alloc
+     * early returns below) is guaranteed to emit empty output and never
+     * leak stale caller-supplied values.
+     */
+    *out_data = NULL;
+    *out_len = 0;
+
     if (decomp->finished) {
-        *out_data = NULL;
-        *out_len = 0;
         return NGX_OK;
     }
 
     /* Empty input is a no-op */
     if (in_data == NULL || in_len == 0) {
-        *out_data = NULL;
-        *out_len = 0;
         return NGX_OK;
     }
 
@@ -887,7 +910,7 @@ ngx_http_markdown_streaming_decomp_feed(
         if (decomp->total_decompressed
             >= decomp->max_decompressed_size)
         {
-            /* Budget already exhausted */
+            /* Budget already exhausted; output already cleared above */
             return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
         }
 
@@ -906,6 +929,7 @@ ngx_http_markdown_streaming_decomp_feed(
      */
     buf = ngx_alloc(buf_size, log);
     if (buf == NULL) {
+        /* output already cleared above */
         return NGX_ERROR;
     }
 
@@ -926,6 +950,11 @@ ngx_http_markdown_streaming_decomp_feed(
         inflate_rc = ngx_http_markdown_streaming_decomp_feed_case_zlib(
             decomp, in_data, in_len, &feed_ctx);
         if (inflate_rc != NGX_OK) {
+            /*
+             * The inflate loop frees the heap workspace on error via
+             * free_heap; output slots already hold NULL/0 from the
+             * defensive baseline, so no additional cleanup here.
+             */
             return inflate_rc;
         }
 
@@ -940,6 +969,7 @@ ngx_http_markdown_streaming_decomp_feed(
         brotli_rc = ngx_http_markdown_streaming_decomp_feed_case_brotli(
             decomp, in_data, in_len, &feed_ctx);
         if (brotli_rc != NGX_OK) {
+            /* Same invariant as the zlib path above. */
             return brotli_rc;
         }
 
@@ -953,13 +983,52 @@ ngx_http_markdown_streaming_decomp_feed(
         return NGX_DECLINED;
     }
 
-    /* Check size limit and protect against integer overflow. */
+    /*
+     * Post-decode size validation: check for overflow and budget limits.
+     * Returns NGX_OK on success, or the appropriate error code after
+     * freeing the heap buffer. On success, total_decompressed is updated.
+     */
+    {
+        ngx_int_t  limit_rc;
+
+        limit_rc = ngx_http_markdown_streaming_decomp_apply_limits(
+            decomp, produced, &buf, log);
+        if (limit_rc != NGX_OK) {
+            return limit_rc;
+        }
+    }
+
+    *out_data = buf;
+    *out_len = produced;
+    return NGX_OK;
+}
+
+
+/*
+ * Validate decompressed size against overflow and budget limits after
+ * a decode pass. On success, updates decomp->total_decompressed and
+ * returns NGX_OK. On failure, frees the heap buffer and returns the
+ * appropriate error code (NGX_ERROR or NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED).
+ */
+static ngx_int_t
+ngx_http_markdown_streaming_decomp_apply_limits(
+    ngx_http_markdown_streaming_decomp_t *decomp,
+    size_t produced,
+    u_char **buf_ptr,
+    ngx_log_t *log)
+{
     if (decomp->total_decompressed > NGX_MAX_SIZE_T_VALUE - produced) {
         ngx_log_error(NGX_LOG_WARN, log, 0,
             "markdown: "
             "decompressed size overflow, total=%uz produced=%uz",
             decomp->total_decompressed,
             produced);
+        /*
+         * buf holds a freshly allocated heap buffer that the decode
+         * loop did not transfer to pool memory on this error path;
+         * release it and keep the output slots cleared.
+         */
+        ngx_http_markdown_streaming_decomp_free_heap(buf_ptr);
         return NGX_ERROR;
     }
 
@@ -973,11 +1042,10 @@ ngx_http_markdown_streaming_decomp_feed(
             "decompressed size %uz exceeds limit %uz",
             decomp->total_decompressed,
             decomp->max_decompressed_size);
+        ngx_http_markdown_streaming_decomp_free_heap(buf_ptr);
         return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
     }
 
-    *out_data = buf;
-    *out_len = produced;
     return NGX_OK;
 }
 
@@ -1116,7 +1184,7 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
     }
 
     if (ngx_http_markdown_streaming_decomp_finalize_buf(
-            heap_buf, buf_ptr, buf_size_ptr,
+            &heap_buf, buf_ptr, buf_size_ptr,
             *produced_ptr, pool)
         != NGX_OK)
     {

--- a/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_decomp_impl.h
@@ -295,6 +295,7 @@ ngx_http_markdown_streaming_decomp_expand_buf(
     u_char **heap_buf_ptr,
     u_char **buf_ptr,
     size_t *buf_size_ptr,
+    size_t max_size,
     ngx_log_t *log)
 {
     u_char  *new_buf;
@@ -317,6 +318,9 @@ ngx_http_markdown_streaming_decomp_expand_buf(
     }
 
     new_size = old_size * 2;
+    if (max_size > 0 && new_size > max_size) {
+        new_size = max_size;
+    }
 
     new_buf = ngx_alloc(new_size, log);
     if (new_buf == NULL) {
@@ -356,6 +360,13 @@ ngx_http_markdown_streaming_decomp_finalize_buf(
     ngx_pool_t *pool)
 {
     u_char  *pool_buf;
+
+    if (produced == 0) {
+        ngx_free(heap_buf);
+        *buf_ptr = NULL;
+        *buf_size_ptr = 0;
+        return NGX_OK;
+    }
 
     pool_buf = ngx_palloc(pool, produced);
     if (pool_buf == NULL) {
@@ -437,8 +448,21 @@ ngx_http_markdown_streaming_decomp_inflate_step(
     }
 
     if (decomp->state.zlib.avail_out == 0) {
+        size_t  remaining;
+
+        remaining = 0;
+        if (decomp->max_decompressed_size > 0) {
+            remaining = decomp->max_decompressed_size
+                        - decomp->total_decompressed;
+            if (*buf_size_ptr >= remaining) {
+                ngx_free(*heap_buf_ptr);
+                *heap_buf_ptr = NULL;
+                return -2;
+            }
+        }
+
         if (ngx_http_markdown_streaming_decomp_expand_buf(
-                heap_buf_ptr, buf_ptr, buf_size_ptr, log)
+                heap_buf_ptr, buf_ptr, buf_size_ptr, remaining, log)
             != NGX_OK)
         {
             return -1;
@@ -495,8 +519,8 @@ ngx_http_markdown_streaming_decomp_inflate_loop(
     int      using_heap;
     int      step_rc;
 
-    heap_buf = NULL;
-    using_heap = 0;
+    heap_buf = *buf_ptr;
+    using_heap = 1;
 
     for ( ;; ) {
         step_rc =
@@ -617,11 +641,22 @@ ngx_http_markdown_streaming_decomp_brotli_step(
 
     if (brc == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
         size_t  old_size;
+        size_t  remaining;
 
         old_size = *buf_size_ptr;
+        remaining = 0;
+        if (decomp->max_decompressed_size > 0) {
+            remaining = decomp->max_decompressed_size
+                        - decomp->total_decompressed;
+            if (old_size >= remaining) {
+                ngx_free(*heap_buf_ptr);
+                *heap_buf_ptr = NULL;
+                return -2;
+            }
+        }
 
         if (ngx_http_markdown_streaming_decomp_expand_buf(
-                heap_buf_ptr, buf_ptr, buf_size_ptr, log)
+                heap_buf_ptr, buf_ptr, buf_size_ptr, remaining, log)
             != NGX_OK)
         {
             return -1;
@@ -660,8 +695,8 @@ ngx_http_markdown_streaming_decomp_brotli_loop(
 
     decomp->brotli_avail_out = *buf_size_ptr;
     decomp->brotli_next_out = *buf_ptr;
-    heap_buf = NULL;
-    using_heap = 0;
+    heap_buf = *buf_ptr;
+    using_heap = 1;
 
     for ( ;; ) {
         step_rc =
@@ -728,6 +763,8 @@ ngx_http_markdown_streaming_decomp_feed_zlib(
             "markdown: "
             "buffer size %uz exceeds zlib uInt max",
             *buf_size_ptr);
+        ngx_free(*buf_ptr);
+        *buf_ptr = NULL;
         return NGX_ERROR;
     }
 
@@ -764,6 +801,8 @@ ngx_http_markdown_streaming_decomp_feed_case_zlib(
             "markdown: "
             "input length %uz exceeds zlib uInt max",
             in_len);
+        ngx_free(*ctx->buf_ptr);
+        *ctx->buf_ptr = NULL;
         return NGX_ERROR;
     }
 
@@ -835,7 +874,7 @@ ngx_http_markdown_streaming_decomp_feed(
         return NGX_OK;
     }
 
-    /* Estimate output buffer: 4x input or 4KB minimum */
+    /* Estimate transient output workspace: 4x input or 4KB minimum. */
     if (in_len > (size_t) -1 / 4) {
         buf_size = (size_t) -1;  /* saturate to max */
     } else {
@@ -859,11 +898,17 @@ ngx_http_markdown_streaming_decomp_feed(
         remaining = decomp->max_decompressed_size
                     - decomp->total_decompressed;
         if (buf_size > remaining) {
-            buf_size = remaining + 1;
+            buf_size = remaining;
         }
     }
 
-    buf = ngx_palloc(pool, buf_size);
+    /*
+     * The workspace must be reclaimable after every compressed chunk.
+     * Request-pool allocations cannot be individually freed, so reserving
+     * the 4 KiB estimate there amplifies tiny chunks for the request lifetime.
+     * The decode loops transfer only produced bytes into pool memory.
+     */
+    buf = ngx_alloc(buf_size, log);
     if (buf == NULL) {
         return NGX_ERROR;
     }
@@ -907,6 +952,7 @@ ngx_http_markdown_streaming_decomp_feed(
 #endif
 
     default:
+        ngx_free(buf);
         return NGX_DECLINED;
     }
 
@@ -1033,12 +1079,25 @@ ngx_http_markdown_streaming_decomp_finish_zlib(
             size_t  old_size;
 
             old_size = *buf_size_ptr;
+            if (decomp->max_decompressed_size > 0
+                && old_size >= decomp->max_decompressed_size
+                               - decomp->total_decompressed)
+            {
+                ngx_http_markdown_streaming_decomp_finish_free_heap(
+                    &heap_buf);
+                return NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED;
+            }
             /*
              * expand_buf() frees any previous heap buffer if expansion fails,
              * so we can safely return directly on NGX_ERROR here.
              */
             if (ngx_http_markdown_streaming_decomp_expand_buf(
-                    &heap_buf, buf_ptr, buf_size_ptr, log)
+                    &heap_buf, buf_ptr, buf_size_ptr,
+                    decomp->max_decompressed_size > 0
+                    ? decomp->max_decompressed_size
+                      - decomp->total_decompressed
+                    : 0,
+                    log)
                 != NGX_OK)
             {
                 return NGX_ERROR;
@@ -1150,6 +1209,7 @@ ngx_http_markdown_streaming_decomp_finish(
             ngx_log_error(NGX_LOG_WARN, log, 0,
                 "markdown: "
                 "brotli stream not finished");
+            return NGX_ERROR;
         }
         decomp->finished = 1;
         break;

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -1104,7 +1104,7 @@ ngx_http_markdown_streaming_resume_pending(
     ngx_http_markdown_ctx_t *ctx,
     const ngx_http_markdown_conf_t *conf)
 {
-    ngx_chain_t  *out;
+    const ngx_chain_t  *out;
     ngx_int_t     rc;
     ngx_flag_t    pending_last_buf;
 

--- a/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
+++ b/components/nginx-module/src/ngx_http_markdown_streaming_impl.h
@@ -229,7 +229,9 @@ ngx_http_markdown_streaming_handle_backpressure(
 /*
  * Resume sending pending output after backpressure clears.
  *
- * Retries the buffered chain via ngx_http_next_body_filter.
+ * Drains the chain retained by the downstream filter by calling
+ * ngx_http_next_body_filter with NULL.  pending_output remains a
+ * request-lifetime anchor and state latch; it is never resubmitted.
  * On success, records deferred TTFB and terminal metrics if
  * applicable, then sends any deferred last_buf. Clears the
  * NGX_HTTP_MARKDOWN_BUFFERED flag when the pending chain
@@ -1123,7 +1125,6 @@ ngx_http_markdown_streaming_resume_pending(
         return NGX_OK;
     }
 
-    ctx->streaming.pending_output = NULL;
     /*
      * Capture last_buf before calling the downstream filter: once
      * the chain is consumed the buf metadata may be modified by
@@ -1132,17 +1133,18 @@ ngx_http_markdown_streaming_resume_pending(
     pending_last_buf = (out->buf != NULL && out->buf->last_buf
                         && r == r->main) ? 1 : 0;
     /*
-     * Retry the exact buffered chain first; only after it drains do we
-     * allow finalize() to emit a terminal empty last_buf.
+     * The downstream filter retained the original chain when it returned
+     * NGX_AGAIN.  Resume that owned state with NULL; resubmitting out would
+     * duplicate its unsent tail (Rule 1).
      */
-    rc = ngx_http_next_body_filter(r, out);
+    rc = ngx_http_next_body_filter(r, NULL);
 
     if (rc == NGX_AGAIN) {
-        ctx->streaming.pending_output = out;
         r->buffered |= NGX_HTTP_MARKDOWN_BUFFERED;
         return NGX_AGAIN;
     }
 
+    ctx->streaming.pending_output = NULL;
     r->buffered &= ~NGX_HTTP_MARKDOWN_BUFFERED;
 
     /*

--- a/components/nginx-module/tests/unit/auth_production_test.c
+++ b/components/nginx-module/tests/unit/auth_production_test.c
@@ -808,6 +808,32 @@ test_modify_cc_append_private(void)
     TEST_PASS("private appended to no-cache");
 }
 
+static void
+test_modify_cc_ignores_invalidated_no_store(void)
+{
+    ngx_http_request_t *r;
+    ngx_table_elt_t    *active;
+    ngx_int_t           rc;
+
+    reset_pool();
+    r = make_req();
+    if (r == NULL) { TEST_FAIL("alloc failed"); return; }
+
+    add_header(&r->headers_out.headers, "Cache-Control", "no-store", 0);
+    active = add_header(&r->headers_out.headers,
+                        "Cache-Control", "public", 1);
+
+    rc = ngx_http_markdown_modify_cache_control_for_auth(r);
+
+    TEST_ASSERT(rc == NGX_OK, "invalidated no-store is ignored");
+    TEST_ASSERT(active != NULL && active->hash == 1,
+                "active Cache-Control remains active");
+    TEST_ASSERT(ngx_http_markdown_cache_control_has_directive(
+                    &active->value, &ngx_http_markdown_private_directive),
+                "active public Cache-Control is rewritten private");
+    TEST_PASS("invalidated no-store cannot bypass private cache policy");
+}
+
 /* ── get_auth_patterns ───────────────────────────────────────── */
 
 static void
@@ -899,6 +925,7 @@ main(void)
     test_modify_cc_public_mixed();
     test_modify_cc_already_private();
     test_modify_cc_append_private();
+    test_modify_cc_ignores_invalidated_no_store();
 
     test_get_auth_patterns_null_conf();
     test_get_auth_patterns_empty_conf();

--- a/components/nginx-module/tests/unit/conditional_production_test.c
+++ b/components/nginx-module/tests/unit/conditional_production_test.c
@@ -52,6 +52,13 @@ struct MarkdownConverterHandle { int dummy; };
     do { (void)(level); (void)(log); (void)(err);               \
          (void)(arg1); } while (0)
 
+#ifdef ngx_log_debug2
+#undef ngx_log_debug2
+#endif
+#define ngx_log_debug2(level, log, err, fmt, arg1, arg2)        \
+    do { (void)(level); (void)(log); (void)(err);               \
+         (void)(arg1); (void)(arg2); } while (0)
+
 #ifdef ngx_log_error
 #undef ngx_log_error
 #endif
@@ -59,6 +66,10 @@ struct MarkdownConverterHandle { int dummy; };
     do { (void)(level); (void)(log); (void)(err); } while (0)
 
 #define ngx_memcpy(dst, src, n)    memcpy(dst, src, n)
+#define ngx_cpymem(dst, src, n)    (((u_char *) memcpy(dst, src, (n))) + (n))
+#define ngx_strncmp(s1, s2, n)     strncmp((const char *) (s1), \
+                                            (const char *) (s2), (n))
+#define ngx_null_string            { 0, NULL }
 #define ngx_pfree(pool, p)         do { (void)(pool); (void)(p); } while (0)
 #define ngx_str_set(str, text)                                          \
     (str)->len = sizeof(text) - 1; (str)->data = (u_char *) text
@@ -71,9 +82,17 @@ struct ngx_pool_s {
     int dummy;
 };
 
+struct ngx_array_s {
+    void       *elts;
+    ngx_uint_t  nelts;
+    size_t      size;
+    ngx_uint_t  nalloc;
+    ngx_pool_t *pool;
+};
+
 /* struct ngx_buf_s provided by nginx_stubs/ngx_core.h */
 
-typedef struct {
+typedef struct ngx_table_elt_s {
     ngx_str_t key;
     ngx_str_t value;
     ngx_uint_t hash;
@@ -106,6 +125,8 @@ struct ngx_http_request_s {
     struct {
         ngx_list_t headers;
         ngx_table_elt_t *accept;
+        ngx_table_elt_t *cookie;
+        ngx_table_elt_t *authorization;
     } headers_in;
     struct {
         ngx_uint_t status;
@@ -185,6 +206,48 @@ static int g_cond_result_code;
 static int g_convert_error_code;
 static uint8_t *g_convert_etag;
 static uintptr_t g_convert_etag_len;
+
+ngx_int_t
+ngx_http_markdown_set_etag(ngx_http_request_t *r, const u_char *etag,
+    size_t etag_len)
+{
+    ngx_list_part_t *part;
+    ngx_table_elt_t *headers;
+
+    for (part = &r->headers_out.headers.part; part != NULL; part = part->next) {
+        headers = part->elts;
+        for (ngx_uint_t i = 0; i < part->nelts; i++) {
+            if (headers[i].hash != 0 && headers[i].key.len == 4
+                && strncasecmp((const char *) headers[i].key.data,
+                               "ETag", 4)
+                   == 0)
+            {
+                headers[i].hash = 0;
+            }
+        }
+    }
+
+    if (etag == NULL || etag_len == 0) {
+        r->headers_out.etag = NULL;
+        return NGX_OK;
+    }
+
+    ngx_table_elt_t *h = ngx_list_push(&r->headers_out.headers);
+    if (h == NULL) {
+        return NGX_ERROR;
+    }
+    h->hash = 1;
+    h->key.data = (u_char *) "ETag";
+    h->key.len = 4;
+    h->value.data = ngx_pnalloc(r->pool, etag_len);
+    if (h->value.data == NULL) {
+        return NGX_ERROR;
+    }
+    ngx_memcpy(h->value.data, etag, etag_len);
+    h->value.len = etag_len;
+    r->headers_out.etag = h;
+    return NGX_OK;
+}
 
 ngx_int_t
 ngx_http_send_header(ngx_http_request_t *r)
@@ -350,6 +413,7 @@ markdown_reason_code_count(void)
 }
 
 #include "../../src/ngx_http_markdown_conditional.c"
+#include "../../src/ngx_http_markdown_auth.c"
 
 static ngx_list_t *
 create_header_list(void)
@@ -423,6 +487,74 @@ test_send_304_with_etag(void)
     TEST_ASSERT(r->headers_out.status == NGX_HTTP_NOT_MODIFIED,
         "Status is 304");
     TEST_PASS("send_304 with ETag");
+}
+
+static void
+test_send_304_replaces_existing_etag(void)
+{
+    ngx_table_elt_t *upstream_etag;
+    ngx_uint_t active_etags;
+
+    g_pool_offset = 0;
+    g_send_header_rc = NGX_OK;
+    ngx_http_request_t *r = make_req();
+    if (r == NULL) { TEST_FAIL("alloc failed"); return; }
+
+    upstream_etag = add_header(&r->headers_out.headers,
+                               "ETag", "\"upstream\"");
+    r->headers_out.etag = upstream_etag;
+
+    static uint8_t etag_data[] = "\"markdown\"";
+    struct MarkdownResult result;
+    memset(&result, 0, sizeof(result));
+    result.etag = etag_data;
+    result.etag_len = sizeof(etag_data) - 1;
+
+    ngx_int_t rc = ngx_http_markdown_send_304(r, &result);
+    TEST_ASSERT(rc == NGX_DONE, "send_304 returns NGX_DONE");
+    TEST_ASSERT(upstream_etag->hash == 0,
+                "Existing upstream ETag should be invalidated");
+    TEST_ASSERT(r->headers_out.etag != upstream_etag,
+                "Typed ETag pointer should reference Markdown ETag");
+
+    active_etags = 0;
+    ngx_table_elt_t *headers = r->headers_out.headers.part.elts;
+    for (ngx_uint_t i = 0; i < r->headers_out.headers.part.nelts; i++) {
+        if (headers[i].hash != 0 && headers[i].key.len == 4
+            && strncasecmp((const char *) headers[i].key.data,
+                           "ETag", 4)
+               == 0)
+        {
+            active_etags++;
+        }
+    }
+    TEST_ASSERT(active_etags == 1,
+                "304 response should contain exactly one active ETag");
+    TEST_PASS("send_304 replaces existing ETag");
+}
+
+static void
+test_auth_ignores_invalidated_authorization(void)
+{
+    ngx_http_request_t *r;
+    ngx_table_elt_t *authorization;
+
+    g_pool_offset = 0;
+    r = make_req();
+    if (r == NULL) { TEST_FAIL("alloc failed"); return; }
+
+    authorization = add_header(&r->headers_in.headers,
+                               "Authorization", "Bearer stale");
+    r->headers_in.authorization = authorization;
+    authorization->hash = 0;
+
+    TEST_ASSERT(ngx_http_markdown_is_authenticated(r, NULL) == 0,
+                "Invalidated Authorization should not authenticate request");
+
+    authorization->hash = 1;
+    TEST_ASSERT(ngx_http_markdown_is_authenticated(r, NULL) == 1,
+                "Active Authorization should authenticate request");
+    TEST_PASS("invalidated Authorization is ignored");
 }
 
 static void
@@ -867,6 +999,8 @@ main(void)
     printf("========================================\n");
 
     test_send_304_with_etag();
+    test_send_304_replaces_existing_etag();
+    test_auth_ignores_invalidated_authorization();
     test_send_304_null_result();
     test_send_304_empty_etag();
     test_send_304_send_header_fails();

--- a/components/nginx-module/tests/unit/config_core_impl_test.c
+++ b/components/nginx-module/tests/unit/config_core_impl_test.c
@@ -451,6 +451,8 @@ test_main_conf_create_and_init(void)
         "metrics_shm_size should be unset");
     TEST_ASSERT(mcf->metrics_shm_zone == NULL,
         "metrics_shm_zone should start NULL");
+    TEST_ASSERT(mcf->dynconf_owner_conf == NULL,
+        "dynconf owner config should start NULL");
 
     memset(&zone, 0, sizeof(zone));
     g_shared_zone = &zone;
@@ -686,6 +688,52 @@ test_merge_conf(void)
         "static enabled source should clear complex pointer");
 
     TEST_PASS("merge_conf branches covered");
+}
+
+static void
+test_dynconf_owner_uses_merged_config(void)
+{
+    ngx_conf_t                     cf;
+    ngx_http_markdown_conf_t      *parent;
+    ngx_http_markdown_conf_t      *owner;
+    ngx_http_markdown_main_conf_t  main_conf;
+    char                          *rc;
+
+    TEST_SUBSECTION("dynconf owner uses merged config");
+
+    memset(&cf, 0, sizeof(cf));
+    cf.pool = &g_pool;
+    memset(&main_conf, 0, sizeof(main_conf));
+
+    parent = ngx_http_markdown_create_conf(&cf);
+    owner = ngx_http_markdown_create_conf(&cf);
+    TEST_ASSERT(parent != NULL && owner != NULL,
+        "dynconf merge configs should allocate");
+
+    parent->advanced.dynconf_enabled = 1;
+    parent->advanced.dynconf_dry_run = 1;
+    owner->advanced.dynconf_path.data =
+        (u_char *) "/etc/nginx/markdown-dynconf.conf";
+    owner->advanced.dynconf_path.len =
+        strlen((char *) owner->advanced.dynconf_path.data);
+    main_conf.dynconf_owner_conf = owner;
+
+    rc = ngx_http_markdown_merge_conf(&cf, parent, owner);
+    TEST_ASSERT(rc == NGX_CONF_OK,
+        "dynconf owner merge should succeed");
+    TEST_ASSERT(ngx_http_markdown_dynconf_owner(&main_conf) == owner,
+        "worker owner lookup should return the path owner");
+    TEST_ASSERT(owner->advanced.dynconf_enabled == 1,
+        "owner should inherit dynconf enablement");
+    TEST_ASSERT(owner->advanced.dynconf_dry_run == 1,
+        "owner should inherit dynconf dry-run mode");
+    TEST_ASSERT(owner->advanced.dynconf_path.len > 0,
+        "owner should retain its configured dynconf path");
+
+    TEST_ASSERT(ngx_http_markdown_dynconf_owner(NULL) == NULL,
+        "worker owner lookup should be NULL-safe");
+
+    TEST_PASS("dynconf watcher binds to coherent merged owner config");
 }
 
 /*
@@ -1394,6 +1442,7 @@ main(void)
     test_main_conf_create_and_init();
     test_create_conf_defaults();
     test_merge_conf();
+    test_dynconf_owner_uses_merged_config();
     test_merge_conf_double_unset();
     test_stream_budget_explicit_maps_to_stream();
     test_stream_preserves_explicit_defaults();

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -1527,6 +1527,21 @@ test_parse_size_edge_cases(void)
     TEST_ASSERT(result == (size_t) NGX_ERROR,
         "negative suffixed size with leading space should return NGX_ERROR");
 
+    set_arg(&line, "   ");
+    result = ngx_http_markdown_parse_size(&line);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "all-whitespace input should return NGX_ERROR (empty after trim)");
+
+    set_arg(&line, "   abc");
+    result = ngx_http_markdown_parse_size(&line);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "whitespace followed by non-digits should return NGX_ERROR");
+
+    set_arg(&line, "   12abc");
+    result = ngx_http_markdown_parse_size(&line);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "digits followed by non-numeric trailing should return NGX_ERROR");
+
     TEST_PASS("parse_size edge cases covered");
 }
 

--- a/components/nginx-module/tests/unit/config_handlers_impl_test.c
+++ b/components/nginx-module/tests/unit/config_handlers_impl_test.c
@@ -1454,7 +1454,7 @@ test_v080_stream_directive_handlers(void)
 
 /*
  * Verify ngx_http_markdown_parse_size edge cases: NULL input,
- * oversized input, and bare number (no suffix).
+ * oversized input, negative input, and bare number (no suffix).
  *
  * Semantic contract mirrored: parse_size returns (size_t) NGX_ERROR
  * for NULL/empty/oversized inputs, and returns the raw value when
@@ -1516,6 +1516,16 @@ test_parse_size_edge_cases(void)
     result = ngx_http_markdown_parse_size(&line);
     TEST_ASSERT(result == 0,
         "zero value should parse");
+
+    set_arg(&line, "-2");
+    result = ngx_http_markdown_parse_size(&line);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "negative bare size should return NGX_ERROR");
+
+    set_arg(&line, " -2k");
+    result = ngx_http_markdown_parse_size(&line);
+    TEST_ASSERT(result == (size_t) NGX_ERROR,
+        "negative suffixed size with leading space should return NGX_ERROR");
 
     TEST_PASS("parse_size edge cases covered");
 }
@@ -1579,6 +1589,7 @@ test_set_dynconf_path(void)
     ngx_str_t                  values[2];
     ngx_command_t              cmd;
     ngx_http_markdown_conf_t   mcf;
+    ngx_http_markdown_conf_t   duplicate_mcf;
     const char                *rc;
 
     TEST_SUBSECTION("set_dynconf_path handler");
@@ -1598,12 +1609,16 @@ test_set_dynconf_path(void)
                 "main conf marked as configured");
     TEST_ASSERT(g_main_conf.dynconf_first_path.len > 0,
                 "first path recorded in main conf");
+    TEST_ASSERT(g_main_conf.dynconf_owner_conf == &mcf,
+                "main conf should retain the path owner config");
 
     /* Duplicate should fail */
-    init_conf(&mcf);
-    rc = ngx_http_markdown_set_dynconf_path(&cf, &cmd, &mcf);
+    init_conf(&duplicate_mcf);
+    rc = ngx_http_markdown_set_dynconf_path(&cf, &cmd, &duplicate_mcf);
     TEST_ASSERT(rc == NGX_CONF_ERROR,
                 "duplicate path should be rejected");
+    TEST_ASSERT(g_main_conf.dynconf_owner_conf == &mcf,
+                "duplicate path must not replace the original owner");
 
     /* Empty value should succeed (no-op) */
     memset(&g_main_conf, 0, sizeof(g_main_conf));

--- a/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
+++ b/components/nginx-module/tests/unit/conversion_impl_base_url_test.c
@@ -894,6 +894,62 @@ test_untrusted_forwarded_headers_ignored(void)
 }
 
 
+/* URI authority delimiters in a trusted forwarded host must be rejected. */
+static void
+test_forwarded_host_authority_delimiters_fall_back(void)
+{
+    static const char *invalid_hosts[] = {
+        "user@attacker.example",
+        "proxy.example#fragment",
+        "proxy.example?query"
+    };
+    ngx_http_request_t r;
+    ngx_http_markdown_conf_t conf;
+    ngx_table_elt_t headers[2];
+    ngx_str_t scheme;
+    ngx_str_t host;
+    ngx_str_t base_url;
+
+    TEST_SUBSECTION("X-Forwarded-Host authority delimiters are rejected");
+
+    for (size_t i = 0; i < ARRAY_SIZE(invalid_hosts); i++) {
+        init_request(&r);
+        memset(&conf, 0, sizeof(conf));
+        conf.ops.trust_forwarded_headers = 1;
+
+        set_str(&r.schema, "http");
+        set_str(&r.headers_in.server, "origin.example.com");
+        set_str(&r.uri, "/articles/page.html");
+
+        set_str(&headers[0].key, "X-Forwarded-Proto");
+        set_str(&headers[0].value, "https");
+        headers[0].hash = 1;
+        set_str(&headers[1].key, "X-Forwarded-Host");
+        set_str(&headers[1].value, invalid_hosts[i]);
+        headers[1].hash = 1;
+        set_single_header_list(&r, headers, ARRAY_SIZE(headers));
+        r.loc_conf = &conf;
+
+        TEST_ASSERT(ngx_http_markdown_select_base_url_parts(
+                        &r, &scheme, &host) == NGX_OK,
+                    "invalid forwarded authority should use direct fallback");
+        assert_str_eq(&scheme, "http", "fallback scheme should be direct");
+        assert_str_eq(&host, "origin.example.com",
+                      "invalid forwarded authority should not enter base_url");
+
+        TEST_ASSERT(ngx_http_markdown_construct_base_url(
+                        &r, r.pool, &base_url) == NGX_OK,
+                    "fallback base_url construction should succeed");
+        assert_str_eq(&base_url,
+                      "http://origin.example.com/articles/page.html",
+                      "base_url should retain direct request authority");
+        free(base_url.data);
+    }
+
+    TEST_PASS("Forwarded authority delimiters fall back safely");
+}
+
+
 static void
 test_direct_request_path(void)
 {
@@ -1947,6 +2003,7 @@ main(void)
 
     test_forwarded_headers_priority();
     test_untrusted_forwarded_headers_ignored();
+    test_forwarded_host_authority_delimiters_fall_back();
     test_direct_request_path();
     test_server_name_fallback_path();
     test_host_with_comma_falls_back();

--- a/components/nginx-module/tests/unit/eligibility_impl_test.c
+++ b/components/nginx-module/tests/unit/eligibility_impl_test.c
@@ -36,7 +36,8 @@ typedef struct ngx_table_elt_s ngx_table_elt_t;
 typedef struct ngx_http_headers_in_s ngx_http_headers_in_t;
 typedef struct ngx_http_headers_out_s ngx_http_headers_out_t;
 
-struct ngx_pool_s { int dummy; };
+struct ngx_log_s { int dummy; };
+struct ngx_pool_s { ngx_log_t *log; };
 
 struct ngx_table_elt_s {
     ngx_str_t key;
@@ -93,6 +94,37 @@ ngx_strlchr(u_char *p, u_char *last, u_char c)
 }
 
 #include "../../src/ngx_http_markdown_eligibility.c"
+
+typedef struct ngx_pool_cleanup_s {
+    void                         (*handler)(void *data);
+    void                          *data;
+    struct ngx_pool_cleanup_s     *next;
+} ngx_pool_cleanup_t;
+
+static ngx_pool_cleanup_t  test_cleanup;
+static ngx_uint_t          test_alloc_calls;
+
+ngx_pool_cleanup_t *
+ngx_pool_cleanup_add(ngx_pool_t *pool, size_t size)
+{
+    UNUSED(pool);
+    UNUSED(size);
+    memset(&test_cleanup, 0, sizeof(test_cleanup));
+    return &test_cleanup;
+}
+
+void *
+ngx_alloc(size_t size, ngx_log_t *log)
+{
+    UNUSED(log);
+    test_alloc_calls++;
+    return malloc(size);
+}
+
+#define ngx_free free
+#define ngx_memcpy memcpy
+
+#include "../../src/ngx_http_markdown_buffer.c"
 
 
 static ngx_pool_t g_pool;
@@ -415,6 +447,12 @@ test_check_size_limit_boundary(void)
         ngx_http_markdown_check_size_limit(&r, &conf, NULL) == 1,
         "max_size=0 (unlimited) + large CL should pass");
 
+    conf.advanced.memory_budget = 1024;
+    r.headers_out.content_length_n = 1025;
+    TEST_ASSERT(
+        ngx_http_markdown_check_size_limit(&r, &conf, NULL) == 0,
+        "memory_budget should bound an unlimited max_size");
+
     TEST_PASS("Size limit boundary cases correct");
 }
 
@@ -536,6 +574,36 @@ test_check_size_limit_with_eff(void)
 }
 
 
+static void
+test_zero_limit_buffer_initializes_lazily(void)
+{
+    ngx_http_markdown_buffer_t  buffer;
+    ngx_log_t                   log;
+    ngx_pool_t                  pool;
+
+    TEST_SUBSECTION("buffer_init: zero limit remains lazy");
+
+    memset(&buffer, 0, sizeof(buffer));
+    memset(&log, 0, sizeof(log));
+    memset(&pool, 0, sizeof(pool));
+    pool.log = &log;
+    test_alloc_calls = 0;
+
+    TEST_ASSERT(ngx_http_markdown_buffer_init(&buffer, 0, &pool) == NGX_OK,
+                "zero limit should initialize as unlimited");
+    TEST_ASSERT(test_alloc_calls == 0,
+                "unlimited initialization should not allocate eagerly");
+    TEST_ASSERT(ngx_http_markdown_buffer_append(
+                    &buffer, (const u_char *) "test", 4) == NGX_OK,
+                "unlimited buffer should accept a bounded append");
+    TEST_ASSERT(test_alloc_calls == 1,
+                "first append should allocate only on demand");
+
+    test_cleanup.handler(test_cleanup.data);
+    TEST_PASS("Zero limit initializes lazily and appends on demand");
+}
+
+
 int
 main(void)
 {
@@ -547,6 +615,7 @@ main(void)
     test_check_content_type_custom_allowlist();
     test_is_streaming_detection();
     test_is_streaming_configured_types();
+    test_zero_limit_buffer_initializes_lazily();
     test_check_eligibility_full_chain();
     test_check_size_limit_boundary();
     test_check_size_limit_with_eff();

--- a/components/nginx-module/tests/unit/headers_test.c
+++ b/components/nginx-module/tests/unit/headers_test.c
@@ -638,6 +638,42 @@ test_update_headers_removes_duplicate_content_encoding(void)
     TEST_PASS("Duplicate Content-Encoding headers are removed");
 }
 
+static void
+test_update_headers_skips_invalidated_accept_ranges(void)
+{
+    ngx_http_request_t r = new_request();
+    ngx_http_markdown_conf_t conf;
+    MarkdownResult result;
+    ngx_table_elt_t *invalid_ranges;
+    ngx_table_elt_t *active_ranges;
+
+    TEST_SUBSECTION("Accept-Ranges removal skips invalidated entries");
+
+    memset(&conf, 0, sizeof(conf));
+    memset(&result, 0, sizeof(result));
+    result.markdown_len = 10;
+
+    invalid_ranges = push_header(&r, "Accept-Ranges", "none");
+    active_ranges = push_header(&r, "Accept-Ranges", "bytes");
+    invalid_ranges->hash = 0;
+    r.headers_out.accept_ranges = active_ranges;
+    r.allow_ranges = 1;
+
+    TEST_ASSERT(ngx_http_markdown_update_headers(&r, &result, &conf) == NGX_OK,
+                "update_headers should remove active Accept-Ranges");
+    TEST_ASSERT(invalid_ranges->hash == 0,
+                "Invalidated Accept-Ranges should stay inactive");
+    TEST_ASSERT(active_ranges->hash == 0,
+                "Active Accept-Ranges after invalid entry should be removed");
+    TEST_ASSERT(r.headers_out.accept_ranges == NULL,
+                "Typed Accept-Ranges pointer should be cleared");
+    TEST_ASSERT(r.allow_ranges == 0,
+                "Range support should be disabled");
+
+    free_request(&r);
+    TEST_PASS("Invalidated Accept-Ranges entries are skipped");
+}
+
 int
 main(void)
 {
@@ -654,6 +690,7 @@ main(void)
     test_update_headers_ignores_invalidated_vary();
     test_update_headers_creates_vary_after_invalidated_only();
     test_update_headers_removes_duplicate_content_encoding();
+    test_update_headers_skips_invalidated_accept_ranges();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -151,6 +151,62 @@ void *ngx_pnalloc(ngx_pool_t *pool, size_t size);
 #define ngx_memcpy(dst, src, n)  memcpy((dst), (src), (n))
 #endif
 
+/* Helper: find a header by name across all ngx_list_part_t parts.
+ * Returns the first matching entry with hash != 0, or NULL.
+ */
+static ngx_table_elt_t *
+test_find_header_in_list(ngx_list_t *list, const char *name, size_t name_len)
+{
+    ngx_list_part_t *part;
+    ngx_table_elt_t *elts;
+    ngx_uint_t       i;
+
+    part = &list->part;
+    while (part != NULL) {
+        elts = (ngx_table_elt_t *) part->elts;
+        for (i = 0; i < part->nelts; i++) {
+            if (elts[i].hash != 0
+                && elts[i].key.len == name_len
+                && ngx_strncasecmp(elts[i].key.data,
+                                   (const u_char *) name, name_len) == 0)
+            {
+                return &elts[i];
+            }
+        }
+        part = part->next;
+    }
+    return NULL;
+}
+
+/* Helper: iterate all entries matching a header name across all parts.
+ * Calls callback for each matching entry with hash != 0.
+ */
+typedef void (*test_header_iter_cb)(ngx_table_elt_t *h, void *ctx);
+
+static void
+test_iter_header_in_list(ngx_list_t *list, const char *name, size_t name_len,
+                         test_header_iter_cb cb, void *cb_ctx)
+{
+    ngx_list_part_t *part;
+    ngx_table_elt_t *elts;
+    ngx_uint_t       i;
+
+    part = &list->part;
+    while (part != NULL) {
+        elts = (ngx_table_elt_t *) part->elts;
+        for (i = 0; i < part->nelts; i++) {
+            if (elts[i].hash != 0
+                && elts[i].key.len == name_len
+                && ngx_strncasecmp(elts[i].key.data,
+                                   (const u_char *) name, name_len) == 0)
+            {
+                cb(&elts[i], cb_ctx);
+            }
+        }
+        part = part->next;
+    }
+}
+
 /* Mock: ngx_http_markdown_add_vary_accept
  *
  * Simulates real behavior: if no Vary header exists, pushes a new
@@ -171,26 +227,9 @@ ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
         return test_vary_accept_rc;
     }
 
-    /* Find existing Vary header */
-    vary = NULL;
-    {
-        ngx_table_elt_t *elts;
-        ngx_uint_t       i;
-        elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
-        for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
-            if (elts[i].hash != 0
-                && elts[i].key.len == 4
-                && ngx_strncasecmp(elts[i].key.data,
-                                   (const u_char *) "Vary", 4) == 0)
-            {
-                vary = &elts[i];
-                break;
-            }
-        }
-    }
+    vary = test_find_header_in_list(&r->headers_out.headers, "Vary", 4);
 
     if (vary == NULL) {
-        /* Push new Vary: Accept */
         h = ngx_list_push(&r->headers_out.headers);
         if (h == NULL) {
             return NGX_ERROR;
@@ -203,7 +242,6 @@ ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    /* Append ", Accept" to existing value */
     len = vary->value.len + sizeof(suffix) - 1;
     p = ngx_pnalloc(r->pool, len);
     if (p == NULL) {
@@ -222,34 +260,33 @@ ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
  * existing ETag entries (hash=0) and clears the typed pointer.
  * This makes rollback tests meaningful.
  */
+typedef struct {
+    ngx_uint_t count;
+} test_etag_invalidate_ctx;
+
+static void
+test_etag_invalidate_cb(ngx_table_elt_t *h, void *ctx)
+{
+    UNUSED(ctx);
+    h->hash = 0;
+}
+
 ngx_int_t
 ngx_http_markdown_set_etag(ngx_http_request_t *r,
                            const u_char *etag_value, size_t etag_len)
 {
-    ngx_table_elt_t  *elts;
-    ngx_uint_t        i;
-
     test_set_etag_called = 1;
     if (test_set_etag_rc != NGX_OK) {
         return test_set_etag_rc;
     }
 
     if (etag_value != NULL && etag_len > 0) {
-        /* Not used by stream_commit_remove_etag, but keep for completeness */
         return NGX_OK;
     }
 
-    /* Invalidate all existing ETag entries (hash=0) */
-    elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
-    for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
-        if (elts[i].hash != 0
-            && elts[i].key.len == 4
-            && ngx_strncasecmp(elts[i].key.data,
-                               (const u_char *) "ETag", 4) == 0)
-        {
-            elts[i].hash = 0;
-        }
-    }
+    test_iter_header_in_list(&r->headers_out.headers,
+                             "ETag", 4,
+                             test_etag_invalidate_cb, NULL);
 
     r->headers_out.etag = NULL;
     return NGX_OK;
@@ -284,10 +321,8 @@ ngx_int_t
 ngx_http_markdown_modify_cache_control_for_auth(ngx_http_request_t *r)
 {
     ngx_table_elt_t  *cc;
-    ngx_table_elt_t  *elts;
     u_char           *p;
     size_t            len;
-    ngx_uint_t        i;
     const char        suffix[] = ", private";
 
     test_auth_cache_control_called = 1;
@@ -295,22 +330,10 @@ ngx_http_markdown_modify_cache_control_for_auth(ngx_http_request_t *r)
         return test_auth_cache_control_rc;
     }
 
-    /* Find existing Cache-Control header */
-    cc = NULL;
-    elts = (ngx_table_elt_t *) r->headers_out.headers.part.elts;
-    for (i = 0; i < r->headers_out.headers.part.nelts; i++) {
-        if (elts[i].hash != 0
-            && elts[i].key.len == 13
-            && ngx_strncasecmp(elts[i].key.data,
-                               (const u_char *) "Cache-Control", 13) == 0)
-        {
-            cc = &elts[i];
-            break;
-        }
-    }
+    cc = test_find_header_in_list(&r->headers_out.headers,
+                                  "Cache-Control", 13);
 
     if (cc == NULL) {
-        /* If no CC header, push a new one */
         cc = ngx_list_push(&r->headers_out.headers);
         if (cc == NULL) {
             return NGX_ERROR;
@@ -323,7 +346,6 @@ ngx_http_markdown_modify_cache_control_for_auth(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    /* Append ", private" to existing value */
     len = cc->value.len + sizeof(suffix) - 1;
     p = ngx_pnalloc(r->pool, len);
     if (p == NULL) {
@@ -1384,9 +1406,7 @@ static void test_multipart_rollback_etag_failure_restores_vary_in_p1_etag_in_p2(
 static void test_multipart_rollback_new_push_invalidated_across_parts(void)
 {
     ngx_http_markdown_ctx_t ctx;
-    ngx_table_elt_t *orig_vary;
     ngx_table_elt_t *new_vary_in_p2;
-    ngx_str_t orig_vary_value;
     ngx_int_t rc;
     ngx_uint_t i;
 
@@ -1402,8 +1422,7 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
     mp_push_part1("X-Region", "us");
     mp_push_part1("X-Shard", "3");
     mp_push_part1("X-Pool", "main");
-    orig_vary = mp_push_part1("Vary", "Cookie");
-    orig_vary_value = orig_vary->value;
+    mp_push_part1("X-Flavor", "dev");
 
     mp_link_part2();
 
@@ -1416,12 +1435,6 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
     rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
 
     TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on ETag failure");
-
-    TEST_ASSERT(orig_vary->hash == 1, "original Vary hash restored in part1");
-    TEST_ASSERT(orig_vary->value.data == orig_vary_value.data,
-                "original Vary value restored in part1");
-    TEST_ASSERT(orig_vary->value.len == orig_vary_value.len,
-                "original Vary value len restored in part1");
 
     new_vary_in_p2 = NULL;
     for (i = 0; i < mp_part2.nelts; i++) {
@@ -1439,6 +1452,10 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
                 "new Vary push entry exists in part2 after rollback");
     TEST_ASSERT(new_vary_in_p2->hash == 0,
                 "new Vary push entry has hash=0 (invalidated by rollback)");
+    TEST_ASSERT(new_vary_in_p2->value.len == 6,
+                "new Vary push entry value is 'Accept'");
+    TEST_ASSERT(memcmp(new_vary_in_p2->value.data, "Accept", 6) == 0,
+                "new Vary push entry value data is 'Accept'");
 
     TEST_PASS("Multipart rollback: new Vary push in part2 invalidated across parts");
 }

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -344,19 +344,31 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log,
     UNUSED(level); UNUSED(log); UNUSED(err); UNUSED(fmt);
 }
 
-/* Stub: ngx_list_push */
+/* Stub: ngx_list_push
+ *
+ * Supports cross-part push: when part1 is full and part2 is linked
+ * (part->next != NULL), pushes into the next part.  This makes
+ * multipart rollback tests realistic.
+ */
 ngx_table_elt_t *
 ngx_list_push(ngx_list_t *list)
 {
+    ngx_list_part_t *part;
     ngx_table_elt_t *elts;
-    if (list->part.elts == NULL) {
+
+    part = &list->part;
+    while (part != NULL) {
+        if (part->nelts < list->nalloc) {
+            elts = (ngx_table_elt_t *) part->elts;
+            return &elts[part->nelts++];
+        }
+        if (part->next != NULL) {
+            part = part->next;
+            continue;
+        }
         return NULL;
     }
-    if (list->part.nelts >= list->nalloc) {
-        return NULL;
-    }
-    elts = (ngx_table_elt_t *) list->part.elts;
-    return &elts[list->part.nelts++];
+    return NULL;
 }
 
 /* Stub: ngx_pnalloc */
@@ -1373,17 +1385,30 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
 {
     ngx_http_markdown_ctx_t ctx;
     ngx_table_elt_t *orig_vary;
-    ngx_table_elt_t *new_vary_via_push;
+    ngx_table_elt_t *new_vary_in_p2;
     ngx_str_t orig_vary_value;
     ngx_int_t rc;
+    ngx_uint_t i;
 
-    test_setup();
+    test_setup_multipart();
     memset(&ctx, 0, sizeof(ctx));
     ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
     ctx.stream_sm.headers_committed = 0;
 
-    orig_vary = test_push_header("Vary", "Cookie");
+    mp_push_part1("X-App", "v1");
+    mp_push_part1("X-Req-Id", "42");
+    mp_push_part1("X-Color", "blue");
+    mp_push_part1("X-Env", "prod");
+    mp_push_part1("X-Region", "us");
+    mp_push_part1("X-Shard", "3");
+    mp_push_part1("X-Pool", "main");
+    orig_vary = mp_push_part1("Vary", "Cookie");
     orig_vary_value = orig_vary->value;
+
+    mp_link_part2();
+
+    mp_push_part2("ETag", "\"orig\"");
+    mp_push_part2("X-Trace", "abc");
 
     test_vary_accept_rc = NGX_OK;
     test_set_etag_rc = NGX_ERROR;
@@ -1392,30 +1417,30 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
 
     TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on ETag failure");
 
-    TEST_ASSERT(orig_vary->hash == 1, "original Vary hash restored");
+    TEST_ASSERT(orig_vary->hash == 1, "original Vary hash restored in part1");
     TEST_ASSERT(orig_vary->value.data == orig_vary_value.data,
-                "original Vary value restored");
+                "original Vary value restored in part1");
+    TEST_ASSERT(orig_vary->value.len == orig_vary_value.len,
+                "original Vary value len restored in part1");
 
-    new_vary_via_push = NULL;
-    {
-        ngx_table_elt_t *elts = (ngx_table_elt_t *)
-            test_request.headers_out.headers.part.elts;
-        ngx_uint_t n = test_request.headers_out.headers.part.nelts;
-        for (ngx_uint_t i = 0; i < n; i++) {
-            if (elts[i].key.len == 4 &&
-                ngx_strncasecmp(elts[i].key.data, (const u_char *) "Vary", 4) == 0 &&
-                elts[i].hash == 0) {
-                new_vary_via_push = &elts[i];
-                break;
-            }
+    new_vary_in_p2 = NULL;
+    for (i = 0; i < mp_part2.nelts; i++) {
+        ngx_table_elt_t *h = &mp_part2_storage[i];
+        if (h->key.len == 4
+            && ngx_strncasecmp(h->key.data, (const u_char *) "Vary", 4) == 0
+            && h->hash == 0)
+        {
+            new_vary_in_p2 = h;
+            break;
         }
     }
 
-    if (new_vary_via_push != NULL) {
-        TEST_PASS("Multipart rollback: new Vary push entry has hash=0 (invalidated)");
-    } else {
-        TEST_PASS("Multipart rollback: no extra Vary push entry (ngx_list_push not called)");
-    }
+    TEST_ASSERT(new_vary_in_p2 != NULL,
+                "new Vary push entry exists in part2 after rollback");
+    TEST_ASSERT(new_vary_in_p2->hash == 0,
+                "new Vary push entry has hash=0 (invalidated by rollback)");
+
+    TEST_PASS("Multipart rollback: new Vary push in part2 invalidated across parts");
 }
 
 static void test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2(void)
@@ -1479,7 +1504,7 @@ static void test_multipart_orig_nelts_cross_part_count(void)
     mp_push_part2("X-Trace", "def");
 
     rc = ngx_http_markdown_stream_commit_snapshot_header(
-        &test_request, &snap.vary, "Vary");
+        &test_request, (const u_char *) "Vary", 4, &snap.vary);
 
     TEST_ASSERT(rc == NGX_OK, "snapshot Vary succeeds");
     TEST_ASSERT(snap.vary.count == 1, "one Vary entry snapshotted");
@@ -1487,7 +1512,7 @@ static void test_multipart_orig_nelts_cross_part_count(void)
                 "orig_nelts counts all entries across both parts");
 
     rc = ngx_http_markdown_stream_commit_snapshot_header(
-        &test_request, &snap.etag, "ETag");
+        &test_request, (const u_char *) "ETag", 4, &snap.etag);
 
     TEST_ASSERT(rc == NGX_OK, "snapshot ETag succeeds");
     TEST_ASSERT(snap.etag.count == 1, "one ETag entry snapshotted");

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -1245,29 +1245,7 @@ mp_push_part2(const char *key, const char *value)
     return h;
 }
 
-static ngx_table_elt_t *
-mp_find_header(const char *key)
-{
-    size_t key_len = strlen(key);
-    ngx_uint_t i;
-    for (i = 0; i < test_request.headers_out.headers.part.nelts; i++) {
-        ngx_table_elt_t *h = &mp_part1_storage[i];
-        if (h->hash != 0 &&
-            h->key.len == key_len &&
-            ngx_strncasecmp(h->key.data, (const u_char *) key, key_len) == 0) {
-            return h;
-        }
-    }
-    for (i = 0; i < mp_part2.nelts; i++) {
-        ngx_table_elt_t *h = &mp_part2_storage[i];
-        if (h->hash != 0 &&
-            h->key.len == key_len &&
-            ngx_strncasecmp(h->key.data, (const u_char *) key, key_len) == 0) {
-            return h;
-        }
-    }
-    return NULL;
-}
+
 
 static void test_multipart_rollback_vary_in_part2(void)
 {

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -1129,6 +1129,374 @@ static void test_snapshot_overflow_fails_before_mutation(void)
     TEST_PASS("All snapshot overflows fail before Phase 1 mutation");
 }
 
+/* --- Multipart header list rollback regression tests (Rule 39 / Rule 40) --- */
+
+static ngx_table_elt_t  mp_part1_storage[8];
+static ngx_table_elt_t  mp_part2_storage[8];
+static ngx_list_part_t  mp_part2;
+
+static void test_setup_multipart(void)
+{
+    memset(&test_log, 0, sizeof(test_log));
+    memset(&test_pool, 0, sizeof(test_pool));
+    memset(&test_connection, 0, sizeof(test_connection));
+    memset(&test_request, 0, sizeof(test_request));
+    memset(&test_content_length_elt, 0, sizeof(test_content_length_elt));
+    memset(mp_part1_storage, 0, sizeof(mp_part1_storage));
+    memset(mp_part2_storage, 0, sizeof(mp_part2_storage));
+    memset(&mp_part2, 0, sizeof(mp_part2));
+
+    test_pool.log = &test_log;
+    test_connection.log = &test_log;
+    test_request.connection = &test_connection;
+    test_request.pool = &test_pool;
+    test_request.main = &test_request;
+    test_request.headers_out.content_length_n = 12345;
+    test_content_length_elt.hash = 1;
+    test_request.headers_out.content_length = &test_content_length_elt;
+
+    test_request.headers_out.headers.part.elts = mp_part1_storage;
+    test_request.headers_out.headers.part.nelts = 0;
+    test_request.headers_out.headers.part.next = NULL;
+    test_request.headers_out.headers.size = sizeof(ngx_table_elt_t);
+    test_request.headers_out.headers.nalloc = 8;
+    test_request.headers_out.headers.pool = NULL;
+    test_request.headers_out.etag = NULL;
+
+    mp_part2.elts = mp_part2_storage;
+    mp_part2.nelts = 0;
+    mp_part2.next = NULL;
+
+    test_vary_accept_called = 0;
+    test_vary_accept_rc = NGX_OK;
+    test_set_etag_called = 0;
+    test_set_etag_rc = NGX_OK;
+    test_is_authenticated = 0;
+    test_auth_cache_control_called = 0;
+    test_auth_cache_control_rc = NGX_OK;
+}
+
+static void mp_link_part2(void)
+{
+    test_request.headers_out.headers.part.next = &mp_part2;
+}
+
+static ngx_table_elt_t *
+mp_push_part1(const char *key, const char *value)
+{
+    ngx_uint_t idx = test_request.headers_out.headers.part.nelts;
+    TEST_ASSERT(idx < 8, "part1 not full");
+    ngx_table_elt_t *h = &mp_part1_storage[idx];
+    h->hash = 1;
+    h->key.data = (u_char *) key;
+    h->key.len = strlen(key);
+    h->value.data = (u_char *) value;
+    h->value.len = strlen(value);
+    test_request.headers_out.headers.part.nelts++;
+    return h;
+}
+
+static ngx_table_elt_t *
+mp_push_part2(const char *key, const char *value)
+{
+    ngx_uint_t idx = mp_part2.nelts;
+    TEST_ASSERT(idx < 8, "part2 not full");
+    ngx_table_elt_t *h = &mp_part2_storage[idx];
+    h->hash = 1;
+    h->key.data = (u_char *) key;
+    h->key.len = strlen(key);
+    h->value.data = (u_char *) value;
+    h->value.len = strlen(value);
+    mp_part2.nelts++;
+    return h;
+}
+
+static ngx_table_elt_t *
+mp_find_header(const char *key)
+{
+    size_t key_len = strlen(key);
+    ngx_uint_t i;
+    for (i = 0; i < test_request.headers_out.headers.part.nelts; i++) {
+        ngx_table_elt_t *h = &mp_part1_storage[i];
+        if (h->hash != 0 &&
+            h->key.len == key_len &&
+            ngx_strncasecmp(h->key.data, (const u_char *) key, key_len) == 0) {
+            return h;
+        }
+    }
+    for (i = 0; i < mp_part2.nelts; i++) {
+        ngx_table_elt_t *h = &mp_part2_storage[i];
+        if (h->hash != 0 &&
+            h->key.len == key_len &&
+            ngx_strncasecmp(h->key.data, (const u_char *) key, key_len) == 0) {
+            return h;
+        }
+    }
+    return NULL;
+}
+
+static void test_multipart_rollback_vary_in_part2(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *vary_in_p2;
+    ngx_table_elt_t *unrelated_in_p1;
+    ngx_table_elt_t *unrelated_in_p2;
+    ngx_str_t orig_vary_value;
+    ngx_str_t orig_unrelated_p1_value;
+    ngx_str_t orig_unrelated_p2_value;
+    ngx_int_t rc;
+
+    test_setup_multipart();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    unrelated_in_p1 = mp_push_part1("X-App", "v1");
+    orig_unrelated_p1_value = unrelated_in_p1->value;
+
+    mp_link_part2();
+
+    vary_in_p2 = mp_push_part2("Vary", "Cookie");
+    orig_vary_value = vary_in_p2->value;
+
+    unrelated_in_p2 = mp_push_part2("X-Trace", "abc");
+    orig_unrelated_p2_value = unrelated_in_p2->value;
+
+    test_vary_accept_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on Vary failure");
+    TEST_ASSERT(vary_in_p2->hash == 1, "Vary hash restored in part2");
+    TEST_ASSERT(vary_in_p2->value.data == orig_vary_value.data,
+                "Vary value restored in part2");
+    TEST_ASSERT(vary_in_p2->value.len == orig_vary_value.len,
+                "Vary value len restored in part2");
+    TEST_ASSERT(unrelated_in_p1->hash == 1, "unrelated header in part1 untouched");
+    TEST_ASSERT(unrelated_in_p1->value.data == orig_unrelated_p1_value.data,
+                "unrelated part1 value untouched");
+    TEST_ASSERT(unrelated_in_p2->hash == 1, "unrelated header in part2 untouched");
+    TEST_ASSERT(unrelated_in_p2->value.data == orig_unrelated_p2_value.data,
+                "unrelated part2 value untouched");
+
+    TEST_PASS("Multipart rollback: Vary in part2 restored, unrelated headers untouched");
+}
+
+static void test_multipart_rollback_target_in_p2_non_target_in_p2(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *vary_in_p2;
+    ngx_table_elt_t *etag_in_p2;
+    ngx_str_t orig_vary_value;
+    ngx_str_t orig_etag_value;
+    ngx_int_t rc;
+
+    test_setup_multipart();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    mp_push_part1("X-App", "v1");
+    mp_push_part1("X-Req-Id", "42");
+
+    mp_link_part2();
+
+    vary_in_p2 = mp_push_part2("Vary", "Cookie");
+    orig_vary_value = vary_in_p2->value;
+
+    etag_in_p2 = mp_push_part2("ETag", "\"orig\"");
+    orig_etag_value = etag_in_p2->value;
+    test_request.headers_out.etag = etag_in_p2;
+
+    mp_push_part2("X-Trace", "abc");
+
+    test_vary_accept_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on Vary failure");
+    TEST_ASSERT(vary_in_p2->hash == 1, "Vary hash restored in part2");
+    TEST_ASSERT(vary_in_p2->value.data == orig_vary_value.data,
+                "Vary value restored in part2");
+    TEST_ASSERT(etag_in_p2->hash == 1, "ETag hash preserved (not mutated yet)");
+    TEST_ASSERT(etag_in_p2->value.data == orig_etag_value.data,
+                "ETag value preserved (not mutated yet)");
+    TEST_ASSERT(test_request.headers_out.etag == etag_in_p2,
+                "typed ETag pointer preserved");
+
+    TEST_PASS("Multipart rollback: target and non-target headers in part2");
+}
+
+static void test_multipart_rollback_etag_failure_restores_vary_in_p1_etag_in_p2(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *vary_in_p1;
+    ngx_table_elt_t *etag_in_p2;
+    ngx_str_t orig_vary_value;
+    ngx_str_t orig_etag_value;
+    ngx_int_t rc;
+
+    test_setup_multipart();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    vary_in_p1 = mp_push_part1("Vary", "Cookie");
+    orig_vary_value = vary_in_p1->value;
+
+    mp_link_part2();
+
+    etag_in_p2 = mp_push_part2("ETag", "\"orig\"");
+    orig_etag_value = etag_in_p2->value;
+    test_request.headers_out.etag = etag_in_p2;
+
+    mp_push_part2("X-Trace", "abc");
+
+    test_set_etag_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on ETag failure");
+    TEST_ASSERT(vary_in_p1->hash == 1, "Vary hash restored in part1");
+    TEST_ASSERT(vary_in_p1->value.data == orig_vary_value.data,
+                "Vary value restored in part1 after cross-header rollback");
+    TEST_ASSERT(etag_in_p2->hash == 1, "ETag hash restored in part2");
+    TEST_ASSERT(etag_in_p2->value.data == orig_etag_value.data,
+                "ETag value restored in part2");
+    TEST_ASSERT(test_request.headers_out.etag == etag_in_p2,
+                "typed ETag pointer restored after cross-header rollback");
+
+    TEST_PASS("Multipart rollback: ETag failure rolls back Vary in p1 and ETag in p2");
+}
+
+static void test_multipart_rollback_new_push_invalidated_across_parts(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *orig_vary;
+    ngx_table_elt_t *new_vary_via_push;
+    ngx_str_t orig_vary_value;
+    ngx_int_t rc;
+
+    test_setup();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    orig_vary = test_push_header("Vary", "Cookie");
+    orig_vary_value = orig_vary->value;
+
+    test_vary_accept_rc = NGX_OK;
+    test_set_etag_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on ETag failure");
+
+    TEST_ASSERT(orig_vary->hash == 1, "original Vary hash restored");
+    TEST_ASSERT(orig_vary->value.data == orig_vary_value.data,
+                "original Vary value restored");
+
+    new_vary_via_push = NULL;
+    {
+        ngx_table_elt_t *elts = (ngx_table_elt_t *)
+            test_request.headers_out.headers.part.elts;
+        ngx_uint_t n = test_request.headers_out.headers.part.nelts;
+        for (ngx_uint_t i = 0; i < n; i++) {
+            if (elts[i].key.len == 4 &&
+                ngx_strncasecmp(elts[i].key.data, (const u_char *) "Vary", 4) == 0 &&
+                elts[i].hash == 0) {
+                new_vary_via_push = &elts[i];
+                break;
+            }
+        }
+    }
+
+    if (new_vary_via_push != NULL) {
+        TEST_PASS("Multipart rollback: new Vary push entry has hash=0 (invalidated)");
+    } else {
+        TEST_PASS("Multipart rollback: no extra Vary push entry (ngx_list_push not called)");
+    }
+}
+
+static void test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2(void)
+{
+    ngx_http_markdown_ctx_t ctx;
+    ngx_table_elt_t *cc_in_p1;
+    ngx_table_elt_t *etag_in_p2;
+    ngx_str_t orig_cc_value;
+    ngx_str_t orig_etag_value;
+    ngx_int_t rc;
+
+    test_setup_multipart();
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
+    ctx.stream_sm.headers_committed = 0;
+
+    cc_in_p1 = mp_push_part1("Cache-Control", "public");
+    orig_cc_value = cc_in_p1->value;
+
+    mp_link_part2();
+
+    etag_in_p2 = mp_push_part2("ETag", "\"orig\"");
+    orig_etag_value = etag_in_p2->value;
+    test_request.headers_out.etag = etag_in_p2;
+
+    mp_push_part2("X-Trace", "abc");
+
+    test_is_authenticated = 1;
+    test_auth_cache_control_rc = NGX_ERROR;
+
+    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+
+    TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on CC failure");
+    TEST_ASSERT(cc_in_p1->hash == 1, "Cache-Control hash restored in part1");
+    TEST_ASSERT(cc_in_p1->value.data == orig_cc_value.data,
+                "Cache-Control value restored in part1");
+    TEST_ASSERT(etag_in_p2->hash == 1, "ETag hash restored in part2");
+    TEST_ASSERT(etag_in_p2->value.data == orig_etag_value.data,
+                "ETag value restored in part2");
+    TEST_ASSERT(test_request.headers_out.etag == etag_in_p2,
+                "typed ETag pointer restored");
+
+    TEST_PASS("Multipart rollback: CC failure rolls back CC in p1 and ETag in p2");
+}
+
+static void test_multipart_orig_nelts_cross_part_count(void)
+{
+    ngx_http_markdown_commit_snap_t snap;
+    ngx_int_t rc;
+
+    test_setup_multipart();
+    memset(&snap, 0, sizeof(snap));
+
+    mp_push_part1("X-App", "v1");
+    mp_push_part1("Vary", "Cookie");
+    mp_push_part1("X-Req-Id", "42");
+
+    mp_link_part2();
+
+    mp_push_part2("ETag", "\"abc\"");
+    mp_push_part2("X-Trace", "def");
+
+    rc = ngx_http_markdown_stream_commit_snapshot_header(
+        &test_request, &snap.vary, "Vary");
+
+    TEST_ASSERT(rc == NGX_OK, "snapshot Vary succeeds");
+    TEST_ASSERT(snap.vary.count == 1, "one Vary entry snapshotted");
+    TEST_ASSERT(snap.vary.orig_nelts == 5,
+                "orig_nelts counts all entries across both parts");
+
+    rc = ngx_http_markdown_stream_commit_snapshot_header(
+        &test_request, &snap.etag, "ETag");
+
+    TEST_ASSERT(rc == NGX_OK, "snapshot ETag succeeds");
+    TEST_ASSERT(snap.etag.count == 1, "one ETag entry snapshotted");
+    TEST_ASSERT(snap.etag.orig_nelts == 5,
+                "orig_nelts same for all headers (total list entry count)");
+
+    TEST_PASS("Multipart orig_nelts: cross-part linear count is correct");
+}
+
 int main(void)
 {
     TEST_SECTION("Stream Header Commit (streaming fallback state machine, header commit)");
@@ -1154,6 +1522,14 @@ int main(void)
     test_rollback_etag_failure_rolls_back_vary();
     test_rollback_restores_typed_etag_pointer();
     test_snapshot_overflow_fails_before_mutation();
+
+    TEST_SECTION("Multipart header list rollback (Rule 39 / Rule 40)");
+    test_multipart_rollback_vary_in_part2();
+    test_multipart_rollback_target_in_p2_non_target_in_p2();
+    test_multipart_rollback_etag_failure_restores_vary_in_p1_etag_in_p2();
+    test_multipart_rollback_new_push_invalidated_across_parts();
+    test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2();
+    test_multipart_orig_nelts_cross_part_count();
 
     printf("\n  All stream commit tests passed\n\n");
     return 0;

--- a/components/nginx-module/tests/unit/stream_commit_test.c
+++ b/components/nginx-module/tests/unit/stream_commit_test.c
@@ -260,9 +260,6 @@ ngx_http_markdown_add_vary_accept(ngx_http_request_t *r)
  * existing ETag entries (hash=0) and clears the typed pointer.
  * This makes rollback tests meaningful.
  */
-typedef struct {
-    ngx_uint_t count;
-} test_etag_invalidate_ctx;
 
 static void
 test_etag_invalidate_cb(ngx_table_elt_t *h, void *ctx)
@@ -1441,6 +1438,7 @@ static void test_multipart_rollback_new_push_invalidated_across_parts(void)
 static void test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2(void)
 {
     ngx_http_markdown_ctx_t ctx;
+    ngx_http_markdown_conf_t conf;
     ngx_table_elt_t *cc_in_p1;
     ngx_table_elt_t *etag_in_p2;
     ngx_str_t orig_cc_value;
@@ -1449,6 +1447,7 @@ static void test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2(void)
 
     test_setup_multipart();
     memset(&ctx, 0, sizeof(ctx));
+    memset(&conf, 0, sizeof(conf));
     ctx.stream_sm.state = NGX_HTTP_MD_STATE_PRE_COMMIT;
     ctx.stream_sm.headers_committed = 0;
 
@@ -1466,7 +1465,8 @@ static void test_multipart_rollback_cc_failure_target_in_p1_etag_in_p2(void)
     test_is_authenticated = 1;
     test_auth_cache_control_rc = NGX_ERROR;
 
-    rc = ngx_http_markdown_stream_commit_headers(&test_request, &ctx, NULL);
+    rc = ngx_http_markdown_stream_commit_headers(
+        &test_request, &ctx, &conf);
 
     TEST_ASSERT(rc == NGX_ERROR, "commit returns NGX_ERROR on CC failure");
     TEST_ASSERT(cc_in_p1->hash == 1, "Cache-Control hash restored in part1");

--- a/components/nginx-module/tests/unit/stream_e2e_test.c
+++ b/components/nginx-module/tests/unit/stream_e2e_test.c
@@ -121,6 +121,10 @@ struct ngx_http_request_s {
 /* Include the module header for types */
 #include "../../src/ngx_http_markdown_filter_module.h"
 
+static ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r,
+    ngx_chain_t *in);
+#include "../../src/ngx_http_markdown_filter_chain_impl.h"
+
 /* Include the decision engine source directly */
 #include "../../src/ngx_http_markdown_stream_state.h"
 #include "../../src/ngx_http_markdown_stream_state.c"
@@ -217,6 +221,7 @@ ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     return mock_output_filter_rc;
 }
+
 
 /*
  * Mock: ngx_http_markdown_stream_replay_chain
@@ -351,6 +356,7 @@ markdown_streaming_output_free(u_char *data, uintptr_t len)
 static void
 e2e_setup(void)
 {
+    ngx_http_next_body_filter = ngx_http_output_filter;
     mock_output_filter_called = 0;
     mock_output_filter_rc = NGX_OK;
     mock_output_filter_chain = NULL;

--- a/components/nginx-module/tests/unit/stream_error_test.c
+++ b/components/nginx-module/tests/unit/stream_error_test.c
@@ -106,6 +106,10 @@ struct ngx_http_request_s {
 /* Include the module header for types */
 #include "../../src/ngx_http_markdown_filter_module.h"
 
+static ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r,
+    ngx_chain_t *in);
+#include "../../src/ngx_http_markdown_filter_chain_impl.h"
+
 /* Include the decision engine source directly */
 #include "../../src/ngx_http_markdown_stream_state.h"
 #include "../../src/ngx_http_markdown_stream_state.c"
@@ -127,6 +131,7 @@ struct ngx_http_request_s {
 static int test_output_filter_called;
 static int test_output_filter_rc;
 static ngx_chain_t *test_output_filter_chain;
+static int test_poison_top_filter_called;
 static int test_replay_chain_called;
 static ngx_chain_t *test_replay_chain_result;
 
@@ -148,14 +153,24 @@ static ngx_http_request_t    test_request;
 /* Function prototypes */
 static void test_setup(void);
 
-/* Mock: ngx_http_output_filter */
-ngx_int_t
-ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
+/* Saved downstream body filter used by the production delegation helper. */
+static ngx_int_t
+test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     UNUSED(r);
     test_output_filter_called++;
     test_output_filter_chain = in;
     return test_output_filter_rc;
+}
+
+/* Poison top filter: replay and postcommit output must bypass it. */
+ngx_int_t
+ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    UNUSED(r);
+    UNUSED(in);
+    test_poison_top_filter_called++;
+    return NGX_ERROR;
 }
 
 /* Mock: replay_chain */
@@ -263,6 +278,8 @@ static void test_setup(void)
     test_output_filter_called = 0;
     test_output_filter_rc = NGX_OK;
     test_output_filter_chain = NULL;
+    test_poison_top_filter_called = 0;
+    ngx_http_next_body_filter = test_next_body_filter;
     test_replay_chain_called = 0;
     test_replay_chain_result = NULL;
     test_calloc_buf_called = 0;
@@ -315,7 +332,12 @@ static void test_task_6_1_precommit_pass_replay_html(void)
 
     TEST_ASSERT(rc == NGX_OK, "6.1: returns NGX_OK");
     TEST_ASSERT(test_replay_chain_called == 1, "6.1: replay_chain called");
-    TEST_ASSERT(test_output_filter_called == 1, "6.1: output_filter called");
+    TEST_ASSERT(test_output_filter_called == 1,
+                "6.1: saved downstream filter called");
+    TEST_ASSERT(test_output_filter_chain == &fc,
+                "6.1: helper forwarded replay chain");
+    TEST_ASSERT(test_poison_top_filter_called == 0,
+                "6.1: replay bypassed poison top filter");
     TEST_ASSERT(ctx.stream_sm.state == NGX_HTTP_MD_STATE_PASSTHROUGH,
                 "6.1: state PASSTHROUGH");
     TEST_ASSERT(test_request.headers_out.content_type_len
@@ -422,6 +444,10 @@ static void test_precommit_pass_replay_html_backpressure(void)
     rc = ngx_http_markdown_stream_on_error(&test_request, &ctx, &conf);
 
     TEST_ASSERT(rc == NGX_AGAIN, "replay backpressure -> NGX_AGAIN");
+    TEST_ASSERT(test_output_filter_called == 1,
+        "replay backpressure came from saved downstream filter");
+    TEST_ASSERT(test_poison_top_filter_called == 0,
+        "replay backpressure bypassed poison top filter");
     TEST_ASSERT(test_output_filter_chain == &fc,
         "output filter should receive replay chain");
     TEST_ASSERT(ctx.streaming.pending_output == &fc,

--- a/components/nginx-module/tests/unit/stream_postcommit_test.c
+++ b/components/nginx-module/tests/unit/stream_postcommit_test.c
@@ -127,6 +127,10 @@ struct ngx_http_request_s {
 /* Include the module header for types */
 #include "../../src/ngx_http_markdown_filter_module.h"
 
+static ngx_int_t (*ngx_http_next_body_filter)(ngx_http_request_t *r,
+    ngx_chain_t *in);
+#include "../../src/ngx_http_markdown_filter_chain_impl.h"
+
 /* Include the decision engine source directly */
 #include "../../src/ngx_http_markdown_stream_state.h"
 #include "../../src/ngx_http_markdown_stream_state.c"
@@ -145,16 +149,27 @@ static int test_output_filter_called;
 static int test_output_filter_rc;
 static ngx_chain_t *test_output_filter_chain;
 static ngx_buf_t *test_output_filter_buf;
+static int test_poison_top_filter_called;
 
-/* Mock: ngx_http_output_filter (needed by postcommit) */
-ngx_int_t
-ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
+/* Saved downstream body filter used by the production delegation helper. */
+static ngx_int_t
+test_next_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     UNUSED(r);
     test_output_filter_called++;
     test_output_filter_chain = in;
     test_output_filter_buf = (in != NULL) ? in->buf : NULL;
     return test_output_filter_rc;
+}
+
+/* Poison top filter: these paths must never re-enter the global chain. */
+ngx_int_t
+ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
+{
+    UNUSED(r);
+    UNUSED(in);
+    test_poison_top_filter_called++;
+    return NGX_ERROR;
 }
 
 /* Track ngx_calloc_buf behavior */
@@ -296,6 +311,8 @@ static void test_setup(void)
     test_output_filter_rc = NGX_OK;
     test_output_filter_chain = NULL;
     test_output_filter_buf = NULL;
+    test_poison_top_filter_called = 0;
+    ngx_http_next_body_filter = test_next_body_filter;
     test_calloc_buf_called = 0;
     test_calloc_buf_result = NULL;
     memset(&test_calloc_buf_storage, 0, sizeof(test_calloc_buf_storage));
@@ -671,7 +688,11 @@ static void test_safe_finish_happy_path(void)
                 == NGX_HTTP_MD_STATE_POST_COMMIT_SAFE_FINISH,
                 "state = POST_COMMIT_SAFE_FINISH");
     TEST_ASSERT(test_output_filter_called == 1,
-                "send_terminal called output_filter");
+                "send_terminal called saved downstream filter");
+    TEST_ASSERT(test_output_filter_chain != NULL,
+                "delegation helper forwarded the terminal chain");
+    TEST_ASSERT(test_poison_top_filter_called == 0,
+                "send_terminal bypassed the poison top filter");
     TEST_ASSERT(test_streaming_abort_called == 0,
                 "streaming abort must not be called on success");
     TEST_PASS("safe_finish happy path");
@@ -771,6 +792,10 @@ static void test_safe_finish_backpressure_preserves_pending_chain(void)
 
     TEST_ASSERT(rc == NGX_AGAIN,
                 "closing-byte backpressure should return NGX_AGAIN");
+    TEST_ASSERT(test_output_filter_called == 1,
+                "NGX_AGAIN came from the saved downstream filter");
+    TEST_ASSERT(test_poison_top_filter_called == 0,
+                "backpressured send bypassed the poison top filter");
     TEST_ASSERT(ctx.streaming.pending_output == test_output_filter_chain,
                 "pending chain should be the pool-owned output chain");
     TEST_ASSERT(ctx.streaming.pending_has_data == 1,

--- a/components/nginx-module/tests/unit/streaming_config_contract_test.c
+++ b/components/nginx-module/tests/unit/streaming_config_contract_test.c
@@ -533,6 +533,34 @@ stream_engine_directive(void)
 }
 
 static void
+test_dynconf_directives_support_published_contexts(void)
+{
+    static const char *names[] = {
+        "markdown_dynamic_config",
+        "markdown_dynamic_config_path",
+        "markdown_dynconf_dry_run"
+    };
+    ngx_command_t     *cmd;
+    size_t             i;
+
+    TEST_SUBSECTION("dynconf directives support published contexts");
+
+    for (i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+        cmd = find_directive(names[i]);
+        TEST_ASSERT(cmd != NULL,
+            "dynconf directive should be registered");
+        TEST_ASSERT((cmd->type & NGX_HTTP_MAIN_CONF) != 0,
+            "dynconf directive should allow HTTP context");
+        TEST_ASSERT((cmd->type & NGX_HTTP_SRV_CONF) != 0,
+            "dynconf directive should allow server context");
+        TEST_ASSERT((cmd->type & NGX_HTTP_LOC_CONF) != 0,
+            "dynconf directive should allow location context");
+    }
+
+    TEST_PASS("dynconf directives preserve all published contexts");
+}
+
+static void
 set_arg(ngx_str_t *arg, const char *s)
 {
     arg->data = (u_char *) (uintptr_t) s;
@@ -1335,6 +1363,7 @@ main(void)
 
     test_valid_values();
     test_stream_engine_handler_valid();
+    test_dynconf_directives_support_published_contexts();
     test_invalid_values();
     test_stream_engine_handler_rejection();
     test_allocation_failure();

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1277,14 +1277,16 @@ test_create_helper_and_limit_branches(void)
     buf_size = 16;
     g_palloc_fail_once = 1;
     rc = ngx_http_markdown_streaming_decomp_finalize_buf(
-        heap_buf, &buf, &buf_size, 8, &tp.pool);
+        &heap_buf, &buf, &buf_size, 8, &tp.pool);
     /*
-     * finalize_buf() takes ownership of heap_buf and frees it on
-     * both success and error paths.
+     * finalize_buf() takes ownership of the heap buffer by pointer-to-
+     * pointer and frees it on both success and error paths, clearing
+     * *heap_buf_ptr so the caller cannot double-free or leak it.
      */
-    heap_buf = NULL;
     TEST_ASSERT(rc == NGX_ERROR,
         "finalize_buf should fail when pool allocation fails");
+    TEST_ASSERT(heap_buf == NULL,
+        "finalize_buf should clear heap pointer on error");
 
     TEST_PASS("create/helper/limit branches covered");
 }

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1580,10 +1580,10 @@ test_feed_mocked_inflate_paths(void)
 /*
  * test_finish_zlib_paths_and_helpers - Verify the finish_zlib helper's
  * error, budget, overflow, expansion, and finalize-failure paths, plus
- * the finish_free_heap helper.
+ * the free_heap helper.
  *
  * Branches covered:
- *   - finish_free_heap frees and clears a non-NULL heap pointer
+ *   - free_heap frees and clears a non-NULL heap pointer
  *   - inflate error during Z_FINISH returns NGX_ERROR
  *   - budget exceeded during finish tail returns
  *     NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED
@@ -1606,9 +1606,9 @@ test_finish_zlib_paths_and_helpers(void)
 
     heap_buf = malloc(16);
     TEST_ASSERT(heap_buf != NULL, "heap allocation should succeed");
-    ngx_http_markdown_streaming_decomp_finish_free_heap(&heap_buf);
+    ngx_http_markdown_streaming_decomp_free_heap(&heap_buf);
     TEST_ASSERT(heap_buf == NULL,
-        "finish helper should free and clear non-NULL heap pointer");
+        "free_heap should free and clear non-NULL heap pointer");
 
     test_pool_reset(&tp);
     decomp = ngx_http_markdown_streaming_decomp_create(

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1661,6 +1661,10 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail on inflate error");
+    /*
+     * finish_zlib() frees the heap buffer on error and clears
+     * *buf_ptr, so buf is NULL here.
+     */
     free(buf);
     free(decomp);
 
@@ -1677,6 +1681,10 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED,
         "finish_zlib should return budget exceeded when tail is too large");
+    /*
+     * finish_zlib() frees the heap buffer on budget-exceeded and
+     * clears *buf_ptr, so buf is NULL here.
+     */
     free(buf);
     free(decomp);
 
@@ -1691,6 +1699,10 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail when initial finish buffer exceeds uInt");
+    /*
+     * g_static_pool_buf is not freed by free_heap (it checks for
+     * this special address), and *buf_ptr is cleared to NULL.
+     */
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1708,6 +1720,11 @@ test_finish_zlib_paths_and_helpers(void)
         "finish_zlib should succeed when mocked flow expands then ends");
     TEST_ASSERT(produced > 64,
         "finish_zlib expand path should report produced bytes above old size");
+    /*
+     * On success finalize_buf() transfers the heap buffer to pool
+     * memory and frees the heap allocation, so buf now points to a
+     * pool-owned buffer (malloc-backed in this harness).
+     */
     free(buf);
     free(decomp);
 
@@ -1726,8 +1743,8 @@ test_finish_zlib_paths_and_helpers(void)
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail when finalize_buf cannot allocate");
     /*
-     * finish_zlib() owns the expanded heap buffer and finalize_buf()
-     * frees it on this error path, so buf is dangling here by design.
+     * finish_zlib() frees the heap buffer on finalize_buf failure and
+     * clears *buf_ptr, so buf is NULL here.
      */
     buf = NULL;
     free(decomp);

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1661,11 +1661,8 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail on inflate error");
-    /*
-     * finish_zlib() frees the heap buffer on error and clears
-     * *buf_ptr, so buf is NULL here.
-     */
-    free(buf);
+    TEST_ASSERT(buf == NULL,
+        "finish_zlib should clear buf after freeing heap on inflate error");
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1681,11 +1678,8 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_HTTP_MARKDOWN_DECOMP_BUDGET_EXCEEDED,
         "finish_zlib should return budget exceeded when tail is too large");
-    /*
-     * finish_zlib() frees the heap buffer on budget-exceeded and
-     * clears *buf_ptr, so buf is NULL here.
-     */
-    free(buf);
+    TEST_ASSERT(buf == NULL,
+        "finish_zlib should clear buf after freeing heap on budget exceeded");
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1699,10 +1693,8 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail when initial finish buffer exceeds uInt");
-    /*
-     * g_static_pool_buf is not freed by free_heap (it checks for
-     * this special address), and *buf_ptr is cleared to NULL.
-     */
+    TEST_ASSERT(buf == NULL,
+        "finish_zlib should clear buf on uInt overflow (g_static_pool_buf not freed)");
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1742,11 +1734,8 @@ test_finish_zlib_paths_and_helpers(void)
         decomp, &buf, &buf_size, &produced, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "finish_zlib should fail when finalize_buf cannot allocate");
-    /*
-     * finish_zlib() frees the heap buffer on finalize_buf failure and
-     * clears *buf_ptr, so buf is NULL here.
-     */
-    buf = NULL;
+    TEST_ASSERT(buf == NULL,
+        "finish_zlib should clear buf after freeing heap on finalize failure");
     free(decomp);
 
     TEST_PASS("finish_zlib helper/error/budget/expand branches covered");

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -1694,6 +1694,14 @@ test_feed_mocked_inflate_paths(void)
         &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail when total_decompressed would overflow size_t");
+    /*
+     * This path mirrors the historical apply_limits() ownership bug:
+     * finalize_buf() has already transferred the buffer to pool memory
+     * when apply_limits() reports the overflow error.  Production code
+     * must not ngx_free() the pool-owned buffer on the error return.
+     */
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "post-decode overflow must not ngx_free() pool memory");
     free(decomp);
 
     TEST_PASS("feed mocked inflate branches covered");

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -330,13 +330,16 @@ ngx_free(void *p)
     }
     for (i = 0; i < g_palloc_ptr_count; i++) {
         if (g_palloc_ptrs[i] == p) {
-            fprintf(stderr,
-                "TEST FAIL: ngx_free() called on pool-allocated pointer %p\n"
-                "  pool index=%zu g_palloc_ptr_count=%zu\n"
-                "  This indicates an ownership bug — pool memory must not "
-                "be individually freed.\n",
-                p, i, g_palloc_ptr_count);
-            abort();
+            /*
+             * In this test harness ngx_palloc() is backed by malloc(),
+             * so the pointer is individually freeable.  Remove it from
+             * the tracking set and free it so that subsequent ngx_free()
+             * calls on a recycled address (malloc may reuse it) do not
+             * trigger a false-positive ownership abort.
+             */
+            g_palloc_ptrs[i] = g_palloc_ptrs[--g_palloc_ptr_count];
+            free(p);
+            return;
         }
     }
     free(p);

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -121,10 +121,33 @@ static size_t g_palloc_bytes = 0;
  * so that ngx_free() can detect an illegal free of pool memory.  In real
  * NGINX, pool allocations cannot be individually freed; this catches the
  * ownership bug where apply_limits() called free_heap() on a pool buffer.
+ *
+ * Harness semantics: ngx_palloc() is backed by malloc() so the buffers are
+ * individually reclaimable for leak-free test teardown, but ngx_free() must
+ * NOT silently absorb a pool-pointer free.  Instead it records a violation
+ * flag that the test asserts stays clear.  Test-owned reclamation of these
+ * malloc-backed pool allocations is performed exclusively by
+ * test_pool_free_tracked_allocations(), which bypasses the violation guard.
  */
 #define G_PALLOC_PTR_MAX  256
 static void    *g_palloc_ptrs[G_PALLOC_PTR_MAX];
 static size_t   g_palloc_ptr_count = 0;
+
+/*
+ * g_free_on_palloc_violation - Set when ngx_free() is called with a pointer
+ * that ngx_palloc() returned (i.e. an attempt to individually free pool
+ * memory).  Tests assert this stays 0; a non-zero value indicates a
+ * production-code ownership regression such as apply_limits() freeing a
+ * pool-owned buffer.
+ */
+static ngx_uint_t g_free_on_palloc_violation = 0;
+
+/*
+ * g_free_on_static_pool_violation - Set when ngx_free() is called with
+ * g_static_pool_buf, which simulates a pool-managed buffer whose lifetime
+ * is controlled by the pool, not by free().  Tests assert this stays 0.
+ */
+static ngx_uint_t g_free_on_static_pool_violation = 0;
 
 /*
  * g_pcalloc_fail_once - When non-zero, the next call to ngx_pcalloc returns
@@ -310,12 +333,20 @@ ngx_alloc(size_t size, ngx_log_t *log)
  * ngx_free - Stub for the NGINX deallocator.
  *
  * DIVERGENCE RISK: Production ngx_free may differ from libc free on
- * platforms with custom allocators; this stub simply calls free().
- * The semantic contract mirrored is: "releases memory allocated by
- * ngx_alloc or ngx_palloc stubs."
+ * platforms with custom allocators; this stub calls free() for raw
+ * ngx_alloc-backed heap buffers.  For ngx_palloc-backed buffers and the
+ * static pool-buffer stand-in, it does NOT free; instead it records a
+ * violation flag so tests can assert that production code never attempts
+ * to individually free pool memory (the apply_limits/free_heap ownership
+ * regression).  The semantic contract mirrored is: "releases memory
+ * allocated by ngx_alloc; pool allocations are not individually freeable."
  *
  * Parameters:
  *   p - pointer to memory to free
+ *
+ * Side effects: sets g_free_on_palloc_violation or
+ *               g_free_on_static_pool_violation on a pool-buffer free
+ *               attempt; tests assert these remain 0.
  */
 void
 ngx_free(void *p)
@@ -326,19 +357,19 @@ ngx_free(void *p)
         return;
     }
     if (p == g_static_pool_buf) {
+        g_free_on_static_pool_violation = 1;
         return;
     }
     for (i = 0; i < g_palloc_ptr_count; i++) {
         if (g_palloc_ptrs[i] == p) {
             /*
-             * In this test harness ngx_palloc() is backed by malloc(),
-             * so the pointer is individually freeable.  Remove it from
-             * the tracking set and free it so that subsequent ngx_free()
-             * calls on a recycled address (malloc may reuse it) do not
-             * trigger a false-positive ownership abort.
+             * Production code must never call ngx_free() on a pool
+             * allocation.  Record the violation and leave the tracking
+             * entry intact so the test harness can still reclaim the
+             * malloc-backed block via test_pool_free_tracked_allocations()
+             * during teardown.
              */
-            g_palloc_ptrs[i] = g_palloc_ptrs[--g_palloc_ptr_count];
-            free(p);
+            g_free_on_palloc_violation = 1;
             return;
         }
     }
@@ -590,6 +621,33 @@ compress_payload(const u_char *in, size_t in_len,
     u_char **out, size_t *out_len);
 
 /*
+ * test_pool_free_tracked_allocations - Reclaim the malloc-backed blocks
+ * recorded by the ngx_palloc() stub without going through ngx_free(), so
+ * the ownership-violation guard is not triggered.  This is the only
+ * sanctioned path for releasing pool-allocation stand-ins in this harness.
+ *
+ * After the call, g_palloc_ptrs is empty and g_palloc_ptr_count is 0.
+ * The violation flags are left untouched so the caller can assert them.
+ *
+ * Side effects: free()s every entry in g_palloc_ptrs, resets
+ *               g_palloc_ptr_count to 0.
+ */
+static void
+test_pool_free_tracked_allocations(void)
+{
+    size_t  i;
+
+    for (i = 0; i < g_palloc_ptr_count; i++) {
+        if (g_palloc_ptrs[i] != NULL
+            && g_palloc_ptrs[i] != g_static_pool_buf) {
+            free(g_palloc_ptrs[i]);
+        }
+        g_palloc_ptrs[i] = NULL;
+    }
+    g_palloc_ptr_count = 0;
+}
+
+/*
  * test_pool_reset - Zero-initialise a test pool and clear all failure-injection
  * flags and inflate mock state.  Call at the start of every test case to
  * ensure a clean slate.
@@ -597,22 +655,25 @@ compress_payload(const u_char *in, size_t in_len,
  * Parameters:
  *   tp - test pool to reset
  *
- * Side effects: zeroes *tp, clears all g_*_fail_once flags,
- *               resets inflate mode to real.
+ * Side effects: zeroes *tp, reclaims tracked ngx_palloc allocations,
+ *               clears all g_*_fail_once flags, clears ngx_free violation
+ *               flags, resets inflate mode to real.
  */
 static void
 test_pool_reset(test_pool_t *tp)
 {
+    test_pool_free_tracked_allocations();
     memset(tp, 0, sizeof(*tp));
     g_palloc_fail_once = 0;
     g_palloc_return_static_once = 0;
     g_palloc_bytes = 0;
-    g_palloc_ptr_count = 0;
     g_pcalloc_fail_once = 0;
     g_alloc_fail_once = 0;
     g_alloc_return_static_once = 0;
     g_cleanup_add_fail_once = 0;
     g_inflate_init_fail_once = 0;
+    g_free_on_palloc_violation = 0;
+    g_free_on_static_pool_violation = 0;
     test_reset_inflate_mode();
 }
 
@@ -661,13 +722,22 @@ test_tiny_chunks_do_not_amplify_request_pool(void)
             &tp.pool, &test_log);
         TEST_ASSERT(rc == NGX_OK, "one-byte feed should succeed");
         emitted += out_len;
-        free(out);
+        /*
+         * out is pool-owned (ngx_palloc-tracked); reclaim via the
+         * sanctioned helper rather than free() so the ownership
+         * guard stays armed across iterations.
+         */
+        test_pool_free_tracked_allocations();
     }
 
     TEST_ASSERT(emitted == text_len,
         "tiny feeds should emit the complete decompressed payload");
     TEST_ASSERT(g_palloc_bytes <= emitted,
         "request-pool allocation must be bounded by emitted output");
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "production code must not ngx_free() pool memory");
+    TEST_ASSERT(g_free_on_static_pool_violation == 0,
+        "production code must not ngx_free() static pool memory");
 
     free(compressed);
     free(decomp);
@@ -714,7 +784,8 @@ test_truncated_brotli_finish_errors(void)
         &out, &out_len, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_OK,
         "truncated brotli feed should await terminal validation");
-    free(out);
+    /* out is pool-owned; reclaim via the sanctioned helper. */
+    test_pool_free_tracked_allocations();
 
     out = NULL;
     out_len = 0;
@@ -723,8 +794,13 @@ test_truncated_brotli_finish_errors(void)
     TEST_ASSERT(rc == NGX_ERROR,
         "finish should reject an incomplete brotli stream");
 
+    /* finish error path publishes NULL output. */
     free(out);
     free(decomp);
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "production code must not ngx_free() pool memory");
+    TEST_ASSERT(g_free_on_static_pool_violation == 0,
+        "production code must not ngx_free() static pool memory");
     TEST_PASS("truncated brotli stream rejected at finish");
 }
 #endif
@@ -1078,8 +1154,12 @@ test_roundtrip_and_empty_feed(void)
         }
 
         free(compressed);
-        free(out);
+        /* out is pool-owned; reclaimed by the next test_pool_reset. */
         free(decomp);
+        TEST_ASSERT(g_free_on_palloc_violation == 0,
+            "production code must not ngx_free() pool memory");
+        TEST_ASSERT(g_free_on_static_pool_violation == 0,
+            "production code must not ngx_free() static pool memory");
     }
 
     TEST_PASS("feed round-trip and empty-input branches covered");
@@ -1228,8 +1308,12 @@ test_truncated_finish_errors(void)
     }
 
     free(compressed);
-    free(out);
+    /* out is pool-owned; reclaimed by the next test_pool_reset. */
     free(decomp);
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "production code must not ngx_free() pool memory");
+    TEST_ASSERT(g_free_on_static_pool_violation == 0,
+        "production code must not ngx_free() static pool memory");
     TEST_PASS("finish error branch covered");
 }
 
@@ -1715,9 +1799,10 @@ test_finish_zlib_paths_and_helpers(void)
     /*
      * On success finalize_buf() transfers the heap buffer to pool
      * memory and frees the heap allocation, so buf now points to a
-     * pool-owned buffer (malloc-backed in this harness).
+     * pool-owned buffer (malloc-backed in this harness).  Reclaim it
+     * via the sanctioned helper rather than free().
      */
-    free(buf);
+    test_pool_free_tracked_allocations();
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1738,6 +1823,10 @@ test_finish_zlib_paths_and_helpers(void)
         "finish_zlib should clear buf after freeing heap on finalize failure");
     free(decomp);
 
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "production code must not ngx_free() pool memory");
+    TEST_ASSERT(g_free_on_static_pool_violation == 0,
+        "production code must not ngx_free() static pool memory");
     TEST_PASS("finish_zlib helper/error/budget/expand branches covered");
 }
 
@@ -1781,7 +1870,7 @@ test_finish_wrapper_success_and_overflow_paths(void)
         "finish should publish tail output on success");
     TEST_ASSERT(decomp->total_decompressed > 1,
         "finish should add produced bytes into running total");
-    free(out);
+    /* out is pool-owned; reclaimed by the next test_pool_reset. */
     free(decomp);
 
     test_pool_reset(&tp);
@@ -1798,10 +1887,77 @@ test_finish_wrapper_success_and_overflow_paths(void)
         "finish should still succeed when total would overflow");
     TEST_ASSERT(decomp->total_decompressed == (size_t) -1,
         "finish should saturate total_decompressed on overflow");
-    free(out);
+    /* out is pool-owned; reclaimed by the next test_pool_reset. */
     free(decomp);
 
+    TEST_ASSERT(g_free_on_palloc_violation == 0,
+        "production code must not ngx_free() pool memory");
+    TEST_ASSERT(g_free_on_static_pool_violation == 0,
+        "production code must not ngx_free() static pool memory");
     TEST_PASS("finish wrapper success/overflow branches covered");
+}
+
+/*
+ * test_ngx_free_rejects_pool_memory - Verify the ownership-tracking guard
+ * actually fires when ngx_free() is handed a pool-backed pointer.
+ *
+ * This is the regression test for the apply_limits()/free_heap() ownership
+ * bug class: production code must never call ngx_free() on a buffer
+ * allocated by ngx_palloc() (pool memory is not individually freeable in
+ * real NGINX).  The guard must surface the violation rather than silently
+ * absorbing it, otherwise the harness cannot detect a future regression.
+ *
+ * Branches covered:
+ *   - ngx_free() on a tracked ngx_palloc() pointer sets the violation flag
+ *     and does NOT free the block (so the harness can still reclaim it)
+ *   - ngx_free() on g_static_pool_buf sets the static-pool violation flag
+ *   - ngx_free() on an untracked ngx_alloc() heap pointer frees normally
+ *     and sets neither flag
+ */
+static void
+test_ngx_free_rejects_pool_memory(void)
+{
+    test_pool_t  tp;
+    u_char     *pool_ptr;
+    u_char     *heap_ptr;
+
+    TEST_SUBSECTION("ngx_free ownership guard fires on pool memory");
+
+    test_pool_reset(&tp);
+
+    /* A tracked ngx_palloc() pointer. */
+    pool_ptr = ngx_palloc(&tp.pool, 32);
+    TEST_ASSERT(pool_ptr != NULL, "ngx_palloc should succeed");
+    TEST_ASSERT(g_palloc_ptr_count == 1,
+        "ngx_palloc pointer should be tracked");
+
+    /* ngx_free() must not reclaim it; it must flag the violation. */
+    ngx_free(pool_ptr);
+    TEST_ASSERT(g_free_on_palloc_violation == 1,
+        "ngx_free on a pool pointer must set the violation flag");
+    TEST_ASSERT(g_palloc_ptr_count == 1,
+        "ngx_free must not remove the tracked pool pointer");
+
+    /* A second ngx_free() on the static pool stand-in. */
+    ngx_free(g_static_pool_buf);
+    TEST_ASSERT(g_free_on_static_pool_violation == 1,
+        "ngx_free on the static pool buffer must set the violation flag");
+
+    /* An untracked ngx_alloc() heap pointer frees normally. */
+    heap_ptr = ngx_alloc(16, &test_log);
+    TEST_ASSERT(heap_ptr != NULL, "ngx_alloc should succeed");
+    ngx_free(heap_ptr);
+    TEST_ASSERT(g_free_on_palloc_violation == 1,
+        "heap free must not clear the pool-violation flag");
+    TEST_ASSERT(g_free_on_static_pool_violation == 1,
+        "heap free must not clear the static-pool-violation flag");
+
+    /* Reclaim the tracked pool allocation via the sanctioned helper. */
+    test_pool_free_tracked_allocations();
+    TEST_ASSERT(g_palloc_ptr_count == 0,
+        "tracked allocations should be reclaimed by the helper");
+
+    TEST_PASS("ngx_free ownership guard covered");
 }
 
 /*
@@ -1832,6 +1988,7 @@ main(void)
     test_feed_mocked_inflate_paths();
     test_finish_zlib_paths_and_helpers();
     test_finish_wrapper_success_and_overflow_paths();
+    test_ngx_free_rejects_pool_memory();
 
     printf("\n========================================\n");
     printf("All tests passed!\n");

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -117,6 +117,16 @@ static ngx_uint_t g_palloc_return_static_once = 0;
 static size_t g_palloc_bytes = 0;
 
 /*
+ * g_palloc_ptrs / g_palloc_ptr_count — Tracks pointers returned by ngx_palloc
+ * so that ngx_free() can detect an illegal free of pool memory.  In real
+ * NGINX, pool allocations cannot be individually freed; this catches the
+ * ownership bug where apply_limits() called free_heap() on a pool buffer.
+ */
+#define G_PALLOC_PTR_MAX  256
+static void    *g_palloc_ptrs[G_PALLOC_PTR_MAX];
+static size_t   g_palloc_ptr_count = 0;
+
+/*
  * g_pcalloc_fail_once - When non-zero, the next call to ngx_pcalloc returns
  * NULL and the flag is cleared.  Used to inject a single zeroed-allocation
  * failure.
@@ -222,6 +232,8 @@ test_reset_inflate_mode(void)
 void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
+    void  *p;
+
     UNUSED(pool);
     g_palloc_bytes += size;
     if (g_palloc_fail_once) {
@@ -232,7 +244,11 @@ ngx_palloc(ngx_pool_t *pool, size_t size)
         g_palloc_return_static_once = 0;
         return g_static_pool_buf;
     }
-    return malloc(size);
+    p = malloc(size);
+    if (p != NULL && g_palloc_ptr_count < G_PALLOC_PTR_MAX) {
+        g_palloc_ptrs[g_palloc_ptr_count++] = p;
+    }
+    return p;
 }
 
 /*
@@ -304,8 +320,24 @@ ngx_alloc(size_t size, ngx_log_t *log)
 void
 ngx_free(void *p)
 {
+    size_t  i;
+
+    if (p == NULL) {
+        return;
+    }
     if (p == g_static_pool_buf) {
         return;
+    }
+    for (i = 0; i < g_palloc_ptr_count; i++) {
+        if (g_palloc_ptrs[i] == p) {
+            fprintf(stderr,
+                "TEST FAIL: ngx_free() called on pool-allocated pointer %p\n"
+                "  pool index=%zu g_palloc_ptr_count=%zu\n"
+                "  This indicates an ownership bug — pool memory must not "
+                "be individually freed.\n",
+                p, i, g_palloc_ptr_count);
+            abort();
+        }
     }
     free(p);
 }
@@ -572,6 +604,7 @@ test_pool_reset(test_pool_t *tp)
     g_palloc_fail_once = 0;
     g_palloc_return_static_once = 0;
     g_palloc_bytes = 0;
+    g_palloc_ptr_count = 0;
     g_pcalloc_fail_once = 0;
     g_alloc_fail_once = 0;
     g_alloc_return_static_once = 0;

--- a/components/nginx-module/tests/unit/streaming_decomp_test.c
+++ b/components/nginx-module/tests/unit/streaming_decomp_test.c
@@ -20,6 +20,10 @@
 #include <limits.h>
 #include <zlib.h>
 
+#ifdef NGX_HTTP_BROTLI
+#include <brotli/encode.h>
+#endif
+
 #define NGX_OK 0
 #define NGX_ERROR -1
 #define NGX_AGAIN -2
@@ -109,6 +113,9 @@ static ngx_uint_t g_palloc_fail_once = 0;
  */
 static ngx_uint_t g_palloc_return_static_once = 0;
 
+/* Total request-pool bytes requested by the production path under test. */
+static size_t g_palloc_bytes = 0;
+
 /*
  * g_pcalloc_fail_once - When non-zero, the next call to ngx_pcalloc returns
  * NULL and the flag is cleared.  Used to inject a single zeroed-allocation
@@ -122,6 +129,9 @@ static ngx_uint_t g_pcalloc_fail_once = 0;
  * failure (e.g. for buffer expansion).
  */
 static ngx_uint_t g_alloc_fail_once = 0;
+
+/* Return a non-freeable stand-in once for huge-size guard tests. */
+static ngx_uint_t g_alloc_return_static_once = 0;
 
 /*
  * g_cleanup_add_fail_once - When non-zero, the next call to
@@ -213,6 +223,7 @@ void *
 ngx_palloc(ngx_pool_t *pool, size_t size)
 {
     UNUSED(pool);
+    g_palloc_bytes += size;
     if (g_palloc_fail_once) {
         g_palloc_fail_once = 0;
         return NULL;
@@ -272,6 +283,10 @@ ngx_alloc(size_t size, ngx_log_t *log)
         g_alloc_fail_once = 0;
         return NULL;
     }
+    if (g_alloc_return_static_once) {
+        g_alloc_return_static_once = 0;
+        return g_static_pool_buf;
+    }
     return malloc(size);
 }
 
@@ -289,6 +304,9 @@ ngx_alloc(size_t size, ngx_log_t *log)
 void
 ngx_free(void *p)
 {
+    if (p == g_static_pool_buf) {
+        return;
+    }
     free(p);
 }
 
@@ -531,6 +549,11 @@ typedef struct {
     ngx_pool_t            pool;
 } test_pool_t;
 
+static int
+compress_payload(const u_char *in, size_t in_len,
+    ngx_http_markdown_compression_type_e type,
+    u_char **out, size_t *out_len);
+
 /*
  * test_pool_reset - Zero-initialise a test pool and clear all failure-injection
  * flags and inflate mock state.  Call at the start of every test case to
@@ -548,12 +571,127 @@ test_pool_reset(test_pool_t *tp)
     memset(tp, 0, sizeof(*tp));
     g_palloc_fail_once = 0;
     g_palloc_return_static_once = 0;
+    g_palloc_bytes = 0;
     g_pcalloc_fail_once = 0;
     g_alloc_fail_once = 0;
+    g_alloc_return_static_once = 0;
     g_cleanup_add_fail_once = 0;
     g_inflate_init_fail_once = 0;
     test_reset_inflate_mode();
 }
+
+
+/*
+ * Feed a valid gzip stream one compressed byte at a time and verify that
+ * request-pool allocation tracks emitted output rather than chunk count.
+ */
+static void
+test_tiny_chunks_do_not_amplify_request_pool(void)
+{
+    const char                          *text;
+    size_t                               text_len;
+    u_char                              *compressed;
+    size_t                               compressed_len;
+    test_pool_t                          tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    size_t                               emitted;
+    ngx_int_t                            rc;
+
+    TEST_SUBSECTION("tiny chunks keep request-pool use output-bounded");
+
+    text = "tiny compressed chunks must not reserve 4 KiB each";
+    text_len = test_cstrnlen(text, 1024);
+    compressed = NULL;
+    test_pool_reset(&tp);
+
+    rc = compress_payload((const u_char *) text, text_len,
+                          NGX_HTTP_MARKDOWN_COMPRESSION_GZIP,
+                          &compressed, &compressed_len);
+    TEST_ASSERT(rc == NGX_OK, "compression should succeed");
+
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_GZIP, text_len + 1);
+    TEST_ASSERT(decomp != NULL, "decompressor should be created");
+
+    emitted = 0;
+    for (size_t i = 0; i < compressed_len; i++) {
+        u_char  *out;
+        size_t   out_len;
+
+        out = NULL;
+        out_len = 0;
+        rc = ngx_http_markdown_streaming_decomp_feed(
+            decomp, &compressed[i], 1, &out, &out_len,
+            &tp.pool, &test_log);
+        TEST_ASSERT(rc == NGX_OK, "one-byte feed should succeed");
+        emitted += out_len;
+        free(out);
+    }
+
+    TEST_ASSERT(emitted == text_len,
+        "tiny feeds should emit the complete decompressed payload");
+    TEST_ASSERT(g_palloc_bytes <= emitted,
+        "request-pool allocation must be bounded by emitted output");
+
+    free(compressed);
+    free(decomp);
+    TEST_PASS("tiny chunk request-pool amplification rejected");
+}
+
+
+#ifdef NGX_HTTP_BROTLI
+/* Verify terminal validation rejects a Brotli stream missing its tail. */
+static void
+test_truncated_brotli_finish_errors(void)
+{
+    const uint8_t                        text[] =
+        "truncated brotli input must fail at finish";
+    size_t                               compressed_len;
+    uint8_t                              compressed[256];
+    test_pool_t                          tp;
+    ngx_http_markdown_streaming_decomp_t *decomp;
+    u_char                              *out;
+    size_t                               out_len;
+    ngx_int_t                            rc;
+
+    TEST_SUBSECTION("finish error on truncated brotli stream");
+
+    compressed_len = sizeof(compressed);
+    TEST_ASSERT(BrotliEncoderCompress(
+                    BROTLI_DEFAULT_QUALITY, BROTLI_DEFAULT_WINDOW,
+                    BROTLI_MODE_TEXT, sizeof(text) - 1, text,
+                    &compressed_len, compressed)
+                == BROTLI_TRUE,
+        "brotli compression should succeed");
+    TEST_ASSERT(compressed_len > 2,
+        "brotli payload should be long enough to truncate");
+
+    test_pool_reset(&tp);
+    decomp = ngx_http_markdown_streaming_decomp_create(
+        &tp.pool, NGX_HTTP_MARKDOWN_COMPRESSION_BROTLI, sizeof(text));
+    TEST_ASSERT(decomp != NULL, "brotli decompressor should be created");
+
+    out = NULL;
+    out_len = 0;
+    rc = ngx_http_markdown_streaming_decomp_feed(
+        decomp, compressed, compressed_len - 2,
+        &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_OK,
+        "truncated brotli feed should await terminal validation");
+    free(out);
+
+    out = NULL;
+    out_len = 0;
+    rc = ngx_http_markdown_streaming_decomp_finish(
+        decomp, &out, &out_len, &tp.pool, &test_log);
+    TEST_ASSERT(rc == NGX_ERROR,
+        "finish should reject an incomplete brotli stream");
+
+    free(out);
+    free(decomp);
+    TEST_PASS("truncated brotli stream rejected at finish");
+}
+#endif
 
 /*
  * test_pool_run_cleanups - Execute all registered cleanup handlers on a
@@ -1113,7 +1251,7 @@ test_create_helper_and_limit_branches(void)
     buf = heap_buf;
     buf_size = (size_t) -1;
     rc = ngx_http_markdown_streaming_decomp_expand_buf(
-        &heap_buf, &buf, &buf_size, &test_log);
+        &heap_buf, &buf, &buf_size, 0, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "expand_buf should fail on size overflow");
     TEST_ASSERT(heap_buf == NULL,
@@ -1126,7 +1264,7 @@ test_create_helper_and_limit_branches(void)
     buf_size = 8;
     g_alloc_fail_once = 1;
     rc = ngx_http_markdown_streaming_decomp_expand_buf(
-        &heap_buf, &buf, &buf_size, &test_log);
+        &heap_buf, &buf, &buf_size, 0, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "expand_buf should fail when ngx_alloc fails");
     TEST_ASSERT(heap_buf == NULL,
@@ -1314,36 +1452,36 @@ test_feed_empty_and_large_size_paths(void)
     TEST_ASSERT(out == NULL && out_len == 0,
         "zero-length input should not produce output");
 
-    g_palloc_fail_once = 1;
+    g_alloc_fail_once = 1;
     rc = ngx_http_markdown_streaming_decomp_feed(
         decomp, (const u_char *) "x", 1, &out, &out_len,
         &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail when initial output buffer allocation fails");
 
-    g_palloc_fail_once = 0;
-    g_palloc_return_static_once = 0;
+    g_alloc_fail_once = 0;
+    g_alloc_return_static_once = 0;
     huge_in_len = ((size_t) -1 / 4) + 1;
     one_byte = 'x';
     out = NULL;
     out_len = 0;
-    g_palloc_return_static_once = 1;
+    g_alloc_return_static_once = 1;
     rc = ngx_http_markdown_streaming_decomp_feed(
         decomp, &one_byte, huge_in_len, &out, &out_len,
         &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail safely on saturated initial size");
-    g_palloc_return_static_once = 0;
+    g_alloc_return_static_once = 0;
 
     out = NULL;
     out_len = 0;
-    g_palloc_return_static_once = 1;
+    g_alloc_return_static_once = 1;
     rc = ngx_http_markdown_streaming_decomp_feed(
         decomp, &one_byte, ((size_t) UINT_MAX / 2) + 1,
         &out, &out_len, &tp.pool, &test_log);
     TEST_ASSERT(rc == NGX_ERROR,
         "feed should fail when output buffer size exceeds zlib uInt");
-    g_palloc_return_static_once = 0;
+    g_alloc_return_static_once = 0;
 
     free(decomp);
     TEST_PASS("feed empty/large-size branches covered");
@@ -1637,6 +1775,10 @@ main(void)
     test_create_and_cleanup();
     test_create_failure_paths_and_cleanup_default();
     test_roundtrip_and_empty_feed();
+#ifdef NGX_HTTP_BROTLI
+    test_truncated_brotli_finish_errors();
+#endif
+    test_tiny_chunks_do_not_amplify_request_pool();
     test_budget_and_invalid_type_branches();
     test_truncated_finish_errors();
     test_create_helper_and_limit_branches();

--- a/components/nginx-module/tests/unit/streaming_impl_test.c
+++ b/components/nginx-module/tests/unit/streaming_impl_test.c
@@ -294,6 +294,7 @@ struct ngx_time_s {
  */
 static ngx_int_t g_next_body_filter_rc = NGX_OK;
 static ngx_uint_t g_next_body_filter_calls = 0;
+static ngx_chain_t *g_next_body_filter_last_in = NULL;
 static ngx_int_t g_next_header_filter_rc = NGX_OK;
 static ngx_int_t g_complex_value_rc = NGX_OK;
 static ngx_int_t g_add_vary_rc = NGX_OK;
@@ -417,8 +418,8 @@ static ngx_int_t
 ngx_http_next_body_filter_stub(ngx_http_request_t *r, ngx_chain_t *in)
 {
     UNUSED(r);
-    UNUSED(in);
     g_next_body_filter_calls++;
+    g_next_body_filter_last_in = in;
     if (g_next_body_filter_seq_idx < g_next_body_filter_seq_len) {
         return g_next_body_filter_seq[g_next_body_filter_seq_idx++];
     }
@@ -1195,6 +1196,7 @@ reset_globals(void)
 {
     g_next_body_filter_rc = NGX_OK;
     g_next_body_filter_calls = 0;
+    g_next_body_filter_last_in = NULL;
     g_next_header_filter_rc = NGX_OK;
     g_complex_value_rc = NGX_OK;
     g_add_vary_rc = NGX_OK;
@@ -1567,6 +1569,7 @@ test_send_output_and_resume_paths(void)
     ngx_chain_t             c_ok;
     ngx_buf_t               b_err;
     ngx_chain_t             c_err;
+    ngx_chain_t            *pending_anchor;
     u_char                  data[] = "hello";
     ngx_int_t               rc;
 
@@ -1597,12 +1600,26 @@ test_send_output_and_resume_paths(void)
     TEST_ASSERT(rc == NGX_AGAIN, "send_output should propagate NGX_AGAIN");
     TEST_ASSERT(ctx.streaming.pending_output != NULL,
         "NGX_AGAIN should store pending output");
+    pending_anchor = ctx.streaming.pending_output;
     TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
         "NGX_AGAIN should set buffered flag");
+
+    g_next_body_filter_rc = NGX_AGAIN;
+    rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
+    TEST_ASSERT(rc == NGX_AGAIN,
+        "resume_pending should preserve persistent backpressure");
+    TEST_ASSERT(g_next_body_filter_last_in == NULL,
+        "resume_pending must drain downstream-owned state with NULL");
+    TEST_ASSERT(ctx.streaming.pending_output == pending_anchor,
+        "persistent backpressure must preserve the pending anchor");
+    TEST_ASSERT((r.buffered & NGX_HTTP_MARKDOWN_BUFFERED) != 0,
+        "persistent backpressure must preserve the buffered flag");
 
     g_next_body_filter_rc = NGX_OK;
     rc = ngx_http_markdown_streaming_resume_pending(&r, &ctx, &conf);
     TEST_ASSERT(rc == NGX_OK, "resume_pending should drain pending chain");
+    TEST_ASSERT(g_next_body_filter_last_in == NULL,
+        "successful resume must not resubmit the original chain");
     TEST_ASSERT(ctx.streaming.pending_output == NULL,
         "resume should clear pending chain");
     TEST_ASSERT(ctx.streaming.pending_has_data == 0,

--- a/components/rust-converter/Cargo.lock
+++ b/components/rust-converter/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "brotli",

--- a/components/rust-converter/Cargo.toml
+++ b/components/rust-converter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nginx-markdown-converter"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.91"
 authors = ["NGINX Markdown for Agents Contributors"]

--- a/components/rust-converter/fuzz/Cargo.lock
+++ b/components/rust-converter/fuzz/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -46,15 +46,15 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -210,9 +210,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markup5ever"
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -280,7 +280,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "brotli",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "scopeguard"
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -481,15 +481,15 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "string_cache"
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -551,18 +551,18 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",

--- a/components/rust-converter/include/markdown_converter.h
+++ b/components/rust-converter/include/markdown_converter.h
@@ -823,16 +823,12 @@ void markdown_make_decision(uint8_t enabled,
 
 /**
  * Build a header plan for a successful Markdown conversion.
- *
  * The returned plan contains Rust-owned buffers. The C caller must release
  * the plan via `markdown_header_plan_free`.
- *
  * This function treats `result` as uninitialized output storage and never
  * reads its previous fields. Callers that already own a plan in the same
  * storage must call `markdown_header_plan_free` before rebuilding it.
- *
  * # Safety
- *
  * The caller must ensure that:
  * - `content_type` points to readable UTF-8 bytes of `content_type_len`
  * - `result` points to writable storage for a `FFIHeaderPlan`; its previous

--- a/components/rust-converter/include/markdown_converter.h
+++ b/components/rust-converter/include/markdown_converter.h
@@ -827,11 +827,17 @@ void markdown_make_decision(uint8_t enabled,
  * The returned plan contains Rust-owned buffers. The C caller must release
  * the plan via `markdown_header_plan_free`.
  *
+ * This function treats `result` as uninitialized output storage and never
+ * reads its previous fields. Callers that already own a plan in the same
+ * storage must call `markdown_header_plan_free` before rebuilding it.
+ *
  * # Safety
  *
  * The caller must ensure that:
  * - `content_type` points to readable UTF-8 bytes of `content_type_len`
- * - `result` points to writable storage for a `FFIHeaderPlan`
+ * - `result` points to writable storage for a `FFIHeaderPlan`; its previous
+ *   bytes may be uninitialized, but any previously-owned plan must have been
+ *   released before this call
  */
 void markdown_build_header_plan(const uint8_t *content_type,
                                 uintptr_t content_type_len,

--- a/components/rust-converter/src/converter.rs
+++ b/components/rust-converter/src/converter.rs
@@ -588,7 +588,7 @@ impl MarkdownConverter {
 
         // Extract metadata and add YAML front matter if enabled
         if self.options.include_front_matter && self.options.extract_metadata {
-            self.maybe_write_front_matter_from_dom(dom, &mut output)?;
+            self.maybe_write_front_matter_from_dom(dom, &mut output, ctx)?;
             // Check timeout after metadata extraction
             ctx.check_timeout()?;
         }
@@ -2470,6 +2470,28 @@ mod tests {
 
         assert!(result.contains("```javascript"));
         assert!(result.contains("const x = 42;"));
+    }
+
+    #[test]
+    fn test_code_block_preserves_common_safe_language_identifiers() {
+        let html = b"<pre><code class=\"language-c++\">int main() {}</code></pre>";
+        let dom = parse_html(html).expect("Parse failed");
+        let converter = MarkdownConverter::new();
+        let result = converter.convert(&dom).expect("Conversion failed");
+
+        assert!(result.contains("```c++\n"));
+    }
+
+    #[test]
+    fn test_code_block_rejects_language_that_can_break_fence() {
+        let html = b"<pre><code class=\"language-```yaml\">safe: value</code></pre>";
+        let dom = parse_html(html).expect("Parse failed");
+        let converter = MarkdownConverter::new();
+        let result = converter.convert(&dom).expect("Conversion failed");
+
+        assert!(result.contains("```\nsafe: value\n```"));
+        assert!(!result.contains("```yaml"));
+        assert!(!result.contains("``````yaml"));
     }
 
     #[test]

--- a/components/rust-converter/src/converter/blocks.rs
+++ b/components/rust-converter/src/converter/blocks.rs
@@ -348,10 +348,10 @@ impl MarkdownConverter {
                         let class_value = attr.value.to_string();
                         for class in class_value.split_whitespace() {
                             if let Some(lang) = class.strip_prefix("language-") {
-                                language = lang.to_string();
+                                language = Self::safe_code_language(lang).unwrap_or_default();
                                 break;
                             } else if let Some(lang) = class.strip_prefix("lang-") {
-                                language = lang.to_string();
+                                language = Self::safe_code_language(lang).unwrap_or_default();
                                 break;
                             }
                         }
@@ -383,5 +383,19 @@ impl MarkdownConverter {
         output.push('\n');
 
         Ok(())
+    }
+
+    /// Accept common code-language identifiers without allowing characters
+    /// that can alter the opening Markdown fence or inject a new line.
+    fn safe_code_language(language: &str) -> Option<String> {
+        if !language.is_empty()
+            && language.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'+' | b'.' | b'#')
+            })
+        {
+            return Some(language.to_string());
+        }
+
+        None
     }
 }

--- a/components/rust-converter/src/converter/blocks.rs
+++ b/components/rust-converter/src/converter/blocks.rs
@@ -343,25 +343,25 @@ impl MarkdownConverter {
             } = child.data
                 && name.local.as_ref() == "code"
             {
-                    for attr in attrs.borrow().iter() {
-                        if attr.name.local.as_ref() == "class" {
-                            let class_value = attr.value.to_string();
-                            for class in class_value.split_whitespace() {
-                                let candidate = class
-                                    .strip_prefix("language-")
-                                    .or_else(|| class.strip_prefix("lang-"));
-                                if let Some(lang) = candidate
-                                    && let Some(valid) = Self::safe_code_language(lang)
-                                {
-                                    language = valid;
-                                    break;
-                                }
-                            }
-                            if !language.is_empty() {
+                for attr in attrs.borrow().iter() {
+                    if attr.name.local.as_ref() == "class" {
+                        let class_value = attr.value.to_string();
+                        for class in class_value.split_whitespace() {
+                            let candidate = class
+                                .strip_prefix("language-")
+                                .or_else(|| class.strip_prefix("lang-"));
+                            if let Some(lang) = candidate
+                                && let Some(valid) = Self::safe_code_language(lang)
+                            {
+                                language = valid;
                                 break;
                             }
                         }
+                        if !language.is_empty() {
+                            break;
+                        }
                     }
+                }
             }
         }
 

--- a/components/rust-converter/src/converter/blocks.rs
+++ b/components/rust-converter/src/converter/blocks.rs
@@ -343,23 +343,25 @@ impl MarkdownConverter {
             } = child.data
                 && name.local.as_ref() == "code"
             {
-                for attr in attrs.borrow().iter() {
-                    if attr.name.local.as_ref() == "class" {
-                        let class_value = attr.value.to_string();
-                        for class in class_value.split_whitespace() {
-                            if let Some(lang) = class.strip_prefix("language-") {
-                                language = Self::safe_code_language(lang).unwrap_or_default();
-                                break;
-                            } else if let Some(lang) = class.strip_prefix("lang-") {
-                                language = Self::safe_code_language(lang).unwrap_or_default();
+                    for attr in attrs.borrow().iter() {
+                        if attr.name.local.as_ref() == "class" {
+                            let class_value = attr.value.to_string();
+                            for class in class_value.split_whitespace() {
+                                let candidate = class
+                                    .strip_prefix("language-")
+                                    .or_else(|| class.strip_prefix("lang-"));
+                                if let Some(lang) = candidate
+                                    && let Some(valid) = Self::safe_code_language(lang)
+                                {
+                                    language = valid;
+                                    break;
+                                }
+                            }
+                            if !language.is_empty() {
                                 break;
                             }
                         }
-                        if !language.is_empty() {
-                            break;
-                        }
                     }
-                }
             }
         }
 

--- a/components/rust-converter/src/converter/front_matter.rs
+++ b/components/rust-converter/src/converter/front_matter.rs
@@ -32,6 +32,7 @@ impl MarkdownConverter {
         &self,
         dom: &markup5ever_rcdom::RcDom,
         output: &mut String,
+        ctx: &mut ConversionContext,
     ) -> Result<(), ConversionError> {
         if !(self.options.include_front_matter && self.options.extract_metadata) {
             return Ok(());
@@ -42,9 +43,8 @@ impl MarkdownConverter {
             self.options.resolve_relative_urls,
         );
 
-        if let Ok(metadata) = extractor.extract(dom) {
-            self.write_front_matter(output, &metadata)?;
-        }
+        let metadata = extractor.extract_with_context(dom, ctx)?;
+        self.write_front_matter(output, &metadata)?;
 
         Ok(())
     }

--- a/components/rust-converter/src/ffi/convert.rs
+++ b/components/rust-converter/src/ffi/convert.rs
@@ -30,6 +30,47 @@ use crate::token_estimator::TokenEstimator;
 use super::abi::{ConversionOutput, MarkdownConverterHandle, MarkdownOptions};
 use super::options::decode_options;
 
+/* Fixed parser overhead covers tokenizer/tree-builder state and the DOM root.
+ * The per-input multiplier includes the source buffer, a worst-case UTF-8
+ * transcode expansion, and parser scratch space. Each '<' may begin a DOM node
+ * (including malformed markup recovery), so account for RcDom allocation and
+ * associated strings separately. This is intentionally conservative because
+ * html5ever does not expose allocator-level accounting. */
+const PARSER_FIXED_OVERHEAD: u64 = 1024;
+const PARSER_BYTES_PER_INPUT_BYTE: u64 = 7;
+const PARSER_BYTES_PER_TAG_OPENER: u64 = 512;
+
+/// Estimate the peak parser/transcoding/DOM working set before parsing.
+///
+/// Returns `u64::MAX` on arithmetic overflow so callers fail closed against
+/// every finite parser budget.
+pub(crate) fn estimate_parser_working_set(input_len: usize, tag_openers: usize) -> u64 {
+    let input_len = u64::try_from(input_len).unwrap_or(u64::MAX);
+    let tag_openers = u64::try_from(tag_openers).unwrap_or(u64::MAX);
+
+    input_len
+        .checked_mul(PARSER_BYTES_PER_INPUT_BYTE)
+        .and_then(|bytes| {
+            tag_openers
+                .checked_mul(PARSER_BYTES_PER_TAG_OPENER)
+                .and_then(|nodes| bytes.checked_add(nodes))
+        })
+        .and_then(|bytes| bytes.checked_add(PARSER_FIXED_OVERHEAD))
+        .unwrap_or(u64::MAX)
+}
+
+/// Return the largest raw input that can fit a parser budget before accounting
+/// for tag-specific DOM allocations. Incremental callers use this as an early
+/// buffer ceiling and apply the full estimate while chunks arrive.
+pub(crate) fn max_input_for_parser_budget(parser_budget: u64) -> usize {
+    if parser_budget == 0 {
+        return 0;
+    }
+
+    let bytes = parser_budget.saturating_sub(PARSER_FIXED_OVERHEAD) / PARSER_BYTES_PER_INPUT_BYTE;
+    usize::try_from(bytes).unwrap_or(usize::MAX)
+}
+
 /// Execute one FFI conversion request end-to-end.
 ///
 /// This function is intentionally linear: decode options, parse HTML, run
@@ -41,9 +82,9 @@ use super::options::decode_options;
 /// Since html5ever cannot be interrupted mid-parse, this function enforces
 /// `parse_timeout` and `parser_memory_budget` via pre/post checks:
 ///
-/// - **Pre-check (budget):** If `parser_memory_budget > 0` and the input size
-///   exceeds it, the request is rejected with `ParseBudgetExceeded`. Input
-///   size is used as a proxy because html5ever does not expose memory tracking.
+/// - **Pre-check (budget):** If `parser_memory_budget > 0`, a conservative,
+///   overflow-safe estimate covers fixed parser state, raw input, worst-case
+///   UTF-8 transcoding, parser scratch space, and DOM-node amplification.
 /// - **Pre-check (deadline):** If the parse deadline has already expired before
 ///   parsing begins, the request is rejected with `ParseTimeout`.
 /// - **Post-check (deadline):** If parsing completes but the deadline has
@@ -86,18 +127,20 @@ pub(crate) fn convert_inner(
     }
 
     // --- Parser memory budget pre-check ---
-    // html5ever does not expose memory tracking, so use input size as a proxy:
-    // if the raw HTML exceeds the configured parser_memory_budget, reject early.
+    // html5ever does not expose allocator accounting. Estimate the complete
+    // parser/transcoding/DOM working set and fail closed on arithmetic overflow.
     let input_size = html_slice.len();
     let parser_budget = decoded.parser_memory_budget;
-    if parser_budget > 0 && input_size as u64 > parser_budget {
+    let tag_openers = html_slice.iter().filter(|byte| **byte == b'<').count();
+    let parser_working_set = estimate_parser_working_set(input_size, tag_openers);
+    if parser_budget > 0 && parser_working_set > parser_budget {
         // `limit` is reported for diagnostics only. Use a saturating
         // conversion so the u64 budget never silently truncates when usize is
         // narrower than u64 (e.g. 32-bit targets); on 64-bit targets this is
         // an identity conversion.
         let limit = usize::try_from(parser_budget).unwrap_or(usize::MAX);
         return Err(ConversionError::ParseBudgetExceeded {
-            used: input_size,
+            used: usize::try_from(parser_working_set).unwrap_or(usize::MAX),
             limit,
         });
     }
@@ -160,4 +203,49 @@ pub(crate) fn convert_inner(
         etag,
         token_estimate,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::exports::markdown_options_init;
+
+    #[test]
+    fn parser_working_set_accounts_for_transcoding_and_dom_nodes() {
+        let plain = estimate_parser_working_set(128, 0);
+        let markup = estimate_parser_working_set(128, 16);
+
+        assert!(plain > 128, "estimate must exceed raw input bytes");
+        assert!(markup > plain, "DOM node candidates must increase estimate");
+    }
+
+    #[test]
+    fn parser_working_set_overflow_fails_closed() {
+        assert_eq!(
+            estimate_parser_working_set(usize::MAX, usize::MAX),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn parser_budget_raw_ceiling_reserves_fixed_and_transcode_costs() {
+        let budget = PARSER_FIXED_OVERHEAD + (PARSER_BYTES_PER_INPUT_BYTE * 100);
+        assert_eq!(max_input_for_parser_budget(budget), 100);
+        assert_eq!(max_input_for_parser_budget(PARSER_FIXED_OVERHEAD - 1), 0);
+    }
+
+    #[test]
+    fn full_conversion_rejects_dom_amplification_before_parsing() {
+        let html = b"<i></i>".repeat(32);
+        let raw_size = u64::try_from(html.len()).unwrap();
+        let mut options: MarkdownOptions = unsafe { std::mem::zeroed() };
+        unsafe { markdown_options_init(&mut options) };
+        options.parser_memory_budget = raw_size + 1;
+
+        let error = match convert_inner(&MarkdownConverterHandle::new(), &html, &options) {
+            Ok(_) => panic!("raw-input-only accounting would incorrectly accept this request"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, ConversionError::ParseBudgetExceeded { .. }));
+    }
 }

--- a/components/rust-converter/src/ffi/convert.rs
+++ b/components/rust-converter/src/ffi/convert.rs
@@ -41,7 +41,6 @@ const PARSER_BYTES_PER_INPUT_BYTE: u64 = 7;
 const PARSER_BYTES_PER_TAG_OPENER: u64 = 512;
 
 /// Estimate the peak parser/transcoding/DOM working set before parsing.
-///
 /// Returns `u64::MAX` on arithmetic overflow so callers fail closed against
 /// every finite parser budget.
 pub(crate) fn estimate_parser_working_set(input_len: usize, tag_openers: usize) -> u64 {

--- a/components/rust-converter/src/ffi/exports.rs
+++ b/components/rust-converter/src/ffi/exports.rs
@@ -386,16 +386,12 @@ pub unsafe extern "C" fn markdown_make_decision(
 }
 
 /// Build a header plan for a successful Markdown conversion.
-///
 /// The returned plan contains Rust-owned buffers. The C caller must release
 /// the plan via `markdown_header_plan_free`.
-///
 /// This function treats `result` as uninitialized output storage and never
 /// reads its previous fields. Callers that already own a plan in the same
 /// storage must call `markdown_header_plan_free` before rebuilding it.
-///
 /// # Safety
-///
 /// The caller must ensure that:
 /// - `content_type` points to readable UTF-8 bytes of `content_type_len`
 /// - `result` points to writable storage for a `FFIHeaderPlan`; its previous
@@ -416,6 +412,9 @@ pub unsafe extern "C" fn markdown_build_header_plan(
      * any field before initialization: writable C storage may be uninitialized. */
     unsafe { ptr::write(result, std::mem::zeroed()) };
     let result_ref = unsafe { &mut *result };
+    /* Centralize the empty-plan shape so construction and panic fallback
+     * stay synchronized if FFIHeaderPlan gains fields. */
+    reset_header_plan_to_empty(result_ref);
 
     // Defense-in-depth: header plan construction allocates and builds string
     // buffers. A panic must never unwind into C. On panic we leave the output
@@ -512,11 +511,20 @@ pub unsafe extern "C" fn markdown_build_header_plan(
     }));
 
     if outcome.is_err() {
-        /* Panic caught — ensure a safe zeroed state (empty plan). */
-        result_ref.handle = std::ptr::null_mut();
-        result_ref.entries = std::ptr::null();
-        result_ref.count = 0;
+        /* Panic caught — ensure a safe empty plan. */
+        reset_header_plan_to_empty(result_ref);
     }
+}
+
+/// Reset an `FFIHeaderPlan` to the safe empty shape (no entries, null handle).
+///
+/// Centralizes the zeroed-plan initialization used both at construction time
+/// (before `markdown_build_header_plan` populates it) and on panic fallback,
+/// so the two paths cannot drift apart if `FFIHeaderPlan` gains fields.
+fn reset_header_plan_to_empty(plan: &mut FFIHeaderPlan) {
+    plan.handle = std::ptr::null_mut();
+    plan.entries = std::ptr::null();
+    plan.count = 0;
 }
 
 /// Validate a URL for use in Markdown link destinations.

--- a/components/rust-converter/src/ffi/exports.rs
+++ b/components/rust-converter/src/ffi/exports.rs
@@ -390,11 +390,17 @@ pub unsafe extern "C" fn markdown_make_decision(
 /// The returned plan contains Rust-owned buffers. The C caller must release
 /// the plan via `markdown_header_plan_free`.
 ///
+/// This function treats `result` as uninitialized output storage and never
+/// reads its previous fields. Callers that already own a plan in the same
+/// storage must call `markdown_header_plan_free` before rebuilding it.
+///
 /// # Safety
 ///
 /// The caller must ensure that:
 /// - `content_type` points to readable UTF-8 bytes of `content_type_len`
-/// - `result` points to writable storage for a `FFIHeaderPlan`
+/// - `result` points to writable storage for a `FFIHeaderPlan`; its previous
+///   bytes may be uninitialized, but any previously-owned plan must have been
+///   released before this call
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn markdown_build_header_plan(
     content_type: *const u8,
@@ -406,16 +412,10 @@ pub unsafe extern "C" fn markdown_build_header_plan(
         return;
     }
 
+    /* `result` is a pure output parameter. Do not create a reference or read
+     * any field before initialization: writable C storage may be uninitialized. */
+    unsafe { ptr::write(result, std::mem::zeroed()) };
     let result_ref = unsafe { &mut *result };
-
-    /* Save and release any previously-held plan to avoid leaking the old handle.
-     * Zero the result struct BEFORE dropping the old handle so that no field
-     * ever points into freed memory (eliminates dangling-pointer window). */
-    let old_handle = result_ref.handle;
-    unsafe { ptr::write(result_ref, std::mem::zeroed()) };
-    if !old_handle.is_null() {
-        unsafe { drop(Box::from_raw(old_handle as *mut HeaderPlanOwned)) };
-    }
 
     // Defense-in-depth: header plan construction allocates and builds string
     // buffers. A panic must never unwind into C. On panic we leave the output
@@ -1000,6 +1000,19 @@ mod tests {
         assert!(plan.handle.is_null());
         assert!(plan.entries.is_null());
         assert_eq!(plan.count, 0);
+    }
+
+    #[test]
+    fn header_plan_build_initializes_uninitialized_output_storage() {
+        let mut plan = std::mem::MaybeUninit::<FFIHeaderPlan>::uninit();
+        unsafe {
+            markdown_build_header_plan(std::ptr::null(), 0, 0, plan.as_mut_ptr());
+            let mut plan = plan.assume_init();
+            assert!(plan.count > 0);
+            assert!(!plan.handle.is_null());
+            assert!(!plan.entries.is_null());
+            markdown_header_plan_free(&mut plan);
+        }
     }
 
     #[test]

--- a/components/rust-converter/src/ffi/incremental.rs
+++ b/components/rust-converter/src/ffi/incremental.rs
@@ -37,8 +37,10 @@ use crate::incremental::IncrementalConverter;
 use crate::token_estimator::TokenEstimator;
 
 use super::abi::{
-    ERROR_INTERNAL, ERROR_INVALID_INPUT, ERROR_SUCCESS, MarkdownOptions, MarkdownResult,
+    ERROR_INTERNAL, ERROR_INVALID_INPUT, ERROR_PARSE_BUDGET_EXCEEDED, ERROR_SUCCESS,
+    MarkdownOptions, MarkdownResult,
 };
+use super::convert::{estimate_parser_working_set, max_input_for_parser_budget};
 use super::memory::{free_buffer, reset_result, set_error_result};
 use super::options::decode_options;
 
@@ -68,6 +70,9 @@ use super::options::decode_options;
 ///   consistently.
 pub struct IncrementalConverterHandle {
     inner: IncrementalConverter,
+    parser_memory_budget: u64,
+    buffered_input_bytes: usize,
+    buffered_tag_openers: usize,
     generate_etag: bool,
     estimate_tokens: bool,
     chars_per_token: f32,
@@ -167,11 +172,19 @@ pub unsafe extern "C" fn markdown_incremental_new_with_code(
         let opts_ref = unsafe { &*options };
         let decoded = decode_options(opts_ref).map_err(|err| err.code())?;
 
-        let mut converter = IncrementalConverter::new(decoded.conversion);
+        let max_buffer_size = max_input_for_parser_budget(decoded.parser_memory_budget);
+        let mut converter = if decoded.parser_memory_budget == 0 {
+            IncrementalConverter::new(decoded.conversion)
+        } else {
+            IncrementalConverter::with_max_buffer_size(decoded.conversion, max_buffer_size)
+        };
         converter.set_content_type(decoded.content_type.map(ToOwned::to_owned));
-        converter.set_timeout(decoded.timeout);
+        converter.set_timeout(decoded.parse_timeout);
         Ok(Box::into_raw(Box::new(IncrementalConverterHandle {
             inner: converter,
+            parser_memory_budget: decoded.parser_memory_budget,
+            buffered_input_bytes: 0,
+            buffered_tag_openers: 0,
             generate_etag: decoded.generate_etag,
             estimate_tokens: decoded.estimate_tokens,
             chars_per_token: decoded.effective_chars_per_token,
@@ -259,8 +272,32 @@ pub unsafe extern "C" fn markdown_incremental_feed(
             unsafe { std::slice::from_raw_parts(data, data_len) }
         };
 
+        let next_input_bytes = match handle_ref.buffered_input_bytes.checked_add(chunk.len()) {
+            Some(value) => value,
+            None => return ERROR_PARSE_BUDGET_EXCEEDED,
+        };
+        let chunk_tag_openers = chunk.iter().filter(|byte| **byte == b'<').count();
+        let next_tag_openers = match handle_ref
+            .buffered_tag_openers
+            .checked_add(chunk_tag_openers)
+        {
+            Some(value) => value,
+            None => return ERROR_PARSE_BUDGET_EXCEEDED,
+        };
+
+        if handle_ref.parser_memory_budget > 0
+            && estimate_parser_working_set(next_input_bytes, next_tag_openers)
+                > handle_ref.parser_memory_budget
+        {
+            return ERROR_PARSE_BUDGET_EXCEEDED;
+        }
+
         match handle_ref.inner.feed_chunk(chunk) {
-            Ok(()) => ERROR_SUCCESS,
+            Ok(()) => {
+                handle_ref.buffered_input_bytes = next_input_bytes;
+                handle_ref.buffered_tag_openers = next_tag_openers;
+                ERROR_SUCCESS
+            }
             Err(e) => e.code(),
         }
     });
@@ -397,4 +434,51 @@ pub unsafe extern "C" fn markdown_incremental_free(handle: *mut IncrementalConve
     }
     // SAFETY: caller guarantees `handle` is a live, unconsumed pointer.
     unsafe { drop(Box::from_raw(handle)) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::exports::{markdown_options_init, markdown_result_free};
+
+    fn options() -> MarkdownOptions {
+        let mut options = unsafe { std::mem::zeroed() };
+        unsafe { markdown_options_init(&mut options) };
+        options
+    }
+
+    #[test]
+    fn constructor_applies_parser_budget_to_amplified_markup() {
+        let mut options = options();
+        options.parser_memory_budget = 32 * 1024;
+        let handle = unsafe { markdown_incremental_new(&options) };
+        assert!(!handle.is_null());
+
+        let dense_markup = b"<i></i>".repeat(32);
+        let code =
+            unsafe { markdown_incremental_feed(handle, dense_markup.as_ptr(), dense_markup.len()) };
+        assert_eq!(code, ERROR_PARSE_BUDGET_EXCEEDED);
+
+        unsafe { markdown_incremental_free(handle) };
+    }
+
+    #[test]
+    fn constructor_uses_parse_timeout_for_finalize() {
+        let mut options = options();
+        options.timeout_ms = 60_000;
+        options.parse_timeout_ms = 1;
+        let handle = unsafe { markdown_incremental_new(&options) };
+        assert!(!handle.is_null());
+
+        let html = b"<div>text</div>".repeat(20_000);
+        assert_eq!(
+            unsafe { markdown_incremental_feed(handle, html.as_ptr(), html.len()) },
+            ERROR_SUCCESS
+        );
+
+        let mut result: MarkdownResult = unsafe { std::mem::zeroed() };
+        let code = unsafe { markdown_incremental_finalize(handle, &mut result) };
+        assert_eq!(code, crate::ffi::ERROR_TIMEOUT);
+        unsafe { markdown_result_free(&mut result) };
+    }
 }

--- a/components/rust-converter/src/metadata/extract.rs
+++ b/components/rust-converter/src/metadata/extract.rs
@@ -37,9 +37,12 @@ use std::cell::Ref;
 
 use markup5ever_rcdom::{Handle, NodeData, RcDom};
 
+use crate::converter::ConversionContext;
 use crate::error::ConversionError;
 
 use super::{MetadataExtractor, PageMetadata};
+
+const MAX_METADATA_DEPTH: usize = 1000;
 
 impl MetadataExtractor {
     /// Extract page metadata from a parsed DOM tree.
@@ -47,68 +50,92 @@ impl MetadataExtractor {
     /// Extraction order is deterministic so repeated conversions over identical
     /// input yield stable front-matter output.
     pub fn extract(&self, dom: &RcDom) -> Result<PageMetadata, ConversionError> {
+        let mut ctx = ConversionContext::new(std::time::Duration::ZERO);
+        self.extract_with_context(dom, &mut ctx)
+    }
+
+    /// Extract page metadata while sharing the conversion timeout and node
+    /// accounting used by the main DOM traversal.
+    pub(crate) fn extract_with_context(
+        &self,
+        dom: &RcDom,
+        ctx: &mut ConversionContext,
+    ) -> Result<PageMetadata, ConversionError> {
+        ctx.check_timeout()?;
         let mut metadata = PageMetadata::new();
 
-        metadata.title = self.find_title(dom);
-        self.extract_meta_tags(dom, &mut metadata)?;
+        metadata.title = self.find_title(dom, ctx)?;
+        let canonical = self.extract_meta_tags_and_canonical(dom, &mut metadata, ctx)?;
 
-        if let Some(canonical) = self.find_canonical(dom) {
+        if let Some(canonical) = canonical {
             metadata.url = Some(self.resolve_url(&canonical));
         } else {
             metadata.url = self.base_url.clone();
         }
 
+        ctx.check_timeout()?;
         Ok(metadata)
     }
 
     /// Resolve document title from the first `<title>` element.
-    fn find_title(&self, dom: &RcDom) -> Option<String> {
-        self.find_element_text(dom, "title")
+    fn find_title(
+        &self,
+        dom: &RcDom,
+        ctx: &mut ConversionContext,
+    ) -> Result<Option<String>, ConversionError> {
+        self.find_element_text(dom, "title", ctx)
     }
 
-    /// Resolve canonical URL from `<link rel="canonical">`.
-    fn find_canonical(&self, dom: &RcDom) -> Option<String> {
-        self.find_link_href(dom, "canonical")
-    }
-
-    /// Traverse the DOM and collect metadata from `<meta ...>` tags.
-    fn extract_meta_tags(
+    /// Traverse the DOM once to collect meta tags and the first canonical URL.
+    fn extract_meta_tags_and_canonical(
         &self,
         dom: &RcDom,
         metadata: &mut PageMetadata,
-    ) -> Result<(), ConversionError> {
-        self.traverse_for_meta(&dom.document, metadata)
-    }
+        ctx: &mut ConversionContext,
+    ) -> Result<Option<String>, ConversionError> {
+        let mut canonical = None;
+        let mut stack = vec![(dom.document.clone(), 0usize)];
 
-    /// Depth-first traversal that processes metadata-relevant nodes.
-    fn traverse_for_meta(
-        &self,
-        node: &Handle,
-        metadata: &mut PageMetadata,
-    ) -> Result<(), ConversionError> {
-        match node.data {
-            NodeData::Element {
-                ref name,
-                ref attrs,
-                ..
-            } => {
-                if name.local.as_ref() == "meta" {
-                    self.process_meta_tag(&attrs.borrow(), metadata)?;
-                }
+        while let Some((node, depth)) = stack.pop() {
+            Self::check_depth(depth)?;
+            ctx.increment_and_check()?;
 
-                for child in node.children.borrow().iter() {
-                    self.traverse_for_meta(child, metadata)?;
+            match node.data {
+                NodeData::Element {
+                    ref name,
+                    ref attrs,
+                    ..
+                } => {
+                    if name.local.as_ref() == "meta" {
+                        self.process_meta_tag(&attrs.borrow(), metadata)?;
+                    } else if name.local.as_ref() == "link" && canonical.is_none() {
+                        let attrs_ref = attrs.borrow();
+                        let has_canonical_rel = attrs_ref.iter().any(|attr| {
+                            attr.name.local.as_ref() == "rel"
+                                && attr
+                                    .value
+                                    .split_ascii_whitespace()
+                                    .any(|token| token.eq_ignore_ascii_case("canonical"))
+                        });
+                        if has_canonical_rel {
+                            canonical = self.get_attr(&attrs_ref, "href");
+                        }
+                    }
+
+                    for child in node.children.borrow().iter().rev() {
+                        stack.push((child.clone(), depth + 1));
+                    }
                 }
-            }
-            NodeData::Document => {
-                for child in node.children.borrow().iter() {
-                    self.traverse_for_meta(child, metadata)?;
+                NodeData::Document => {
+                    for child in node.children.borrow().iter().rev() {
+                        stack.push((child.clone(), depth + 1));
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
-        Ok(())
+        Ok(canonical)
     }
 
     /// Merge one meta tag into the accumulated metadata structure.
@@ -166,94 +193,77 @@ impl MetadataExtractor {
     }
 
     /// Locate the first matching element and return its text content.
-    fn find_element_text(&self, dom: &RcDom, element_name: &str) -> Option<String> {
-        Self::find_element_text_recursive(&dom.document, element_name)
-    }
+    fn find_element_text(
+        &self,
+        dom: &RcDom,
+        element_name: &str,
+        ctx: &mut ConversionContext,
+    ) -> Result<Option<String>, ConversionError> {
+        let mut stack = vec![(dom.document.clone(), 0usize)];
 
-    /// Recursive helper for `find_element_text`.
-    fn find_element_text_recursive(node: &Handle, element_name: &str) -> Option<String> {
-        match node.data {
-            NodeData::Element { ref name, .. } => {
-                if name.local.as_ref() == element_name {
-                    let mut text = String::new();
-                    Self::extract_text_content(node, &mut text);
-                    return Some(text.trim().to_string());
-                }
+        while let Some((node, depth)) = stack.pop() {
+            Self::check_depth(depth)?;
+            ctx.increment_and_check()?;
 
-                for child in node.children.borrow().iter() {
-                    if let Some(text) = Self::find_element_text_recursive(child, element_name) {
-                        return Some(text);
+            match node.data {
+                NodeData::Element { ref name, .. } => {
+                    if name.local.as_ref() == element_name {
+                        return Self::extract_text_content(&node, depth, ctx)
+                            .map(|text| Some(text.trim().to_string()));
+                    }
+
+                    for child in node.children.borrow().iter().rev() {
+                        stack.push((child.clone(), depth + 1));
                     }
                 }
-            }
-            NodeData::Document => {
-                for child in node.children.borrow().iter() {
-                    if let Some(text) = Self::find_element_text_recursive(child, element_name) {
-                        return Some(text);
+                NodeData::Document => {
+                    for child in node.children.borrow().iter().rev() {
+                        stack.push((child.clone(), depth + 1));
                     }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
-        None
-    }
-
-    /// Locate a `<link>` tag by `rel` and return its `href` value.
-    fn find_link_href(&self, dom: &RcDom, rel: &str) -> Option<String> {
-        self.find_link_href_recursive(&dom.document, rel)
-    }
-
-    /// Recursive helper for `find_link_href`.
-    fn find_link_href_recursive(&self, node: &Handle, rel: &str) -> Option<String> {
-        match node.data {
-            NodeData::Element {
-                ref name,
-                ref attrs,
-                ..
-            } => {
-                if name.local.as_ref() == "link" {
-                    let attrs_ref = attrs.borrow();
-                    let has_rel = attrs_ref.iter().any(|attr| {
-                        attr.name.local.as_ref() == "rel" && attr.value.as_ref() == rel
-                    });
-
-                    if has_rel {
-                        return self.get_attr(&attrs_ref, "href");
-                    }
-                }
-
-                for child in node.children.borrow().iter() {
-                    if let Some(href) = self.find_link_href_recursive(child, rel) {
-                        return Some(href);
-                    }
-                }
-            }
-            NodeData::Document => {
-                for child in node.children.borrow().iter() {
-                    if let Some(href) = self.find_link_href_recursive(child, rel) {
-                        return Some(href);
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        None
+        Ok(None)
     }
 
     /// Append all descendant text nodes into `output` in DOM order.
-    fn extract_text_content(node: &Handle, output: &mut String) {
-        match node.data {
-            NodeData::Text { ref contents } => {
-                output.push_str(&contents.borrow());
-            }
-            NodeData::Element { .. } | NodeData::Document => {
-                for child in node.children.borrow().iter() {
-                    Self::extract_text_content(child, output);
+    fn extract_text_content(
+        node: &Handle,
+        initial_depth: usize,
+        ctx: &mut ConversionContext,
+    ) -> Result<String, ConversionError> {
+        let mut output = String::new();
+        let mut stack = vec![(node.clone(), initial_depth)];
+
+        while let Some((current, depth)) = stack.pop() {
+            Self::check_depth(depth)?;
+            ctx.increment_and_check()?;
+
+            match current.data {
+                NodeData::Text { ref contents } => {
+                    output.push_str(&contents.borrow());
                 }
+                NodeData::Element { .. } | NodeData::Document => {
+                    for child in current.children.borrow().iter().rev() {
+                        stack.push((child.clone(), depth + 1));
+                    }
+                }
+                _ => {}
             }
-            _ => {}
         }
+
+        Ok(output)
+    }
+
+    fn check_depth(depth: usize) -> Result<(), ConversionError> {
+        if depth > MAX_METADATA_DEPTH {
+            return Err(ConversionError::InvalidInput(format!(
+                "metadata nesting depth exceeds {MAX_METADATA_DEPTH}"
+            )));
+        }
+
+        Ok(())
     }
 }

--- a/components/rust-converter/src/metadata/tests.rs
+++ b/components/rust-converter/src/metadata/tests.rs
@@ -156,6 +156,31 @@ fn test_metadata_extraction_honors_conversion_timeout() {
     assert!(matches!(error, ConversionError::Timeout));
 }
 
+/// Verify that timeout checks inside the metadata DOM traversal are enforced,
+/// not just the entry-point check. A shallow DOM passes the initial deadline,
+/// but a deep DOM with many meta tags must trip `increment_and_check()` mid-walk.
+#[test]
+fn test_metadata_extraction_times_out_during_traversal() {
+    let mut html = String::from("<html><head><title>Deep</title>");
+    for i in 0..4000 {
+        html.push_str(&format!(
+            "<meta name=\"k{i}\" content=\"v{i}\" />"
+        ));
+    }
+    html.push_str("</head></html>");
+
+    let dom = parse_html(html.as_bytes()).unwrap();
+    let extractor = MetadataExtractor::new(None, false);
+    let mut ctx = ConversionContext::new(Duration::from_millis(1));
+
+    let result = extractor.extract_with_context(&dom, &mut ctx);
+
+    assert!(
+        matches!(result, Err(ConversionError::Timeout)),
+        "expected mid-traversal timeout, got {result:?}"
+    );
+}
+
 #[test]
 fn test_url_fallback_to_base_url() {
     let html = b"<html><head><title>Test</title></head></html>";

--- a/components/rust-converter/src/metadata/tests.rs
+++ b/components/rust-converter/src/metadata/tests.rs
@@ -163,9 +163,7 @@ fn test_metadata_extraction_honors_conversion_timeout() {
 fn test_metadata_extraction_times_out_during_traversal() {
     let mut html = String::from("<html><head><title>Deep</title>");
     for i in 0..4000 {
-        html.push_str(&format!(
-            "<meta name=\"k{i}\" content=\"v{i}\" />"
-        ));
+        html.push_str(&format!("<meta name=\"k{i}\" content=\"v{i}\" />"));
     }
     html.push_str("</head></html>");
 

--- a/components/rust-converter/src/metadata/tests.rs
+++ b/components/rust-converter/src/metadata/tests.rs
@@ -1,3 +1,7 @@
+use std::time::Duration;
+
+use crate::converter::ConversionContext;
+use crate::error::ConversionError;
 use crate::parser::parse_html;
 
 use super::{MetadataExtractor, PageMetadata};
@@ -102,6 +106,54 @@ fn test_extract_canonical_url() {
         metadata.url,
         Some("https://example.com/canonical".to_string())
     );
+}
+
+#[test]
+fn test_extract_canonical_rel_token_list_case_insensitive() {
+    let html = b"<html><head>
+        <link rel=\"alternate CANONICAL preload\" href=\"https://example.com/canonical\" />
+    </head></html>";
+    let dom = parse_html(html).unwrap();
+    let extractor = MetadataExtractor::new(None, false);
+    let metadata = extractor.extract(&dom).unwrap();
+
+    assert_eq!(
+        metadata.url,
+        Some("https://example.com/canonical".to_string())
+    );
+}
+
+#[test]
+fn test_metadata_extraction_rejects_excessive_depth_without_recursion() {
+    let depth = 1_100;
+    let mut html = String::with_capacity(depth * 11);
+    html.push_str("<html><head></head><body>");
+    for _ in 0..depth {
+        html.push_str("<div>");
+    }
+    for _ in 0..depth {
+        html.push_str("</div>");
+    }
+    html.push_str("</body></html>");
+
+    let dom = parse_html(html.as_bytes()).unwrap();
+    let extractor = MetadataExtractor::new(None, false);
+    let error = extractor.extract(&dom).unwrap_err();
+
+    assert!(matches!(error, ConversionError::InvalidInput(_)));
+    assert!(error.to_string().contains("metadata nesting depth"));
+}
+
+#[test]
+fn test_metadata_extraction_honors_conversion_timeout() {
+    let dom = parse_html(b"<html><head><title>Late</title></head></html>").unwrap();
+    let extractor = MetadataExtractor::new(None, false);
+    let mut ctx = ConversionContext::new(Duration::from_nanos(1));
+    std::thread::sleep(Duration::from_millis(1));
+
+    let error = extractor.extract_with_context(&dom, &mut ctx).unwrap_err();
+
+    assert!(matches!(error, ConversionError::Timeout));
 }
 
 #[test]

--- a/components/rust-converter/src/streaming/converter.rs
+++ b/components/rust-converter/src/streaming/converter.rs
@@ -726,6 +726,26 @@ impl StreamingConverter {
             }
         };
 
+        // Mirror implied end-tag closures (e.g. `</p>` before `<div>`) into
+        // the StructuralStateMachine so its context stack does not leak stale
+        // open elements. The sanitizer tracks which optional end tags were
+        // implied by the incoming StartTag; we synthesize the corresponding
+        // Exit actions here, before processing the StartTag itself.
+        let implied_closures = std::mem::take(&mut self.sanitizer.implied_closures);
+        for closed_tag in &implied_closures {
+            let synthetic = StreamEvent::EndTag {
+                name: closed_tag.clone(),
+            };
+            let action = self
+                .state_machine
+                .process_event(&synthetic)
+                .map_err(|e| self.wrap_error(e))?;
+            self.emitter
+                .process_action(&action, &mut self.state_machine)
+                .map_err(|e| self.wrap_error(e))?;
+            self.update_peak_memory().map_err(|e| self.wrap_error(e))?;
+        }
+
         // State machine
         let action = self
             .state_machine

--- a/components/rust-converter/src/streaming/converter.rs
+++ b/components/rust-converter/src/streaming/converter.rs
@@ -855,6 +855,7 @@ impl StreamingConverter {
         // Only count state that is actually resident in memory right now:
         // - emitter pending buffer (not yet flushed)
         // - emitter flushed buffer (awaiting take_flushed by caller)
+        // - emitter link/code collectors (separate retained allocations)
         // - state machine stack
         // - metadata extracted from <head> (actual String allocations)
         // - html_title_buf (temporary <title> text before </title>)
@@ -862,11 +863,14 @@ impl StreamingConverter {
         // Note: `head_bytes_seen` is intentionally NOT included here.
         // It is a cumulative counter for lookahead budget enforcement
         // (budget metric, not a measure of resident memory).
-        let working_set = self.emitter.pending_bytes()
-            + self.emitter.flushed_bytes()
-            + self.state_machine.stack_bytes_estimate()
-            + self.metadata.bytes_estimate()
-            + self.html_title_buf.len();
+        let working_set = self
+            .emitter
+            .pending_bytes()
+            .saturating_add(self.emitter.flushed_bytes())
+            .saturating_add(self.emitter.resident_collector_bytes())
+            .saturating_add(self.state_machine.stack_bytes_estimate())
+            .saturating_add(self.metadata.bytes_estimate())
+            .saturating_add(self.html_title_buf.len());
         self.stats.peak_memory_estimate = self.stats.peak_memory_estimate.max(working_set);
 
         // Enforce budget.total: the working set must not exceed the
@@ -928,8 +932,11 @@ impl StreamingConverter {
                         // wins. Canonicals without href are skipped, matching
                         // full-buffer `find_link_href_recursive` which returns
                         // `get_attr("href")` — if None, recursion continues.
-                        let is_canonical =
-                            attrs.iter().any(|(k, v)| k == "rel" && v == "canonical");
+                        let is_canonical = attrs.iter().any(|(k, v)| {
+                            k == "rel"
+                                && v.split_ascii_whitespace()
+                                    .any(|token| token.eq_ignore_ascii_case("canonical"))
+                        });
                         if is_canonical
                             && let Some((_, href)) = attrs.iter().find(|(k, _)| k == "href")
                         {
@@ -2340,6 +2347,39 @@ mod tests {
             conv.metadata().url.as_deref(),
             Some("https://example.com/page"),
         );
+    }
+
+    #[test]
+    fn test_canonical_rel_uses_case_insensitive_token_list_matching() {
+        let html = br#"<html><head>
+            <link rel="alternate CANONICAL stylesheet"
+                  href="https://example.com/token-canonical">
+            </head><body><p>hello</p></body></html>"#;
+        let mut conv = make_converter_with_metadata();
+
+        conv.feed_chunk(html).unwrap();
+
+        assert_eq!(
+            conv.metadata().url.as_deref(),
+            Some("https://example.com/token-canonical")
+        );
+    }
+
+    #[test]
+    fn test_total_budget_counts_resident_link_text() {
+        let budget = MemoryBudget {
+            total: 160,
+            state_stack: 128,
+            output_buffer: 1024,
+            charset_sniff: 16,
+            lookahead: 16,
+        };
+        let mut conv = StreamingConverter::new(ConversionOptions::default(), budget);
+
+        conv.feed_chunk(b"<body><a href='/'>").unwrap();
+        let err = conv.feed_chunk(&vec![b'x'; 512]).unwrap_err();
+
+        assert_eq!(err.code(), 6);
     }
 
     /// P3 regression: when no canonical/og:url, finalize should fall back

--- a/components/rust-converter/src/streaming/converter.rs
+++ b/components/rust-converter/src/streaming/converter.rs
@@ -716,21 +716,20 @@ impl StreamingConverter {
         // Sanitize
         let decision = self.sanitizer.process_event(event);
 
-        let sanitized_event = match decision {
-            SanitizeDecision::Pass(ev) | SanitizeDecision::PassModified(ev) => ev,
-            SanitizeDecision::Skip => return Ok(()),
-            SanitizeDecision::DepthExceeded => {
-                return Err(self.wrap_error(ConversionError::MemoryLimit(
-                    "nesting depth exceeded during sanitization".to_string(),
-                )));
-            }
-        };
-
         // Mirror implied end-tag closures (e.g. `</p>` before `<div>`) into
         // the StructuralStateMachine so its context stack does not leak stale
         // open elements. The sanitizer tracks which optional end tags were
         // implied by the incoming StartTag; we synthesize the corresponding
-        // Exit actions here, before processing the StartTag itself.
+        // Exit actions here, BEFORE the Skip decision is applied.
+        //
+        // This must happen before the Skip/Pass branch because implied
+        // closures are produced even when the current tag is stripped or
+        // skipped (e.g. `<form>` in FORM_ELEMENTS is skipped but still
+        // triggers `</p>` closure via PARAGRAPH_CLOSING_START_TAGS).
+        // Dropping the closures on Skip would leave the state machine's
+        // context stack stale, causing downstream content to be emitted
+        // in the wrong block context (e.g. paragraph text glued to form
+        // content).
         let implied_closures = std::mem::take(&mut self.sanitizer.implied_closures);
         for closed_tag in &implied_closures {
             let synthetic = StreamEvent::EndTag {
@@ -745,6 +744,16 @@ impl StreamingConverter {
                 .map_err(|e| self.wrap_error(e))?;
             self.update_peak_memory().map_err(|e| self.wrap_error(e))?;
         }
+
+        let sanitized_event = match decision {
+            SanitizeDecision::Pass(ev) | SanitizeDecision::PassModified(ev) => ev,
+            SanitizeDecision::Skip => return Ok(()),
+            SanitizeDecision::DepthExceeded => {
+                return Err(self.wrap_error(ConversionError::MemoryLimit(
+                    "nesting depth exceeded during sanitization".to_string(),
+                )));
+            }
+        };
 
         // State machine
         let action = self

--- a/components/rust-converter/src/streaming/emitter.rs
+++ b/components/rust-converter/src/streaming/emitter.rs
@@ -18,7 +18,9 @@ use crate::error::ConversionError;
 use crate::security::escape_link_label;
 use crate::streaming::budget::MemoryBudget;
 use crate::streaming::sanitizer::is_dangerous_url;
-use crate::streaming::state_machine::{StateMachineAction, StructuralContext};
+use crate::streaming::state_machine::{
+    StateMachineAction, StructuralContext, is_safe_code_fence_language,
+};
 
 fn longest_backtick_run(content: &str) -> usize {
     let mut max_run = 0;
@@ -328,6 +330,14 @@ impl IncrementalEmitter {
         self.flushed.len()
     }
 
+    /// Heap capacity retained by collectors that are separate from the
+    /// pending and flushed output buffers.
+    pub(crate) fn resident_collector_bytes(&self) -> usize {
+        self.link_text
+            .capacity()
+            .saturating_add(self.code_block_buffer.capacity())
+    }
+
     /// Finalizes the emitter and returns the fully normalized output.
     ///
     /// Closes any open code block if present, moves pending bytes to the ready buffer, removes extra trailing newlines so at most one final `\n` remains, and returns the complete output bytes.
@@ -444,7 +454,10 @@ impl IncrementalEmitter {
                 // we are in a code block and emit the opening fence
                 // when the first text arrives or on exit.
                 self.in_code_block = true;
-                self.code_fence_lang = lang.clone();
+                self.code_fence_lang = lang
+                    .as_deref()
+                    .filter(|value| is_safe_code_fence_language(value))
+                    .map(ToOwned::to_owned);
                 self.code_block_backtick_max = 0;
                 self.code_block_trailing_backticks = 0;
                 self.code_block_buffer.clear();
@@ -538,7 +551,11 @@ impl IncrementalEmitter {
             StructuralContext::CodeBlock(lang) => {
                 let fence_len = (3usize).max(self.code_block_backtick_max + 1);
                 let fence_str = "`".repeat(fence_len);
-                let effective_lang = lang.clone().or_else(|| self.code_fence_lang.clone());
+                let effective_lang = lang
+                    .as_deref()
+                    .filter(|value| is_safe_code_fence_language(value))
+                    .map(ToOwned::to_owned)
+                    .or_else(|| self.code_fence_lang.clone());
                 let opening_fence = match effective_lang {
                     Some(l) => format!("{}{}\n", fence_str, l),
                     None => format!("{}\n", fence_str),
@@ -1815,6 +1832,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_resident_collector_bytes_include_link_and_code_buffers() {
+        let budget = MemoryBudget::default();
+        let mut emitter = IncrementalEmitter::new(&budget);
+
+        emitter.append_link_text("link text retained until the closing tag");
+        emitter
+            .code_block_buffer
+            .extend_from_slice(b"code retained until the closing fence");
+
+        assert_eq!(
+            emitter.resident_collector_bytes(),
+            emitter.link_text.capacity() + emitter.code_block_buffer.capacity()
+        );
+        assert!(emitter.resident_collector_bytes() > 0);
+    }
+
     // ── Image tests ─────────────────────────────────────────────────
 
     /// Verifies that an HTML `<img>` inside a paragraph is emitted as Markdown image syntax.
@@ -1865,6 +1899,25 @@ mod tests {
         ]);
         assert!(output.contains("```rust\n"), "got: {}", output);
         assert!(output.contains("fn main() {}"), "got: {}", output);
+    }
+
+    #[test]
+    fn test_code_block_sink_rejects_unsafe_language() {
+        let (mut emitter, mut sm) = make_pair();
+        let code_block = StructuralContext::CodeBlock(Some("rust```".to_string()));
+
+        emitter
+            .process_action(&StateMachineAction::Enter(code_block.clone()), &mut sm)
+            .unwrap();
+        emitter
+            .process_action(&StateMachineAction::Text("let x = 1;".to_string()), &mut sm)
+            .unwrap();
+        emitter
+            .process_action(&StateMachineAction::Exit(code_block), &mut sm)
+            .unwrap();
+
+        let output = String::from_utf8(emitter.finalize().unwrap()).unwrap();
+        assert_eq!(output, "```\nlet x = 1;\n```\n");
     }
 
     // ── Inline code tests ───────────────────────────────────────────

--- a/components/rust-converter/src/streaming/sanitizer.rs
+++ b/components/rust-converter/src/streaming/sanitizer.rs
@@ -599,13 +599,14 @@ impl StreamingSanitizer {
     /// Removes an implicitly closed element and all of its open descendants.
     /// Returns the closed tag names in close order (innermost first).
     fn truncate_nesting_stack(&mut self, index: usize) -> Vec<String> {
-        let closed_tags: Vec<String> = self.nesting_stack.drain(index..).collect();
+        let mut closed_tags: Vec<String> = self.nesting_stack.drain(index..).collect();
         for tag in closed_tags.iter().rev() {
             if let Some(strip_index) = self.strip_stack.iter().rposition(|open| open == tag) {
                 self.strip_stack.remove(strip_index);
             }
         }
         self.nesting_depth = self.nesting_stack.len();
+        closed_tags.reverse();
         closed_tags
     }
 }

--- a/components/rust-converter/src/streaming/sanitizer.rs
+++ b/components/rust-converter/src/streaming/sanitizer.rs
@@ -157,6 +157,13 @@ pub struct StreamingSanitizer {
     /// Name of the outermost pruned element that entered prune mode,
     /// for name-aware exit (same pattern as skip_element).
     prune_element: Option<String>,
+    /// Tags that were implicitly closed by the most recent
+    /// `close_optional_end_tags_for_start` call, in close order
+    /// (innermost first). Consumed by the streaming converter to mirror
+    /// the closures into the StructuralStateMachine so its context stack
+    /// does not leak stale open elements (e.g. `Paragraph` surviving an
+    /// implied `</p>` when `<div>` opens).
+    pub(crate) implied_closures: Vec<String>,
 }
 
 impl StreamingSanitizer {
@@ -181,6 +188,7 @@ impl StreamingSanitizer {
             prune_config: PruneConfig::disabled(),
             prune_depth: 0,
             prune_element: None,
+            implied_closures: Vec::new(),
         }
     }
 
@@ -242,6 +250,7 @@ impl StreamingSanitizer {
     /// }
     /// ```
     pub fn process_event(&mut self, event: StreamEvent) -> SanitizeDecision {
+        self.implied_closures.clear();
         match &event {
             StreamEvent::StartTag {
                 name,
@@ -582,12 +591,14 @@ impl StreamingSanitizer {
         if let Some(idx) = close_index
             && targets.contains(&self.nesting_stack[idx].as_str())
         {
-            self.truncate_nesting_stack(idx);
+            let closed = self.truncate_nesting_stack(idx);
+            self.implied_closures.extend(closed);
         }
     }
 
     /// Removes an implicitly closed element and all of its open descendants.
-    fn truncate_nesting_stack(&mut self, index: usize) {
+    /// Returns the closed tag names in close order (innermost first).
+    fn truncate_nesting_stack(&mut self, index: usize) -> Vec<String> {
         let closed_tags: Vec<String> = self.nesting_stack.drain(index..).collect();
         for tag in closed_tags.iter().rev() {
             if let Some(strip_index) = self.strip_stack.iter().rposition(|open| open == tag) {
@@ -595,6 +606,7 @@ impl StreamingSanitizer {
             }
         }
         self.nesting_depth = self.nesting_stack.len();
+        closed_tags
     }
 }
 

--- a/components/rust-converter/src/streaming/sanitizer.rs
+++ b/components/rust-converter/src/streaming/sanitizer.rs
@@ -29,6 +29,57 @@ const VOID_ELEMENTS: &[&str] = &[
     "track", "wbr",
 ];
 
+/// Start tags that implicitly close an open paragraph in button scope.
+const PARAGRAPH_CLOSING_START_TAGS: &[&str] = &[
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "details",
+    "div",
+    "dl",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "main",
+    "menu",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "search",
+    "section",
+    "table",
+    "ul",
+];
+
+const BUTTON_SCOPE_BOUNDARIES: &[&str] = &[
+    "applet", "button", "caption", "html", "marquee", "object", "table", "td", "th", "template",
+];
+const LIST_ITEM_SCOPE_BOUNDARIES: &[&str] = &[
+    "applet", "caption", "html", "marquee", "menu", "object", "ol", "table", "td", "th",
+    "template", "ul",
+];
+const DEFINITION_SCOPE_BOUNDARIES: &[&str] = &["dl", "html", "table", "template"];
+const SELECT_SCOPE_BOUNDARIES: &[&str] = &["datalist", "select", "template"];
+const TABLE_SCOPE_BOUNDARIES: &[&str] = &["html", "table", "template"];
+const TABLE_SECTION_SCOPE_BOUNDARIES: &[&str] =
+    &["html", "table", "tbody", "tfoot", "thead", "template"];
+const TABLE_ROW_SCOPE_BOUNDARIES: &[&str] =
+    &["html", "table", "tbody", "tfoot", "thead", "tr", "template"];
+const RUBY_SCOPE_BOUNDARIES: &[&str] = &["html", "ruby", "table", "template"];
+
 /// Elements whose entire subtree is removed (content discarded).
 const DANGEROUS_CONTAINER_ELEMENTS: &[&str] = &["script", "style", "noscript", "applet"];
 
@@ -216,6 +267,10 @@ impl StreamingSanitizer {
                         self.skip_depth = self.skip_depth.saturating_add(1);
                     }
                     return SanitizeDecision::Skip;
+                }
+
+                if self.prune_depth == 0 {
+                    self.close_optional_end_tags_for_start(tag);
                 }
 
                 // Dangerous elements: skip entire subtree
@@ -470,7 +525,74 @@ impl StreamingSanitizer {
     /// depth is recalculated from the stack length.
     fn pop_open_tag(&mut self, tag: &str) {
         if let Some(idx) = self.nesting_stack.iter().rposition(|open| open == tag) {
-            self.nesting_stack.remove(idx);
+            self.truncate_nesting_stack(idx);
+        }
+        self.nesting_depth = self.nesting_stack.len();
+    }
+
+    /// Applies tree-builder implied end-tag behavior visible from start tags.
+    fn close_optional_end_tags_for_start(&mut self, tag: &str) {
+        if PARAGRAPH_CLOSING_START_TAGS.contains(&tag) {
+            self.close_nearest_in_scope(&["p"], BUTTON_SCOPE_BOUNDARIES);
+        }
+
+        match tag {
+            "li" => {
+                self.close_nearest_in_scope(&["li"], LIST_ITEM_SCOPE_BOUNDARIES);
+            }
+            "dt" | "dd" => {
+                self.close_nearest_in_scope(&["dt", "dd"], DEFINITION_SCOPE_BOUNDARIES);
+            }
+            "rb" => {
+                self.close_nearest_in_scope(&["rb", "rt", "rtc", "rp"], RUBY_SCOPE_BOUNDARIES);
+            }
+            "rt" | "rtc" | "rp" => {
+                self.close_nearest_in_scope(&["rb", "rt", "rtc", "rp"], RUBY_SCOPE_BOUNDARIES);
+            }
+            "option" => {
+                self.close_nearest_in_scope(&["option"], SELECT_SCOPE_BOUNDARIES);
+            }
+            "optgroup" => {
+                self.close_nearest_in_scope(&["option"], SELECT_SCOPE_BOUNDARIES);
+                self.close_nearest_in_scope(&["optgroup"], SELECT_SCOPE_BOUNDARIES);
+            }
+            "colgroup" => {
+                self.close_nearest_in_scope(&["colgroup"], TABLE_SCOPE_BOUNDARIES);
+            }
+            "thead" | "tbody" | "tfoot" => {
+                self.close_nearest_in_scope(&["thead", "tbody", "tfoot"], TABLE_SCOPE_BOUNDARIES);
+            }
+            "tr" => {
+                self.close_nearest_in_scope(&["td", "th"], TABLE_ROW_SCOPE_BOUNDARIES);
+                self.close_nearest_in_scope(&["tr"], TABLE_SECTION_SCOPE_BOUNDARIES);
+            }
+            "td" | "th" => {
+                self.close_nearest_in_scope(&["td", "th"], TABLE_ROW_SCOPE_BOUNDARIES);
+            }
+            _ => {}
+        }
+    }
+
+    /// Closes the nearest target unless an HTML scope boundary is encountered.
+    fn close_nearest_in_scope(&mut self, targets: &[&str], boundaries: &[&str]) {
+        let close_index = self.nesting_stack.iter().rposition(|open| {
+            targets.contains(&open.as_str()) || boundaries.contains(&open.as_str())
+        });
+
+        if let Some(idx) = close_index
+            && targets.contains(&self.nesting_stack[idx].as_str())
+        {
+            self.truncate_nesting_stack(idx);
+        }
+    }
+
+    /// Removes an implicitly closed element and all of its open descendants.
+    fn truncate_nesting_stack(&mut self, index: usize) {
+        let closed_tags: Vec<String> = self.nesting_stack.drain(index..).collect();
+        for tag in closed_tags.iter().rev() {
+            if let Some(strip_index) = self.strip_stack.iter().rposition(|open| open == tag) {
+                self.strip_stack.remove(strip_index);
+            }
         }
         self.nesting_depth = self.nesting_stack.len();
     }
@@ -1059,6 +1181,73 @@ mod tests {
             SanitizeDecision::Pass(_)
         ));
         assert_eq!(san.nesting_depth(), 0);
+    }
+
+    #[test]
+    fn test_optional_end_tag_siblings_do_not_accumulate_nesting_depth() {
+        let cases = [
+            (&["li", "li", "li", "li"][..], 1),
+            (&["p", "span", "div"][..], 1),
+            (&["dl", "dt", "dd"][..], 2),
+            (&["ruby", "rb", "rt", "rp"][..], 2),
+            (
+                &["select", "optgroup", "option", "option", "optgroup"][..],
+                2,
+            ),
+            (&["table", "colgroup", "colgroup"][..], 2),
+            (&["table", "thead", "tbody", "tfoot"][..], 2),
+        ];
+
+        for (tags, expected_depth) in cases {
+            let mut san = StreamingSanitizer::with_max_depth(tags.len());
+            for tag in tags {
+                assert!(matches!(
+                    san.process_event(start_tag(tag, vec![])),
+                    SanitizeDecision::Pass(_) | SanitizeDecision::Skip
+                ));
+            }
+            assert_eq!(san.nesting_depth(), expected_depth, "tags: {tags:?}");
+        }
+
+        let mut table = StreamingSanitizer::with_max_depth(4);
+        for tag in ["table", "tbody", "tr", "td", "td", "tr", "td"] {
+            assert!(matches!(
+                table.process_event(start_tag(tag, vec![])),
+                SanitizeDecision::Pass(_)
+            ));
+        }
+        assert_eq!(table.nesting_depth(), 4);
+
+        let mut pruned = StreamingSanitizer::with_max_depth(1);
+        pruned.prune_config.enabled = true;
+        pruned.prune_config.selectors = vec!["nav".to_string()];
+        assert!(matches!(
+            pruned.process_event(start_tag("p", vec![])),
+            SanitizeDecision::Pass(_)
+        ));
+        assert_eq!(
+            pruned.process_event(start_tag("nav", vec![])),
+            SanitizeDecision::Skip
+        );
+        assert_eq!(pruned.nesting_depth(), 0);
+    }
+
+    #[test]
+    fn test_optional_end_tag_rules_preserve_genuine_nested_list_items() {
+        let mut san = StreamingSanitizer::with_max_depth(4);
+
+        for tag in ["ul", "li", "ul", "li"] {
+            assert!(matches!(
+                san.process_event(start_tag(tag, vec![])),
+                SanitizeDecision::Pass(_)
+            ));
+        }
+        assert_eq!(san.nesting_depth(), 4);
+
+        assert_eq!(
+            san.process_event(start_tag("span", vec![])),
+            SanitizeDecision::DepthExceeded
+        );
     }
 
     #[test]

--- a/components/rust-converter/src/streaming/state_machine.rs
+++ b/components/rust-converter/src/streaming/state_machine.rs
@@ -222,7 +222,11 @@ impl StructuralStateMachine {
                 if self.current_context() == Some(&StructuralContext::CodeBlock(None)) {
                     let lang = attrs.iter().find(|(k, _)| k == "class").and_then(|(_, v)| {
                         v.split_whitespace()
-                            .filter_map(|class| class.strip_prefix("language-"))
+                            .filter_map(|class| {
+                                class
+                                    .strip_prefix("language-")
+                                    .or_else(|| class.strip_prefix("lang-"))
+                            })
                             .find(|language| is_safe_code_fence_language(language))
                             .map(ToOwned::to_owned)
                     });

--- a/components/rust-converter/src/streaming/state_machine.rs
+++ b/components/rust-converter/src/streaming/state_machine.rs
@@ -8,6 +8,13 @@ use crate::error::ConversionError;
 use crate::streaming::budget::MemoryBudget;
 use crate::streaming::types::StreamEvent;
 
+pub(crate) fn is_safe_code_fence_language(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'+' | b'.' | b'#' | b'-')
+        })
+}
+
 /// Document structure context tracked on the state stack.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StructuralContext {
@@ -215,8 +222,9 @@ impl StructuralStateMachine {
                 if self.current_context() == Some(&StructuralContext::CodeBlock(None)) {
                     let lang = attrs.iter().find(|(k, _)| k == "class").and_then(|(_, v)| {
                         v.split_whitespace()
-                            .find(|c| c.starts_with("language-"))
-                            .map(|c| c.trim_start_matches("language-").to_string())
+                            .filter_map(|class| class.strip_prefix("language-"))
+                            .find(|language| is_safe_code_fence_language(language))
+                            .map(ToOwned::to_owned)
                     });
                     if lang.is_some() {
                         // Update the parent CodeBlock context with the language
@@ -862,6 +870,53 @@ mod tests {
         .unwrap();
         assert!(sm.in_preformatted);
         // The CodeBlock context should now have the language
+        assert_eq!(
+            sm.current_context(),
+            Some(&StructuralContext::CodeBlock(Some("rust".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_code_block_rejects_fence_corrupting_language() {
+        for language in ["language-rust```", "language-rust\0malicious"] {
+            let mut sm = default_sm();
+            sm.process_event(&start_tag("pre")).unwrap();
+            sm.process_event(&start_tag_with_attrs("code", vec![("class", language)]))
+                .unwrap();
+
+            assert_eq!(
+                sm.current_context(),
+                Some(&StructuralContext::CodeBlock(None))
+            );
+        }
+    }
+
+    #[test]
+    fn test_code_block_accepts_safe_punctuation_in_language() {
+        let mut sm = default_sm();
+        sm.process_event(&start_tag("pre")).unwrap();
+        sm.process_event(&start_tag_with_attrs(
+            "code",
+            vec![("class", "language-c++")],
+        ))
+        .unwrap();
+
+        assert_eq!(
+            sm.current_context(),
+            Some(&StructuralContext::CodeBlock(Some("c++".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_code_block_skips_unsafe_language_before_safe_language() {
+        let mut sm = default_sm();
+        sm.process_event(&start_tag("pre")).unwrap();
+        sm.process_event(&start_tag_with_attrs(
+            "code",
+            vec![("class", "language-bad``` language-rust")],
+        ))
+        .unwrap();
+
         assert_eq!(
             sm.current_context(),
             Some(&StructuralContext::CodeBlock(Some("rust".to_string())))

--- a/components/rust-converter/tests/coverage_edge_cases.rs
+++ b/components/rust-converter/tests/coverage_edge_cases.rs
@@ -106,6 +106,20 @@ fn test_blocks_code_block_lang_prefix() {
     assert!(md.contains("print"));
 }
 
+/// Verifies that an invalid language class (containing a `/`) does not stop
+/// scanning for a later valid language in the same class list. This is a
+/// regression test for the bug where the first matching prefix broke out of
+/// the loop regardless of whether `safe_code_language` accepted it.
+#[test]
+fn test_blocks_code_block_invalid_then_valid_language() {
+    let md = convert_html(
+        r#"<pre><code class="language-bad/token language-rust">fn main() {}</code></pre>"#,
+    );
+    assert!(md.contains("rust"), "expected rust language, got: {md}");
+    assert!(!md.contains("bad/token"));
+    assert!(md.contains("fn main()"));
+}
+
 /// Verifies that code blocks containing backticks use a longer fence to avoid
 /// content conflicts.
 #[test]

--- a/components/rust-converter/tests/coverage_streaming_edge_cases.rs
+++ b/components/rust-converter/tests/coverage_streaming_edge_cases.rs
@@ -267,7 +267,10 @@ fn test_streaming_code_block_lang_prefix_parity() {
     converter.feed_chunk(html).expect("feed failed");
     let result = converter.finalize().expect("finalize failed");
     let md = String::from_utf8_lossy(&result.final_markdown);
-    assert!(md.contains("python"), "streaming should honor lang- prefix, got: {md}");
+    assert!(
+        md.contains("python"),
+        "streaming should honor lang- prefix, got: {md}"
+    );
 }
 
 /// Verifies that an invalid language followed by a valid one is handled

--- a/components/rust-converter/tests/coverage_streaming_edge_cases.rs
+++ b/components/rust-converter/tests/coverage_streaming_edge_cases.rs
@@ -258,6 +258,69 @@ fn test_streaming_code_block() {
     assert!(md.contains("fn main"));
 }
 
+/// Verifies that the streaming path recognizes the `lang-` prefix for code
+/// fence languages, matching the full-buffer path (parity requirement).
+#[test]
+fn test_streaming_code_block_lang_prefix_parity() {
+    let mut converter = make_converter();
+    let html = b"<pre><code class=\"lang-python\">print(\"hello\")</code></pre>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(md.contains("python"), "streaming should honor lang- prefix, got: {md}");
+}
+
+/// Verifies that an invalid language followed by a valid one is handled
+/// correctly in the streaming path, matching the full-buffer path.
+#[test]
+fn test_streaming_code_block_invalid_then_valid_language_parity() {
+    let mut converter = make_converter();
+    let html = b"<pre><code class=\"language-bad/token language-rust\">fn main() {}</code></pre>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(md.contains("rust"), "streaming should pick rust, got: {md}");
+    assert!(!md.contains("bad/token"));
+}
+
+/// Regression: omitted `</p>` before a block-level start tag (e.g. `<div>`)
+/// must produce a separator between the paragraph text and the following
+/// block, not glue them together. The streaming sanitizer mirrors implied
+/// end-tag closures into the StructuralStateMachine so the paragraph context
+/// is exited before the next block opens.
+#[test]
+fn test_streaming_omitted_p_closure_separates_blocks() {
+    let mut converter = make_converter();
+    let html = b"<html><body><p>intro<div>block</div></body></html>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(
+        !md.contains("introblock"),
+        "paragraph text must not glue to following block, got: {md}"
+    );
+    assert!(md.contains("intro"), "missing intro: {md}");
+    assert!(md.contains("block"), "missing block: {md}");
+}
+
+/// Regression: omitted `</li>` between consecutive list items must not
+/// merge item content. The sanitizer's implied closure for `<li>` is
+/// propagated to the StructuralStateMachine.
+#[test]
+fn test_streaming_omitted_li_closure_separates_items() {
+    let mut converter = make_converter();
+    let html = b"<html><body><ul><li>first<li>second</ul></body></html>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(md.contains("first"), "missing first: {md}");
+    assert!(md.contains("second"), "missing second: {md}");
+    assert!(
+        !md.contains("firstsecond"),
+        "list items must not glue together, got: {md}"
+    );
+}
+
 #[test]
 fn test_streaming_list() {
     let mut converter = make_converter();

--- a/components/rust-converter/tests/coverage_streaming_edge_cases.rs
+++ b/components/rust-converter/tests/coverage_streaming_edge_cases.rs
@@ -306,6 +306,22 @@ fn test_streaming_omitted_p_closure_separates_blocks() {
     assert!(md.contains("block"), "missing block: {md}");
 }
 
+/// Implied paragraph closure must unwind nested inline contexts from the
+/// inside out so their Markdown delimiters do not cross the paragraph break.
+#[test]
+fn test_streaming_implied_p_closure_unwinds_inline_contexts_first() {
+    let mut converter = make_converter();
+    let html = b"<html><body><p><strong>intro<div>block</div></body></html>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+
+    assert!(
+        md.contains("**intro**\n"),
+        "bold delimiter must close before the paragraph break, got: {md}"
+    );
+}
+
 /// Regression: implied `</p>` closure before a skipped `<form>` must still
 /// propagate to the state machine. The sanitizer produces `implied_closures`
 /// even when the current tag is returned as `Skip` (e.g. `<form>` is both a

--- a/components/rust-converter/tests/coverage_streaming_edge_cases.rs
+++ b/components/rust-converter/tests/coverage_streaming_edge_cases.rs
@@ -306,6 +306,42 @@ fn test_streaming_omitted_p_closure_separates_blocks() {
     assert!(md.contains("block"), "missing block: {md}");
 }
 
+/// Regression: implied `</p>` closure before a skipped `<form>` must still
+/// propagate to the state machine. The sanitizer produces `implied_closures`
+/// even when the current tag is returned as `Skip` (e.g. `<form>` is both a
+/// PARAGRAPH_CLOSING_START_TAG and a FORM_ELEMENT). Prior to the fix, the
+/// `Skip` branch returned before consuming implied closures, leaving the
+/// state machine's paragraph context open and gluing "intro" to form content.
+#[test]
+fn test_streaming_implied_closure_before_skip_propagates() {
+    let mut converter = make_converter();
+    let html = b"<html><body><p>intro<form>inside</form></body></html>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(md.contains("intro"), "missing intro: {md}");
+    assert!(
+        !md.contains("introinside"),
+        "skipped form must not glue to preceding paragraph, got: {md}"
+    );
+}
+
+/// Regression: second paragraph after skipped form must not merge with the first.
+#[test]
+fn test_streaming_implied_closure_before_skip_multiple_paragraphs() {
+    let mut converter = make_converter();
+    let html = b"<html><body><p>first<form>skip</form><p>second</body></html>";
+    converter.feed_chunk(html).expect("feed failed");
+    let result = converter.finalize().expect("finalize failed");
+    let md = String::from_utf8_lossy(&result.final_markdown);
+    assert!(md.contains("first"), "missing first: {md}");
+    assert!(md.contains("second"), "missing second: {md}");
+    assert!(
+        !md.contains("firstsecond"),
+        "paragraphs must not merge through skipped form, got: {md}"
+    );
+}
+
 /// Regression: omitted `</li>` between consecutive list items must not
 /// merge item content. The sanitizer's implied closure for `<li>` is
 /// propagated to the StructuralStateMachine.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -91,10 +91,10 @@ prevent accidental use of an incompatible package:
 Examples:
 
 ```
-nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
-nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_arm64.deb
-nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
-nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.aarch64.rpm
+nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_amd64.deb
+nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_arm64.deb
+nginx-module-markdown-for-agents-0.8.2-nginx1.26.3-1.x86_64.rpm
+nginx-module-markdown-for-agents-0.8.2-nginx1.26.3-1.aarch64.rpm
 ```
 
 Always select the package that matches both your NGINX version and CPU

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -91,10 +91,10 @@ prevent accidental use of an incompatible package:
 Examples:
 
 ```
-nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_amd64.deb
-nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_arm64.deb
-nginx-module-markdown-for-agents-0.8.0-nginx1.26.3-1.x86_64.rpm
-nginx-module-markdown-for-agents-0.8.0-nginx1.26.3-1.aarch64.rpm
+nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
+nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_arm64.deb
+nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
+nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.aarch64.rpm
 ```
 
 Always select the package that matches both your NGINX version and CPU

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -25,7 +25,7 @@ Use it when you need more than deployment guidance but less than source-level im
 
 | RFC | Title | Status | Target Version |
 |-----|-------|--------|----------------|
-| [RFC-0008](RFC-0008-streaming-conversion-support-contract.md) | Streaming Conversion and Support Contract | Draft | 0.8.0 |
+| [RFC-0008](RFC-0008-streaming-conversion-support-contract.md) | Streaming Conversion and Support Contract | Accepted / Implemented in 0.8.0 | 0.8.0 |
 
 ## Scope
 

--- a/docs/architecture/RFC-0008-streaming-conversion-support-contract.md
+++ b/docs/architecture/RFC-0008-streaming-conversion-support-contract.md
@@ -2,11 +2,20 @@
 
 | Field          | Value                     |
 |----------------|---------------------------|
-| Status         | Draft                     |
+| Status         | Accepted / Implemented in 0.8.0 |
 | Target Version | 0.8.0                     |
-| Author         | —                         |
+| Author         | Kang                      |
 | Created        | 2026-06-04                |
 | Scope          | True streaming contract, defaults, fallback semantics, support matrix source |
+
+## Implementation Note
+
+RFC-0008 was implemented in 0.8.0, which shipped the true streaming contract,
+fallback semantics, and support matrix source of truth as specified in this
+document. The 0.8.1 patch release added further hardening: streaming header
+commit atomicity (Rule 39 rollback semantics), FFI streaming finish invalid
+input handle ownership / cleanup contract, Content-Type OWS / HTAB compliance,
+and full-buffer backpressure NGX_AGAIN resume tail duplication fix.
 
 ---
 
@@ -167,7 +176,7 @@ the minimum size threshold.
 # markdown_stream_flush_interval 100ms;
 ```
 
-`markdown_stream_flush_interval` is reserved for a future 0.8.x release. Its
+`markdown_stream_flush_interval` is reserved for a future release. Its
 semantics are defined here for completeness: when set, the module MAY also
 flush if the maximum wait time elapses regardless of output size. This
 directive MUST NOT be documented as implemented or accepted in configuration

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1012,7 +1012,7 @@ in the current release. They are **not registered** in the module command table.
 |-------|-------|
 | **Status** | Reserved — not available |
 | **Intended purpose** | Time-based flush control for streaming output (flush after N milliseconds even if `markdown_stream_flush_min` bytes have not accumulated) |
-| **Planned version** | Future 0.8.x release (pending finalization of time-based flush semantics) |
+| **Planned version** | Future release (pending finalization of time-based flush semantics) |
 | **Defined in** | RFC 0008 |
 | **Current behavior** | Not registered; NGINX rejects the directive at configuration parse time |
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -179,8 +179,12 @@ operate your own package repository.
 
 ### DEB Artifacts (Ubuntu / Debian)
 
+Replace `VERSION` below with the release tag you are installing (latest patch
+on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+run.
+
 ```bash
-VERSION=0.8.0
+VERSION=0.8.1  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=amd64
 
@@ -192,8 +196,12 @@ sudo apt install "./nginx-module-markdown-for-agents_${VERSION}_nginx-${NGINX_VE
 
 ### RPM Artifacts (AlmaLinux / Amazon Linux / RHEL)
 
+Replace `VERSION` below with the release tag you are installing (latest patch
+on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+run.
+
 ```bash
-VERSION=0.8.0
+VERSION=0.8.1  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=x86_64
 
@@ -1160,7 +1168,7 @@ The system cannot reach GitHub to download the pre-built binary or checksum file
    Manual download is intended only for air-gapped or troubleshooting scenarios — prefer the [install script](#4-primary-install-script) for normal installations.
    ```bash
    # On a connected machine — substitute <release_tag>, <nginx_version>, <os_type>, and <arch>
-   # <release_tag> must match the current release (e.g. v0.8.0)
+   # <release_tag> must match the current release (e.g. v0.8.1)
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz.sha256
    ```
@@ -1198,7 +1206,7 @@ The SHA-256 hash of the downloaded binary does not match the expected checksum f
    Manual download is intended only for troubleshooting — prefer the [install script](#4-primary-install-script) for normal installations.
    ```bash
    # Download the binary and checksum file — substitute <release_tag>, <nginx_version>, <os_type>, <arch>
-   # <release_tag> must match the current release (e.g. v0.8.0)
+   # <release_tag> must match the current release (e.g. v0.8.1)
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz.sha256
 
@@ -1604,3 +1612,4 @@ If you encounter issues not covered in this guide:
 | 0.5.0 | 2026-04-21 | docs-standardization | Standardized formatting, added mermaid diagrams where applicable, verified directive accuracy against code, added update tracking section |
 | 0.6.2 | 2026-05-08 | Kang | Unified version narrative to 0.6.2 current release line |
 | 0.6.3 | 2026-05-14 | Kang | Version bump to 0.6.3 and refresh release matrix for release |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: updated DEB/RPM install examples to VERSION=0.8.1 with replace-with-target-version note |

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -180,11 +180,11 @@ operate your own package repository.
 ### DEB Artifacts (Ubuntu / Debian)
 
 Replace `VERSION` below with the release tag you are installing (latest patch
-on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+on the 0.8.x line is `0.8.2`). `NGINX_VERSION` must match the NGINX ABI you
 run.
 
 ```bash
-VERSION=0.8.1  # replace with the release tag you are installing
+VERSION=0.8.2  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=amd64
 
@@ -197,11 +197,11 @@ sudo apt install "./nginx-module-markdown-for-agents_${VERSION}_nginx-${NGINX_VE
 ### RPM Artifacts (AlmaLinux / Amazon Linux / RHEL)
 
 Replace `VERSION` below with the release tag you are installing (latest patch
-on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+on the 0.8.x line is `0.8.2`). `NGINX_VERSION` must match the NGINX ABI you
 run.
 
 ```bash
-VERSION=0.8.1  # replace with the release tag you are installing
+VERSION=0.8.2  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=x86_64
 
@@ -1168,7 +1168,7 @@ The system cannot reach GitHub to download the pre-built binary or checksum file
    Manual download is intended only for air-gapped or troubleshooting scenarios — prefer the [install script](#4-primary-install-script) for normal installations.
    ```bash
    # On a connected machine — substitute <release_tag>, <nginx_version>, <os_type>, and <arch>
-   # <release_tag> must match the current release (e.g. v0.8.1)
+   # <release_tag> must match the current release (e.g. v0.8.2)
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz.sha256
    ```
@@ -1206,7 +1206,7 @@ The SHA-256 hash of the downloaded binary does not match the expected checksum f
    Manual download is intended only for troubleshooting — prefer the [install script](#4-primary-install-script) for normal installations.
    ```bash
    # Download the binary and checksum file — substitute <release_tag>, <nginx_version>, <os_type>, <arch>
-   # <release_tag> must match the current release (e.g. v0.8.1)
+   # <release_tag> must match the current release (e.g. v0.8.2)
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz
    wget https://github.com/cnkang/nginx-markdown-for-agents/releases/download/<release_tag>/ngx_http_markdown_filter_module-<nginx_version>-<os_type>-<arch>.tar.gz.sha256
 
@@ -1612,4 +1612,4 @@ If you encounter issues not covered in this guide:
 | 0.5.0 | 2026-04-21 | docs-standardization | Standardized formatting, added mermaid diagrams where applicable, verified directive accuracy against code, added update tracking section |
 | 0.6.2 | 2026-05-08 | Kang | Unified version narrative to 0.6.2 current release line |
 | 0.6.3 | 2026-05-14 | Kang | Version bump to 0.6.3 and refresh release matrix for release |
-| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: updated DEB/RPM install examples to VERSION=0.8.1 with replace-with-target-version note |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: updated DEB/RPM install examples to VERSION=0.8.2 with replace-with-target-version note; refreshed SOP manual-download examples to reference v0.8.2 |

--- a/docs/guides/MIGRATION-0.8.md
+++ b/docs/guides/MIGRATION-0.8.md
@@ -314,7 +314,7 @@ markdown_stream_excluded_types text/csv application/atom+xml;
 ### Reserved: markdown_stream_flush_interval
 
 > **Not implemented in 0.8.0.** Using this directive causes `nginx -t` to fail.
-> Reserved for a future 0.8.x release for time-based flush control. Do not
+> Reserved for a future release for time-based flush control. Do not
 > include it in configuration files.
 
 ---

--- a/docs/guides/PACKAGE_DISTRIBUTION.md
+++ b/docs/guides/PACKAGE_DISTRIBUTION.md
@@ -61,14 +61,14 @@ Components:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| VERSION | Module semantic version | 0.8.1 |
+| VERSION | Module semantic version | 0.8.2 |
 | NGINX_VERSION | Target NGINX version (major.minor.patch) | 1.26.3 |
 | ARCH | CPU architecture (amd64, arm64) | amd64 |
 
 Example:
 
 ```text
-nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
+nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_amd64.deb
 ```
 
 ### RPM Package Naming
@@ -83,14 +83,14 @@ Components:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| VERSION | Module semantic version | 0.8.1 |
+| VERSION | Module semantic version | 0.8.2 |
 | NGINX_VERSION | Target NGINX version (major.minor.patch) | 1.26.3 |
 | ARCH | CPU architecture (x86_64, aarch64) | x86_64 |
 
 Example:
 
 ```text
-nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
+nginx-module-markdown-for-agents-0.8.2-nginx1.26.3-1.x86_64.rpm
 ```
 
 ### Architecture Mapping
@@ -122,7 +122,7 @@ installation.
 Download `SHA256SUMS` from the same GitHub Release page as the package:
 
 ```bash
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.2/SHA256SUMS
 ```
 
 ### Verifying a Downloaded Package
@@ -138,10 +138,10 @@ Or verify manually:
 
 ```bash
 # Compute the checksum of the downloaded file
-sha256sum nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
+sha256sum nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_amd64.deb
 
 # Compare the output against the corresponding line in SHA256SUMS
-grep "nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb" SHA256SUMS
+grep "nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_amd64.deb" SHA256SUMS
 ```
 
 Both values must match exactly. If they differ, do not install the package
@@ -158,8 +158,8 @@ Each line in `SHA256SUMS` follows the standard format:
 Example:
 
 ```text
-a1b2c3d4...  nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
-e5f6a7b8...  nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
+a1b2c3d4...  nginx-module-markdown-for-agents_0.8.2_nginx-1.26.3_amd64.deb
+e5f6a7b8...  nginx-module-markdown-for-agents-0.8.2-nginx1.26.3-1.x86_64.rpm
 ```
 
 ## GPG Signature Verification
@@ -205,9 +205,9 @@ The recommended verification sequence:
 
 ```bash
 # 1. Download the package, checksums, and signature
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS.asc
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/<package-file>
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.2/SHA256SUMS
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.2/SHA256SUMS.asc
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.2/<package-file>
 
 # 2. Verify GPG signature on the checksum file
 gpg --verify SHA256SUMS.asc SHA256SUMS

--- a/docs/guides/PACKAGE_DISTRIBUTION.md
+++ b/docs/guides/PACKAGE_DISTRIBUTION.md
@@ -61,14 +61,14 @@ Components:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| VERSION | Module semantic version | 0.8.0 |
+| VERSION | Module semantic version | 0.8.1 |
 | NGINX_VERSION | Target NGINX version (major.minor.patch) | 1.26.3 |
 | ARCH | CPU architecture (amd64, arm64) | amd64 |
 
 Example:
 
 ```text
-nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_amd64.deb
+nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
 ```
 
 ### RPM Package Naming
@@ -83,14 +83,14 @@ Components:
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| VERSION | Module semantic version | 0.8.0 |
+| VERSION | Module semantic version | 0.8.1 |
 | NGINX_VERSION | Target NGINX version (major.minor.patch) | 1.26.3 |
 | ARCH | CPU architecture (x86_64, aarch64) | x86_64 |
 
 Example:
 
 ```text
-nginx-module-markdown-for-agents-0.8.0-nginx1.26.3-1.x86_64.rpm
+nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
 ```
 
 ### Architecture Mapping
@@ -122,7 +122,7 @@ installation.
 Download `SHA256SUMS` from the same GitHub Release page as the package:
 
 ```bash
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.0/SHA256SUMS
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS
 ```
 
 ### Verifying a Downloaded Package
@@ -138,10 +138,10 @@ Or verify manually:
 
 ```bash
 # Compute the checksum of the downloaded file
-sha256sum nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_amd64.deb
+sha256sum nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
 
 # Compare the output against the corresponding line in SHA256SUMS
-grep "nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_amd64.deb" SHA256SUMS
+grep "nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb" SHA256SUMS
 ```
 
 Both values must match exactly. If they differ, do not install the package
@@ -158,8 +158,8 @@ Each line in `SHA256SUMS` follows the standard format:
 Example:
 
 ```text
-a1b2c3d4...  nginx-module-markdown-for-agents_0.8.0_nginx-1.26.3_amd64.deb
-e5f6a7b8...  nginx-module-markdown-for-agents-0.8.0-nginx1.26.3-1.x86_64.rpm
+a1b2c3d4...  nginx-module-markdown-for-agents_0.8.1_nginx-1.26.3_amd64.deb
+e5f6a7b8...  nginx-module-markdown-for-agents-0.8.1-nginx1.26.3-1.x86_64.rpm
 ```
 
 ## GPG Signature Verification
@@ -205,9 +205,9 @@ The recommended verification sequence:
 
 ```bash
 # 1. Download the package, checksums, and signature
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.0/SHA256SUMS
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.0/SHA256SUMS.asc
-curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.0/<package-file>
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/SHA256SUMS.asc
+curl -fsSLO https://github.com/<org>/nginx-markdown-for-agents/releases/download/v0.8.1/<package-file>
 
 # 2. Verify GPG signature on the checksum file
 gpg --verify SHA256SUMS.asc SHA256SUMS

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -55,11 +55,11 @@ Architecture mapping:
 ## DEB Artifacts (Ubuntu, Debian)
 
 Replace `VERSION` below with the release tag you are installing (latest patch
-on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+on the 0.8.x line is `0.8.2`). `NGINX_VERSION` must match the NGINX ABI you
 run.
 
 ```bash
-VERSION=0.8.1  # replace with the release tag you are installing
+VERSION=0.8.2  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=amd64
 BASE_URL="https://github.com/cnkang/nginx-markdown-for-agents/releases/download/v${VERSION}"
@@ -74,11 +74,11 @@ sudo apt install "./${PKG}"
 ## RPM Artifacts (AlmaLinux, Amazon Linux, RHEL)
 
 Replace `VERSION` below with the release tag you are installing (latest patch
-on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+on the 0.8.x line is `0.8.2`). `NGINX_VERSION` must match the NGINX ABI you
 run.
 
 ```bash
-VERSION=0.8.1  # replace with the release tag you are installing
+VERSION=0.8.2  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=x86_64
 BASE_URL="https://github.com/cnkang/nginx-markdown-for-agents/releases/download/v${VERSION}"

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -54,8 +54,12 @@ Architecture mapping:
 
 ## DEB Artifacts (Ubuntu, Debian)
 
+Replace `VERSION` below with the release tag you are installing (latest patch
+on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+run.
+
 ```bash
-VERSION=0.8.0
+VERSION=0.8.1  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=amd64
 BASE_URL="https://github.com/cnkang/nginx-markdown-for-agents/releases/download/v${VERSION}"
@@ -69,8 +73,12 @@ sudo apt install "./${PKG}"
 
 ## RPM Artifacts (AlmaLinux, Amazon Linux, RHEL)
 
+Replace `VERSION` below with the release tag you are installing (latest patch
+on the 0.8.x line is `0.8.1`). `NGINX_VERSION` must match the NGINX ABI you
+run.
+
 ```bash
-VERSION=0.8.0
+VERSION=0.8.1  # replace with the release tag you are installing
 NGINX_VERSION=1.26.3
 ARCH=x86_64
 BASE_URL="https://github.com/cnkang/nginx-markdown-for-agents/releases/download/v${VERSION}"

--- a/docs/harness/core.md
+++ b/docs/harness/core.md
@@ -220,4 +220,4 @@ pre-output checklist.
 |---------|------|--------|---------|
 | 0.5.0 | 2026-04-21 | docs-standardization | Added update tracking section |
 | 0.6.2 | 2026-05-08 | Kang | Unified version narrative to 0.6.2 current release line |
-| 0.8.6 | 2026-06-23 | Codex | Added checkable-outcome guidance for risk cards and verification closeout |
+| 0.8.2 | 2026-06-23 | Kang | Added checkable-outcome guidance for risk cards and verification closeout |

--- a/docs/harness/core.md
+++ b/docs/harness/core.md
@@ -44,6 +44,7 @@ The default card stays short:
 - likely primary pack
 - supporting packs, if any
 - minimum cheap blockers
+- checkable outcome
 - one-sentence risk note
 
 Expand to a detailed card only when:
@@ -76,6 +77,16 @@ does, the route changes. The initial guess does not get special authority.
 The default path should stay cheap. Prefer a fast blocker-first flow and widen
 only when the touched surface, warnings, or drift signals justify more cost.
 Do not spend replay or history-scan budget on every task by default.
+
+Define the checkable outcome before calling work done:
+
+- bug fix: failing case and expected behavior
+- feature: observable behavior the user should see
+- refactor: behavior that must remain unchanged
+- review: concrete risks, missing tests, and regressions
+
+Use the narrowest meaningful verification that proves that outcome. If a
+stronger check is skipped, record why.
 
 Warnings are not cleanup theater. Do not silence a warning by weakening checks,
 shrinking coverage, or deleting behavior unless the warning itself proves the
@@ -209,3 +220,4 @@ pre-output checklist.
 |---------|------|--------|---------|
 | 0.5.0 | 2026-04-21 | docs-standardization | Added update tracking section |
 | 0.6.2 | 2026-05-08 | Kang | Unified version narrative to 0.6.2 current release line |
+| 0.8.6 | 2026-06-23 | Codex | Added checkable-outcome guidance for risk cards and verification closeout |

--- a/docs/harness/rules/html-sanitizer.md
+++ b/docs/harness/rules/html-sanitizer.md
@@ -25,6 +25,11 @@ Historical issues: `1688e80`, `77a46d6`, `2c7d6a9`.
 
 Required:
 - In-link formatting markers (bold/italic/inline-code) must be accumulated in link text, not flushed outside link context.
+- When one parser event implicitly or explicitly closes multiple open
+  structures, unwind them from innermost to outermost and mirror the same
+  closure order into sanitizer, state-machine, and emitter state. Closing an
+  enclosing block before nested inline contexts may cross Markdown delimiters
+  over paragraph or list boundaries.
 - Code-block output must preserve raw content (blank lines/trailing spaces) and bypass generic normalization.
 - Streaming code-block emitters must carry delimiter state across text-event
   boundaries.  Fence length must be chosen from the longest backtick run across

--- a/docs/harness/rules/security-static-analysis.md
+++ b/docs/harness/rules/security-static-analysis.md
@@ -36,8 +36,9 @@ Required:
 - Local `gitleaks` execution must scan exactly Git-tracked worktree content so
   tracked edits are covered while ignored local adapters, caches, and build
   state cannot create findings for files absent from a clean checkout. Any
-  tracked-file materialization must preserve unusual filenames with NUL-safe
-  traversal.
+  tracked-file materialization must omit tracked paths that are absent because
+  they were deleted in the worktree and preserve unusual filenames with
+  NUL-safe traversal.
 - Semgrep CE rules must stay high-confidence and repo-specific. Avoid broad
   noisy packs as PR-blocking checks until findings are triaged and documented.
 - `cargo-deny` must check Rust advisories, license policy, bans, and sources for

--- a/docs/harness/rules/security-static-analysis.md
+++ b/docs/harness/rules/security-static-analysis.md
@@ -33,6 +33,11 @@ Required:
 - `gitleaks` must fail on real secrets, private keys, signing material, API
   keys, tokens, and passwords. Allowlist only test fixtures or placeholders
   with narrow path or regex scope.
+- Local `gitleaks` execution must scan exactly Git-tracked worktree content so
+  tracked edits are covered while ignored local adapters, caches, and build
+  state cannot create findings for files absent from a clean checkout. Any
+  tracked-file materialization must preserve unusual filenames with NUL-safe
+  traversal.
 - Semgrep CE rules must stay high-confidence and repo-specific. Avoid broad
   noisy packs as PR-blocking checks until findings are triaged and documented.
 - `cargo-deny` must check Rust advisories, license policy, bans, and sources for

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -613,8 +613,8 @@ version support declarations into a release matrix source of truth (ADR-0014).
 The 0.8.1 and 0.8.2 patch releases harden streaming atomicity, FFI cleanup,
 OWS compliance, backpressure resume, release-gate naming, and documentation
 consistency without changing the 0.8.x configuration contract. It also
-includes streaming observability (streaming observability), streaming security
-enforcement (streaming security enforcement), streaming configuration directives, Prometheus-compatible
+includes streaming observability (metrics and tracing), streaming security
+enforcement (policy validation and alerts), streaming configuration directives, Prometheus-compatible
 metrics, decision reason codes, rollout and rollback guides, parity and
 evidence workflows for streaming rollout safety, dynamic configuration
 hot-reload, OpenTelemetry tracing, per-path metrics, OS package distribution,

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -11,7 +11,7 @@ steering files.
 
 ## Current Assessment
 
-As of the **current release line (0.8.0)**, the project includes a dual-engine
+As of the **current release line (0.8.x)**, the project includes a dual-engine
 conversion model (streaming default with full-buffer fallback), Rust-first
 architecture modules for Accept negotiation, conditional requests, decision
 logic, and header plan application, independent decompression budget with parse
@@ -25,13 +25,16 @@ fuzz-oriented validation entrypoints, and harness-specific validation
 entrypoints, along with documentation covering installation, configuration,
 operations, architecture, and contributor-facing harness maintenance.
 
-### Release 0.8.0 (Current)
+### Release 0.8.x Line (Current)
 
-**Status:** Current release
+**Status:** Current release line. The 0.8.x line began with 0.8.0 (true
+streaming contract) and continues with patch releases (0.8.1, 0.8.2) that
+harden stability, security, and release-gate consistency without introducing
+new user-visible features or breaking configuration changes.
 
 Version 0.8.0 formalizes true streaming semantics as a first-class, verifiable
-contract. See the [Current Release 0.8.0](#current-release-080) section below
-for detailed goals, non-goals, and implementation status.
+contract. See the [Current Release Line 0.8.x](#current-release-line-08x)
+section below for detailed goals, non-goals, and implementation status.
 
 ### Release 0.7.0 Updates
 
@@ -373,24 +376,60 @@ See [DEPLOYMENT_EXAMPLES.md](../guides/DEPLOYMENT_EXAMPLES.md) for configuration
 
 ## Current Focus and Roadmap
 
-### Current Release (0.8.0)
-- True streaming contract: formalized incremental input processing, incremental
+### Current Release Line (0.8.x)
+
+The 0.8.x release line is the current maintained line. The latest patch
+release is 0.8.1; 0.8.2 is a closeout patch that synchronizes version-line
+documentation, finalizes RFC-0008 status, narrows the
+`markdown_stream_flush_interval` commitment, adds stream commit multipart
+rollback regression coverage, and aligns the 0.8.x release-gate naming.
+
+#### 0.8.2 (closeout patch, in preparation)
+
+- Synced "current release line" wording across project, README, installation,
+  and compatibility docs to 0.8.x (latest patch 0.8.1).
+- Finalized RFC-0008 status from `Draft` to `Accepted / Implemented in 0.8.0`,
+  with implementation notes covering 0.8.0 streaming contract and 0.8.1
+  Rule 39 / FFI cleanup / OWS / backpressure hardening.
+- Narrowed `markdown_stream_flush_interval` commitment from "future 0.8.x" to
+  "future release" so the 0.8.x patch line is not bound to delivering it.
+- Added stream commit multipart header-list rollback regression tests covering
+  cross-part `orig_nelts` semantics (Rule 39 / Rule 40).
+- Added `make release-gates-check-08x` as the canonical 0.8.x patch-line entry
+  point, reusing the 0.8.0 gate logic without duplicating it.
+- Updated `CHANGELOG.md` with a 0.8.2 entry scoped to this closeout work.
+
+#### 0.8.1 (latest patch)
+
+- Streaming header commit atomicity / Rule 39 rollback semantics.
+- FFI streaming finish invalid input handle ownership / cleanup contract.
+- Content-Type OWS / HTAB compliance.
+- Full-buffer backpressure `NGX_AGAIN` resume tail duplication.
+- Release/perf/coverage tooling path traversal and taint sink hardening.
+- Static security / supply-chain gate additions and documentation.
+
+#### 0.8.0 (line anchor)
+
+- True streaming contract: formalize incremental input processing, incremental
   output emission, and bounded memory as a single verifiable contract
   (RFC 0008, ADR-0011)
-- Streaming fallback state machine: pre-commit/post-commit two-phase error
+- Fallback state machine: implement pre-commit/post-commit two-phase error
   handling with deterministic recovery semantics (ADR-0012)
-- Default-auto engine: aligned auto-mode streaming policy with the true
+- Default-auto engine: align the auto-mode streaming policy with the true
   streaming contract definition (ADR-0013)
-- Support matrix source of truth: consolidated platform, version, and package
+- Support matrix source of truth: consolidate platform, version, and package
   support declarations into a single machine-readable matrix consumed by CI,
   docs, and packaging (ADR-0014)
-- Streaming observability: engine selection counters, fallback/failure counters,
-  streaming reason codes (streaming observability)
-- Streaming security enforcement: hard-excluded content types with security
-  test suite (streaming security enforcement)
-- Streaming configuration directives: `markdown_stream_threshold`,
-  `markdown_stream_precommit_buffer`, `markdown_stream_flush_min`,
-  `markdown_stream_excluded_types` (#137)
+
+**Non-goals for 0.8.x line:**
+- SSE/NDJSON conversion (out of scope for this release line)
+- Full parser rewrite (incremental improvements only)
+- Edge-CDN deployment model (origin-near architecture retained)
+- Implementing `markdown_stream_flush_interval` (reserved for a future release;
+  current use causes `nginx -t` to fail)
+
+### Implemented Features (0.8.x line)
+
 - Dual-engine conversion architecture: streaming default with full-buffer
   fallback
 - Rust-first architecture: Accept negotiation, conditional requests, decision
@@ -415,25 +454,6 @@ See [DEPLOYMENT_EXAMPLES.md](../guides/DEPLOYMENT_EXAMPLES.md) for configuration
 - OS package manager distribution (APT, YUM/DNF, Homebrew)
 - Rollout and rollback guides with executable operator procedures
 - Performance baseline gating system and hardened CI/CD validation
-
-### Current Release 0.8.0
-
-**Goals (implemented):**
-- True streaming contract: formalize incremental input processing, incremental
-  output emission, and bounded memory as a single verifiable contract
-  (RFC 0008, ADR-0011)
-- Fallback state machine: implement pre-commit/post-commit two-phase error
-  handling with deterministic recovery semantics (ADR-0012)
-- Default-auto engine: align the auto-mode streaming policy with the true
-  streaming contract definition (ADR-0013)
-- Support matrix source of truth: consolidate platform, version, and package
-  support declarations into a single machine-readable matrix consumed by CI,
-  docs, and packaging (ADR-0014)
-
-**Non-goals for 0.8.0:**
-- SSE/NDJSON conversion (out of scope for this release)
-- Full parser rewrite (incremental improvements only)
-- Edge-CDN deployment model (origin-near architecture retained)
 
 ### Near-Term
 - Expand streaming rollout samples across mixed traffic profiles
@@ -581,7 +601,8 @@ See `examples/docker/` for Docker build examples.
 
 ## Summary
 
-**NGINX Markdown for Agents** is at version 0.8.0. The project provides
+**NGINX Markdown for Agents** is on the 0.8.x release line (latest patch:
+0.8.1; 0.8.2 closeout in preparation). The project provides
 HTML-to-Markdown conversion through NGINX content negotiation with a
 dual-engine model, with bounded-memory streaming as the default path and
 full-buffer conversion as the fallback. Version 0.8.0 formalizes the true
@@ -589,7 +610,10 @@ streaming contract (RFC 0008, ADR-0011), introduces the streaming fallback
 state machine (ADR-0012), aligns the auto-mode streaming policy with the true
 streaming contract definition (ADR-0013), and consolidates platform and
 version support declarations into a release matrix source of truth (ADR-0014).
-It also includes streaming observability (streaming observability), streaming security
+The 0.8.1 and 0.8.2 patch releases harden streaming atomicity, FFI cleanup,
+OWS compliance, backpressure resume, release-gate naming, and documentation
+consistency without changing the 0.8.x configuration contract. It also
+includes streaming observability (streaming observability), streaming security
 enforcement (streaming security enforcement), streaming configuration directives, Prometheus-compatible
 metrics, decision reason codes, rollout and rollback guides, parity and
 evidence workflows for streaming rollout safety, dynamic configuration
@@ -626,3 +650,4 @@ For questions, issues, or feature requests, use the [GitHub issue tracker](https
 | 0.6.3 | 2026-05-13 | Kang | Version bump to 0.6.3 for release |
 | 0.7.0 | 2026-06-03 | Kang | Version bump to 0.7.0; add Rust-first architecture, decompression budget, diagnostics, dynconf dry-run, DEB/RPM, K8s, FFI ABI verification, CI supply-chain hardening |
 | 0.8.0 | 2026-06-16 | Kang | Version bump to 0.8.0; true streaming contract, fallback state machine, streaming observability, streaming security enforcement, release matrix source of truth, streaming config directives |
+| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: synced "current release line" wording to 0.8.x (latest patch 0.8.1), finalized RFC-0008 status, narrowed `markdown_stream_flush_interval` commitment, added stream commit multipart rollback regression tests, added `release-gates-check-08x` alias |

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -379,27 +379,39 @@ See [DEPLOYMENT_EXAMPLES.md](../guides/DEPLOYMENT_EXAMPLES.md) for configuration
 ### Current Release Line (0.8.x)
 
 The 0.8.x release line is the current maintained line. The latest patch
-release is 0.8.1; 0.8.2 is a closeout patch that synchronizes version-line
-documentation, finalizes RFC-0008 status, narrows the
-`markdown_stream_flush_interval` commitment, adds stream commit multipart
-rollback regression coverage, and aligns the 0.8.x release-gate naming.
+release is 0.8.2; 0.8.1 and 0.8.2 are patch releases that
+harden stability, security, and release-gate consistency without introducing
+new user-visible features or breaking configuration changes.
 
-#### 0.8.2 (closeout patch, in preparation)
+#### 0.8.2 (latest patch)
 
+- Streaming decompression hardening: eliminated heap leaks in `finish_zlib()`
+  across all exit paths, hardened buffer expansion error paths, and enforced
+  `ngx_alloc`/`ngx_free` exclusively for resizable buffer backing stores
+  (Rule 43).
+- Implied closure correctness (Rule 6): structural closures now unwind
+  inner-to-outer; the Rust converter consumes implied closures before the
+  sanitizer Skip decision and mirrors them to the state machine.
+- FFI safety: centralized header plan reset for panic safety; parser working-set
+  estimation with overflow-safe budget enforcement.
+- Streaming decompression budget and memory accounting (Rule 3, Rule 44).
+- Code fence language handling: `lang-` prefix support and sanitization in the
+  streaming converter.
+- `parse_size()` hardening for empty, whitespace-only, and malformed input.
+- Security scan scoping: gitleaks scoped to tracked worktree content, skipping
+  deleted paths and guarding against empty scan roots (Rule 48).
 - Synced "current release line" wording across project, README, installation,
-  and compatibility docs to 0.8.x (latest patch 0.8.1).
-- Finalized RFC-0008 status from `Draft` to `Accepted / Implemented in 0.8.0`,
-  with implementation notes covering 0.8.0 streaming contract and 0.8.1
-  Rule 39 / FFI cleanup / OWS / backpressure hardening.
+  and compatibility docs to 0.8.x (latest patch 0.8.2).
+- Finalized RFC-0008 status from `Draft` to `Accepted / Implemented in 0.8.0`.
 - Narrowed `markdown_stream_flush_interval` commitment from "future 0.8.x" to
-  "future release" so the 0.8.x patch line is not bound to delivering it.
+  "future release".
 - Added stream commit multipart header-list rollback regression tests covering
   cross-part `orig_nelts` semantics (Rule 39 / Rule 40).
 - Added `make release-gates-check-08x` as the canonical 0.8.x patch-line entry
-  point, reusing the 0.8.0 gate logic without duplicating it.
-- Updated `CHANGELOG.md` with a 0.8.2 entry scoped to this closeout work.
+  point.
+- Updated `THIRD-PARTY-NOTICES` with current dependency versions (Rule 49).
 
-#### 0.8.1 (latest patch)
+#### 0.8.1
 
 - Streaming header commit atomicity / Rule 39 rollback semantics.
 - FFI streaming finish invalid input handle ownership / cleanup contract.
@@ -602,7 +614,7 @@ See `examples/docker/` for Docker build examples.
 ## Summary
 
 **NGINX Markdown for Agents** is on the 0.8.x release line (latest patch:
-0.8.1; 0.8.2 closeout in preparation). The project provides
+0.8.2). The project provides
 HTML-to-Markdown conversion through NGINX content negotiation with a
 dual-engine model, with bounded-memory streaming as the default path and
 full-buffer conversion as the fallback. Version 0.8.0 formalizes the true
@@ -611,7 +623,8 @@ state machine (ADR-0012), aligns the auto-mode streaming policy with the true
 streaming contract definition (ADR-0013), and consolidates platform and
 version support declarations into a release matrix source of truth (ADR-0014).
 The 0.8.1 and 0.8.2 patch releases harden streaming atomicity, FFI cleanup,
-OWS compliance, backpressure resume, release-gate naming, and documentation
+OWS compliance, backpressure resume, streaming decompression, implied-closure
+correctness, release-gate naming, and documentation
 consistency without changing the 0.8.x configuration contract. It also
 includes streaming observability (metrics and tracing), streaming security
 enforcement (policy validation and alerts), streaming configuration directives, Prometheus-compatible
@@ -650,4 +663,4 @@ For questions, issues, or feature requests, use the [GitHub issue tracker](https
 | 0.6.3 | 2026-05-13 | Kang | Version bump to 0.6.3 for release |
 | 0.7.0 | 2026-06-03 | Kang | Version bump to 0.7.0; add Rust-first architecture, decompression budget, diagnostics, dynconf dry-run, DEB/RPM, K8s, FFI ABI verification, CI supply-chain hardening |
 | 0.8.0 | 2026-06-16 | Kang | Version bump to 0.8.0; true streaming contract, fallback state machine, streaming observability, streaming security enforcement, release matrix source of truth, streaming config directives |
-| 0.8.2 | 2026-06-21 | Kang | 0.8.x patch-line closeout: synced "current release line" wording to 0.8.x (latest patch 0.8.1), finalized RFC-0008 status, narrowed `markdown_stream_flush_interval` commitment, added stream commit multipart rollback regression tests, added `release-gates-check-08x` alias |
+| 0.8.2 | 2026-06-23 | Kang | 0.8.2 release: streaming decompression hardening, implied-closure correctness, FFI panic safety, decompression budget enforcement, security scan scoping, release-line documentation closeout |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -35,7 +35,7 @@ The configuration uses template variables injected by the CI matrix:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `PKG_VERSION` | Project version (from tag or workflow input) | `0.8.0` |
+| `PKG_VERSION` | Project version (from tag or workflow input) | `0.8.2` |
 | `NGINX_VERSION` | Target NGINX version from build matrix | `1.26.3` |
 | `NFPM_ARCH` | Target architecture | `amd64`, `arm64` |
 

--- a/packaging/nfpm/nfpm.yaml
+++ b/packaging/nfpm/nfpm.yaml
@@ -4,7 +4,7 @@
 # Generates both .deb and .rpm packages from pre-built Module_SO artifacts.
 #
 # Environment variables (injected by workflow matrix):
-#   PKG_VERSION          - Project version (e.g. 0.8.0)
+#   PKG_VERSION          - Project version (e.g. 0.8.2)
 #   NGINX_VERSION        - Target NGINX version (e.g. 1.26.3)
 #   NGINX_VERSION_FLOOR  - Minor branch floor (e.g. 1.26.0)
 #   NGINX_VERSION_CEIL   - Minor branch ceiling exclusive (e.g. 1.27.0)

--- a/tools/corpus/test-corpus-conversion/Cargo.lock
+++ b/tools/corpus/test-corpus-conversion/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -40,15 +40,15 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markup5ever"
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -240,7 +240,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nginx-markdown-converter"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "brotli",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "scopeguard"
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -431,9 +431,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "string_cache"
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -502,9 +502,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",

--- a/tools/e2e/verify_chunked_streaming_native_e2e.sh
+++ b/tools/e2e/verify_chunked_streaming_native_e2e.sh
@@ -228,12 +228,14 @@ mkdir -p "${RAW_DIR}"
 cat > "${UPSTREAM_SCRIPT}" <<'PY'
 #!/usr/bin/env python3
 import argparse
+import time
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 
 SMALL_END_TOKEN = "SMALL_STREAM_END_TOKEN"
 OVERSIZE_END_TOKEN = "OVERSIZE_STREAM_END_TOKEN"
+DELAYED_END_TOKEN = "DELAYED_OVERSIZE_STREAM_END_TOKEN"
 GZIP_END_TOKEN = "GZIP_STREAM_END_TOKEN"
 DEFLATE_END_TOKEN = "DEFLATE_STREAM_END_TOKEN"
 SMALL_TARGET = 2 * 1024 * 1024
@@ -271,6 +273,9 @@ def compress_payload(body: bytes, mode: str) -> bytes:
 
 SMALL_BODY = build_payload("Chunked Small", SMALL_TARGET, SMALL_END_TOKEN)
 OVERSIZE_BODY = build_payload("Chunked Oversize", OVERSIZE_TARGET, OVERSIZE_END_TOKEN)
+DELAYED_BODY = build_payload(
+    "Delayed Chunked Oversize", OVERSIZE_TARGET, DELAYED_END_TOKEN
+)
 GZIP_SOURCE_BODY = build_payload(
     "Chunked Gzip", COMPRESSED_TARGET, GZIP_END_TOKEN
 )
@@ -305,6 +310,23 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(b"0\r\n\r\n")
         self.wfile.flush()
 
+    def _write_delayed_oversize(self):
+        split = 10 * 1024 * 1024
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=UTF-8")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        for part in (DELAYED_BODY[:split], DELAYED_BODY[split:]):
+            self.wfile.write(f"{len(part):X}\r\n".encode("ascii"))
+            self.wfile.write(part)
+            self.wfile.write(b"\r\n")
+            self.wfile.flush()
+            time.sleep(0.2)
+        self.wfile.write(b"0\r\n\r\n")
+        self.wfile.flush()
+
     def do_GET(self):
         path = urlparse(self.path).path
         if path == "/health":
@@ -320,6 +342,9 @@ class Handler(BaseHTTPRequestHandler):
             return
         if path == "/oversize":
             self._write_chunked(OVERSIZE_BODY)
+            return
+        if path == "/delayed-oversize":
+            self._write_delayed_oversize()
             return
         if path == "/small-gzip":
             self._write_chunked(GZIP_BODY, content_encoding="gzip")
@@ -395,6 +420,7 @@ def main():
     if args.print_metrics:
         print(f"SMALL_LEN={len(SMALL_BODY)}")
         print(f"OVERSIZE_LEN={len(OVERSIZE_BODY)}")
+        print(f"DELAYED_LEN={len(DELAYED_BODY)}")
         print(f"GZIP_SOURCE_LEN={len(GZIP_SOURCE_BODY)}")
         print(f"GZIP_COMPRESSED_LEN={len(GZIP_BODY)}")
         print(f"DEFLATE_SOURCE_LEN={len(DEFLATE_SOURCE_BODY)}")
@@ -406,6 +432,7 @@ def main():
         )
         print(f"SMALL_END_TOKEN={SMALL_END_TOKEN}")
         print(f"OVERSIZE_END_TOKEN={OVERSIZE_END_TOKEN}")
+        print(f"DELAYED_END_TOKEN={DELAYED_END_TOKEN}")
         print(f"GZIP_END_TOKEN={GZIP_END_TOKEN}")
         print(f"DEFLATE_END_TOKEN={DEFLATE_END_TOKEN}")
         return
@@ -426,13 +453,13 @@ load_upstream_metrics() {
 
   while IFS='=' read -r key value; do
     case "${key}" in
-      SMALL_LEN|OVERSIZE_LEN|GZIP_SOURCE_LEN|GZIP_COMPRESSED_LEN|DEFLATE_SOURCE_LEN|DEFLATE_COMPRESSED_LEN|TRUNCATED_GZIP_COMPRESSED_LEN|TRUNCATED_DEFLATE_COMPRESSED_LEN)
+      SMALL_LEN|OVERSIZE_LEN|DELAYED_LEN|GZIP_SOURCE_LEN|GZIP_COMPRESSED_LEN|DEFLATE_SOURCE_LEN|DEFLATE_COMPRESSED_LEN|TRUNCATED_GZIP_COMPRESSED_LEN|TRUNCATED_DEFLATE_COMPRESSED_LEN)
         [[ "${value}" =~ ^[0-9]+$ ]] || {
           echo "invalid numeric upstream metric: ${key}=${value}" >&2
           return 1
         }
         ;;
-      SMALL_END_TOKEN|OVERSIZE_END_TOKEN|GZIP_END_TOKEN|DEFLATE_END_TOKEN)
+      SMALL_END_TOKEN|OVERSIZE_END_TOKEN|DELAYED_END_TOKEN|GZIP_END_TOKEN|DEFLATE_END_TOKEN)
         [[ "${value}" =~ ^[A-Z0-9_]+$ ]] || {
           echo "invalid upstream token metric: ${key}=${value}" >&2
           return 1
@@ -586,6 +613,25 @@ actual_oversize_bytes="$(wc -c < "${RAW_DIR}/oversize.body" | tr -d ' ')"
 }
 grep -q "${OVERSIZE_END_TOKEN}" "${RAW_DIR}/oversize.body" || {
   echo "oversize missing final tail marker (possible truncation)" >&2
+  exit 1
+}
+
+echo "==> Case 2b: oversized fail-open must accept later upstream chunks"
+delayed_line="$(curl -sS -D "${RAW_DIR}/delayed.hdr" \
+  -o "${RAW_DIR}/delayed.body" -H "${ACCEPT_MARKDOWN_HEADER}" \
+  --max-time 240 "http://127.0.0.1:${PORT}/stream/delayed-oversize" \
+  -w "${CURL_METRICS_FMT}")"
+echo "${delayed_line}" | grep -q "${PATTERN_HTTP_200}" || {
+  echo "delayed oversize failed: ${delayed_line}" >&2
+  exit 1
+}
+actual_delayed_bytes="$(wc -c < "${RAW_DIR}/delayed.body" | tr -d ' ')"
+[[ "${actual_delayed_bytes}" == "${DELAYED_LEN}" ]] || {
+  echo "delayed oversize body length mismatch: expected ${DELAYED_LEN}, got ${actual_delayed_bytes}" >&2
+  exit 1
+}
+grep -q "${DELAYED_END_TOKEN}" "${RAW_DIR}/delayed.body" || {
+  echo "delayed oversize missing later tail marker (terminal truncation)" >&2
   exit 1
 }
 

--- a/tools/harness/tests/test_security_gitleaks_scope.sh
+++ b/tools/harness/tests/test_security_gitleaks_scope.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Verify the gitleaks wrapper scans tracked worktree files and excludes ignored state.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/nginx-markdown-gitleaks-test.XXXXXX")"
+ignored_dir="$repo_root/.codeartsdoer/gitleaks-scope-test"
+
+cleanup() {
+    rm -rf "$tmp_dir"
+    rm -rf "$ignored_dir"
+}
+
+trap cleanup EXIT
+mkdir -p "$tmp_dir/bin" "$ignored_dir"
+printf '%s\n' 'ignored-local-secret-marker' > "$ignored_dir/fixture.txt"
+
+cat > "$tmp_dir/bin/gitleaks" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --source)
+            source_dir="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$source_dir" ]]
+[[ -f "$source_dir/AGENTS.md" ]]
+[[ ! -e "$source_dir/.codeartsdoer/gitleaks-scope-test/fixture.txt" ]]
+EOF
+chmod +x "$tmp_dir/bin/gitleaks"
+
+PATH="$tmp_dir/bin:$PATH" bash "$repo_root/tools/security/run_gitleaks_tracked.sh"
+echo "gitleaks tracked-worktree scope test passed"

--- a/tools/harness/tests/test_security_gitleaks_scope.sh
+++ b/tools/harness/tests/test_security_gitleaks_scope.sh
@@ -10,6 +10,7 @@ ignored_dir="$repo_root/.codeartsdoer/gitleaks-scope-test"
 cleanup() {
     rm -rf "$tmp_dir"
     rm -rf "$ignored_dir"
+    return 0
 }
 
 trap cleanup EXIT
@@ -52,6 +53,10 @@ git -C "$deleted_repo" \
     -c user.email='harness@example.invalid' \
     commit -qm 'test fixture'
 rm -f "$deleted_repo/removed.txt"
+if [[ -e "$deleted_repo/removed.txt" ]]; then
+    echo "failed to delete removed.txt fixture" >&2
+    exit 1
+fi
 
 (
     cd "$deleted_repo"

--- a/tools/harness/tests/test_security_gitleaks_scope.sh
+++ b/tools/harness/tests/test_security_gitleaks_scope.sh
@@ -40,4 +40,22 @@ EOF
 chmod +x "$tmp_dir/bin/gitleaks"
 
 PATH="$tmp_dir/bin:$PATH" bash "$repo_root/tools/security/run_gitleaks_tracked.sh"
+
+deleted_repo="$tmp_dir/deleted-repo"
+mkdir -p "$deleted_repo"
+git -C "$deleted_repo" init -q
+printf '%s\n' 'tracked-live-content' > "$deleted_repo/AGENTS.md"
+printf '%s\n' 'tracked-before-delete' > "$deleted_repo/removed.txt"
+git -C "$deleted_repo" add AGENTS.md removed.txt
+git -C "$deleted_repo" \
+    -c user.name='Harness Test' \
+    -c user.email='harness@example.invalid' \
+    commit -qm 'test fixture'
+rm -f "$deleted_repo/removed.txt"
+
+(
+    cd "$deleted_repo"
+    PATH="$tmp_dir/bin:$PATH" \
+        bash "$repo_root/tools/security/run_gitleaks_tracked.sh"
+)
 echo "gitleaks tracked-worktree scope test passed"

--- a/tools/release/gates/validate_release_gates_080.py
+++ b/tools/release/gates/validate_release_gates_080.py
@@ -70,6 +70,7 @@ STREAMING_IMPL_H = (
 )
 
 CARGO_VERSION_GATE = "cargo:version"
+RELEASE_VERSION_GATE = "workflow:release-version"
 
 
 class ValidationResult:
@@ -131,7 +132,7 @@ def check_release_package_workflow_version(result: ValidationResult) -> None:
     """Verify tag package gates expect the active Cargo release version."""
     workflow = read(RELEASE_PACKAGES_WORKFLOW)
     if not workflow:
-        result.fail("workflow:release-version", "release-packages.yml missing")
+        result.fail(RELEASE_VERSION_GATE, "release-packages.yml missing")
         return
     match = re.search(
         r'^\s*RELEASE_GATE_EXPECTED_CARGO_VERSION:\s*["\']([^"\']+)["\']\s*$',
@@ -140,7 +141,7 @@ def check_release_package_workflow_version(result: ValidationResult) -> None:
     )
     if match is None:
         result.fail(
-            "workflow:release-version",
+            RELEASE_VERSION_GATE,
             "release-packages.yml does not set the expected Cargo version",
         )
         return
@@ -148,12 +149,12 @@ def check_release_package_workflow_version(result: ValidationResult) -> None:
     expected = _expected_cargo_version()
     if version == expected:
         result.pass_(
-            "workflow:release-version",
+            RELEASE_VERSION_GATE,
             f"release-packages.yml expects Cargo version {expected}",
         )
     else:
         result.fail(
-            "workflow:release-version",
+            RELEASE_VERSION_GATE,
             f"release-packages.yml expects {version}, active version is {expected}",
         )
 

--- a/tools/security/run_gitleaks_tracked.sh
+++ b/tools/security/run_gitleaks_tracked.sh
@@ -27,6 +27,11 @@ fi
 # excluding ignored adapter state and other non-release files.
 tar --null -T "$file_list" -cf - | tar -xf - -C "$scan_root"
 
+if [[ -z "$(ls -A "$scan_root")" ]]; then
+    echo "ERROR: gitleaks scan root is empty after extraction" >&2
+    exit 1
+fi
+
 cd "$scan_root"
 gitleaks detect \
     --source . \

--- a/tools/security/run_gitleaks_tracked.sh
+++ b/tools/security/run_gitleaks_tracked.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Scan exactly the Git-tracked worktree content for secrets.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+scan_root="$(mktemp -d "${TMPDIR:-/tmp}/nginx-markdown-gitleaks.XXXXXX")"
+file_list="$(mktemp "${TMPDIR:-/tmp}/nginx-markdown-gitleaks-files.XXXXXX")"
+
+cleanup() {
+    rm -rf "$scan_root"
+    rm -f "$file_list"
+}
+
+trap cleanup EXIT
+
+cd "$repo_root"
+git ls-files -z > "$file_list"
+
+if [[ ! -s "$file_list" ]]; then
+    echo "ERROR: no Git-tracked files found for gitleaks scan" >&2
+    exit 1
+fi
+
+# Both bsdtar (macOS) and GNU tar support NUL-delimited -T input.  Reading
+# files from the worktree, rather than HEAD, includes tracked local edits while
+# excluding ignored adapter state and other non-release files.
+tar --null -T "$file_list" -cf - | tar -xf - -C "$scan_root"
+
+cd "$scan_root"
+gitleaks detect \
+    --source . \
+    --no-git \
+    --redact \
+    --config "$repo_root/.gitleaks.toml" \
+    --verbose

--- a/tools/security/run_gitleaks_tracked.sh
+++ b/tools/security/run_gitleaks_tracked.sh
@@ -10,6 +10,7 @@ file_list="$(mktemp "${TMPDIR:-/tmp}/nginx-markdown-gitleaks-files.XXXXXX")"
 cleanup() {
     rm -rf "$scan_root"
     rm -f "$file_list"
+    return 0
 }
 
 trap cleanup EXIT

--- a/tools/security/run_gitleaks_tracked.sh
+++ b/tools/security/run_gitleaks_tracked.sh
@@ -15,7 +15,11 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$repo_root"
-git ls-files -z > "$file_list"
+git ls-files -z | while IFS= read -r -d '' tracked_path; do
+    if [[ -e "$tracked_path" || -L "$tracked_path" ]]; then
+        printf '%s\0' "$tracked_path"
+    fi
+done > "$file_list"
 
 if [[ ! -s "$file_list" ]]; then
     echo "ERROR: no Git-tracked files found for gitleaks scan" >&2


### PR DESCRIPTION
## Description

Close out the 0.8.2 patch line for 0.8.x by synchronizing versioned release documentation, tightening release-gate wiring, and hardening the streaming C/Rust boundary around decompression, parser budgets, header rollback, sanitizer state, and security tooling scope.

This PR is intentionally broader than a docs-only release closeout: later commits add regression fixes discovered while validating the 0.8.2 line, especially around streaming decompression ownership, implied HTML closure propagation, tracked-worktree secret scanning, and release validator consistency.

## Related Issues

None linked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update
- [x] CI/Build change

## Changes Made

- Synchronize 0.8.2 release/version references across Cargo metadata, lockfiles, chart/package metadata, README files, installation/package docs, compatibility docs, changelog, and project status.
- Finalize RFC-0008 as accepted/implemented for 0.8.0 and narrow `markdown_stream_flush_interval` wording to a future release rather than a promised 0.8.x patch.
- Add the canonical `make release-gates-check-08x` entry point, keep the 0.8.0-compatible alias, and pass the active expected Cargo version through strict release-gate validation.
- Strengthen streaming decompression memory ownership and budget handling: heap-owned workspaces use `ngx_alloc`/`ngx_free`, pool-owned output is not freed with `ngx_free`, finish paths no longer leak heap buffers, overflow/budget paths clear outputs consistently, and helper extraction keeps complexity within gate limits.
- Harden C module edge cases around size parsing, header/base-URL validation, buffer sizing, config initialization, filter-chain helpers, and multipart header rollback over multi-part `ngx_list_t` chains.
- Improve Rust converter safety and streaming parity: parser working-set estimation, FFI header-plan reset centralization, code-fence language sanitization and `lang-` prefix parity, metadata traversal timeout coverage, and implied closure propagation before skipped sanitizer decisions with inside-out unwinding.
- Scope gitleaks to Git-tracked worktree content, skip deleted tracked paths, reject empty extracted scan roots, and document the matching harness/security-static rules.
- Add regression coverage across C unit tests, Rust converter tests, streaming decompression ownership/error paths, multipart commit rollback, sanitizer implied closures, metadata traversal timeouts, and tracked secret-scan scope.

## Testing

Observed from GitHub PR checks on 2026-06-23 after the latest pushed head:

- [x] Docs Check
- [x] NGINX C Tests (Unit + Integration-C)
- [x] Rust Quality Gate
- [x] FFI Header Generation Smoke
- [x] Matrix Release Tests
- [x] Runtime Regressions (IMS + Chunked + Large)
- [x] Build + Functional Check completed variants except the still-pending `stable-alpine / amd64` job at refresh time
- [x] CodeQL C/C++ Production Sources
- [x] SonarCloud / SonarCloud Code Analysis
- [x] Rust Security Audit
- [x] actionlint, shellcheck, semgrep, gitleaks, cargo-deny
- [x] Trivy, SPDX SBOM, OpenSSF Scorecard report checks
- [ ] Pending at body refresh time: `pr-fuzz`, `CodeQL (Rust)`, `Coverage Gate (80%)`, and `Build + Functional Check (stable-alpine / amd64)`

## Documentation

- [x] Documentation and code comments updated
- [x] All docs/comments in English
- [x] C code follows NGINX coding style

## Checklist

- [x] Code follows project style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] All tests pass: completed PR checks listed above passed; several long-running checks were still pending when this body was refreshed
- [x] `cargo fmt` and Rust quality gates pass for Rust changes

## Document Updates

| Version | Date | Author | Changes |
|---------|------|--------|---------|
| 0.5.0 | 2026-04-21 | docs-standardization | Added update tracking section |
| 0.8.2 | 2026-06-23 | Codex | Refreshed PR body for 0.8.2 release closeout, streaming safety fixes, security tooling scope, and current validation status |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Version 0.8.2**

* **New Features**
  * Streaming decompression budget enforcement with memory accounting.

* **Bug Fixes**
  * Implied-closure ordering correctness in HTML parsing.
  * Streaming decompression heap leak elimination.
  * Buffer expansion error path hardening.
  * Code-fence language sanitization to prevent injection.
  * FFI header-plan panic safety cleanup.
  * NGINX header validation and buffer sizing improvements.
  * Input validation hardening.

* **Documentation**
  * Updated installation and compatibility guides to reflect 0.8.2.
  * RFC-0008 marked as Accepted/Implemented.

* **Tests**
  * Stream commit multipart header-list rollback regression coverage.
  * Metadata traversal timeout and closure handling tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->