### PR TITLE
cleanup: C module minor — inline filter wrapper + remove dead reason …

### DIFF
--- a/components/nginx-module/src/ngx_http_markdown_reason.c
+++ b/components/nginx-module/src/ngx_http_markdown_reason.c
@@ -66,12 +66,6 @@ static ngx_str_t ngx_http_markdown_reason_skip_accept_reject_str =
 static ngx_str_t ngx_http_markdown_reason_skip_conditional_str =
     ngx_string("SKIPPED_CONDITIONAL");
 
-/* Content-type routing reason codes */
-
-static ngx_str_t ngx_http_markdown_reason_ct_route_default_str =
-    ngx_string("CT_ROUTE_DEFAULT");
-static ngx_str_t ngx_http_markdown_reason_ct_route_configured_str =
-    ngx_string("CT_ROUTE_CONFIGURED");
 
 /* Eligible outcome reason codes */
 
@@ -527,33 +521,4 @@ ngx_http_markdown_reason_eligible_fullbuffer_auto(void)
 #endif /* MARKDOWN_STREAMING_ENABLED */
 
 
-/*
- * Return the CT_ROUTE_DEFAULT reason code.
- *
- * Logged when the content-type allowlist is the default
- * (text/html only) and the request matches.
- *
- * Returns:
- *   Pointer to static ngx_str_t "CT_ROUTE_DEFAULT"
- */
-const ngx_str_t *
-ngx_http_markdown_reason_ct_route_default(void)
-{
-    return &ngx_http_markdown_reason_ct_route_default_str;
-}
 
-
-/*
- * Return the CT_ROUTE_CONFIGURED reason code.
- *
- * Logged when the content-type allowlist was configured
- * via markdown_content_types and the request matches.
- *
- * Returns:
- *   Pointer to static ngx_str_t "CT_ROUTE_CONFIGURED"
- */
-const ngx_str_t *
-ngx_http_markdown_reason_ct_route_configured(void)
-{
-    return &ngx_http_markdown_reason_ct_route_configured_str;
-}

--- a/components/nginx-module/tests/unit/reason_code_test.c
+++ b/components/nginx-module/tests/unit/reason_code_test.c
@@ -421,17 +421,6 @@ main(void)
         "eligible_fullbuffer_auto string should not be empty");
 #endif
 
-    TEST_SUBSECTION("ct_route accessor");
-    TEST_ASSERT(ngx_http_markdown_reason_ct_route_default() != NULL,
-        "ct_route_default should return non-NULL");
-    TEST_ASSERT(ngx_http_markdown_reason_ct_route_default()->len > 0,
-        "ct_route_default string should not be empty");
-
-    TEST_ASSERT(ngx_http_markdown_reason_ct_route_configured() != NULL,
-        "ct_route_configured should return non-NULL");
-    TEST_ASSERT(ngx_http_markdown_reason_ct_route_configured()->len > 0,
-        "ct_route_configured string should not be empty");
-
     printf("\n========================================\n");
     printf("All tests passed!\n");
     printf("========================================\n\n");

--- a/tools/e2e-harness/Cargo.lock
+++ b/tools/e2e-harness/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"


### PR DESCRIPTION
## Summary by Sourcery

Simplify the nginx markdown filter module by inlining use of the core body filter and removing unused content-type routing reason accessors and their tests.

Enhancements:
- Remove the custom ngx_http_markdown_next_body_filter wrapper and call ngx_http_next_body_filter directly in streaming HTML and postcommit paths.
- Drop unused content-type routing reason code accessors and associated declarations from the markdown reason module.

Tests:
- Delete unit tests and test includes related to the removed content-type routing reason accessors and filter chain wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how streaming responses are passed through the response pipeline, including error handling and final output delivery.
  * Removed outdated response reason entries and updated the available streaming status reasons.
* **Tests**
  * Updated unit tests to match the revised streaming behavior and reason reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->