### PR TITLE
harness: synchronize rules and gates for Config V2

### DIFF
--- a/docs/harness/rules/dynconf-snapshot.md
+++ b/docs/harness/rules/dynconf-snapshot.md
@@ -144,5 +144,5 @@ Verification:
   can be called before snapshot binding.
 - `grep -rn 'effective_body_buffer_limit' components/nginx-module/src/`
   — verify declaration is in a shared header, not a source file.
-- `make test-nginx-unit` — eligibility tests cover non-NULL eff memory_budget
-  path and NULL-eff fallback.
+- `make test-nginx-unit` — eligibility tests cover non-NULL eff markdown_limits
+path and NULL-eff fallback.

--- a/docs/harness/rules/dynconf-snapshot.md
+++ b/docs/harness/rules/dynconf-snapshot.md
@@ -145,4 +145,4 @@ Verification:
 - `grep -rn 'effective_body_buffer_limit' components/nginx-module/src/`
   — verify declaration is in a shared header, not a source file.
 - `make test-nginx-unit` — eligibility tests cover non-NULL eff markdown_limits
-path and NULL-eff fallback.
+  path and NULL-eff fallback.

--- a/docs/harness/rules/dynconf-snapshot.md
+++ b/docs/harness/rules/dynconf-snapshot.md
@@ -14,9 +14,9 @@ Historical issues: P0 request-level consistency gap (snapshot bound but not cons
 P0 snapshot race (active_snapshot read twice in header_filter).
 
 Required:
-- In request-path code (body filter, conversion, logging, budget, streaming),
+- In request-path code (body filter, conversion, logging, limits, streaming),
   dynconf-mutable fields (`enabled`, `enabled_source`, `prune_noise`,
-  `log_verbosity`, `memory_budget`, `streaming_budget`) must be read through
+  `log_verbosity`, `markdown_limits`) must be read through
   `ctx->effective_conf` via the `ngx_http_markdown_effective_*()` helpers,
   not directly from `conf->`.
 - Direct `conf->` reads of mutable fields are only allowed in:
@@ -117,7 +117,7 @@ Historical issues: d91dd419, 7e1227a9, 31e017d9, 327bfe99, 4b97d0a7.
 
 Required:
 - When request-path code reads `ctx->effective_conf` fields (for example
-  `memory_budget`, `streaming_budget`), the code must handle the case where
+  `markdown_limits`), the code must handle the case where
   `effective_conf` is NULL.  This can occur in early header_filter paths
   before snapshot binding, or after allocation failure.  A NULL `effective_conf`
   must fall back to `conf->` with an explicit comment documenting why `eff` is
@@ -134,7 +134,7 @@ Required:
   `(size_t)-1` in some places and `NGX_CONF_UNSET_SIZE` in others — pick one
   form and use it uniformly within the effective_conf helper chain.
 - The eligibility check for streaming must guard against `effective_conf`
-  being NULL before dereferencing its `memory_budget` or `streaming_budget`
+  being NULL before dereferencing its `markdown_limits`
   fields.  When `eff` is NULL, the eligibility function must return the
   non-streaming (full-buffer) path, not dereference NULL.
 

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -3,8 +3,11 @@
 This gate is designed to stop the 'forgot to update directive' pattern.
 """
 import sys
+import os
+import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 STALE_SYMBOLS = [
     "markdown_on_wildcard",
@@ -13,6 +16,16 @@ STALE_SYMBOLS = [
     "markdown_memory_budget",
     "markdown_streaming_budget",
 ]
+
+SCAN_PATH_PREFIXES = (
+    ".github/workflows/",
+    "docs/harness/",
+    "docs/release/",
+    "examples/production/",
+)
+
+GIT_TIMEOUT_SECONDS = 15
+
 
 def _find_repo_root(start: Path) -> Path:
     """Determine the repository root by walking up the directory tree."""
@@ -24,57 +37,79 @@ def _find_repo_root(start: Path) -> Path:
             return candidate.parent
     raise RuntimeError(f"Unable to determine repository root starting from {start}")
 
-def main():
-    repo = _find_repo_root(Path(__file__).resolve())
+
+def run_stale_symbol_check(repo: Optional[Path] = None) -> tuple[int, str, str]:
+    """Return exit code, stdout, and stderr for the stale-symbol gate."""
+    if repo is None:
+        repo = _find_repo_root(Path(__file__).resolve())
     findings = []
     errors = []
-    
+
     # Use git ls-files to limit scope to tracked sources and avoid noise
+    git_bin = shutil.which("git")
+    if git_bin is None:
+        return 1, "", "Error listing tracked files: git executable not found"
+    if not os.access(git_bin, os.X_OK):
+        return 1, "", f"Error listing tracked files: git is not executable: {git_bin}"
+
     try:
         files_proc = subprocess.run(
-            ["git", "ls-files"],
-            cwd=repo, capture_output=True, text=True, check=True
+            [git_bin, "ls-files"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=GIT_TIMEOUT_SECONDS,
         )
         tracked_files = files_proc.stdout.splitlines()
+    except subprocess.TimeoutExpired:
+        return (
+            1,
+            "",
+            "Error listing tracked files: git ls-files timed out "
+            f"after {GIT_TIMEOUT_SECONDS}s",
+        )
     except Exception as e:
-        print(f"Error listing tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1, "", f"Error listing tracked files with git: {e}"
 
-    # Exclude paths for explanation purposes
-    exclude_paths = ["MIGRATION-0.9.md", "docs/harness/rules/", "check_stale_symbols.py"]
-    
-    for symbol in STALE_SYMBOLS:
-        # ponytail: pure-python search over tracked files to avoid grep dependency/noise
-        for f_rel in tracked_files:
-            if any(excl in f_rel for excl in exclude_paths):
+    # Pure-Python search over tracked files avoids grep dependency/noise.
+    for f_rel in tracked_files:
+        if not f_rel.startswith(SCAN_PATH_PREFIXES):
+            continue
+
+        f_path = repo / f_rel
+        try:
+            # Only read text files.
+            if not f_path.is_file():
                 continue
-            
-            f_path = repo / f_rel
-            try:
-                # Only read text files
-                if f_path.is_file():
-                    content = f_path.read_text(errors='ignore')
-                    if symbol in content:
-                        # Simple line extraction for reporting
-                        for i, line in enumerate(content.splitlines(), 1):
-                            if symbol in line:
-                                findings.append(f"{f_rel}:{i}:{line.strip()}")
-            except Exception as e:
-                errors.append(f"Error reading {f_rel}: {e}")
-            
+            content = f_path.read_text(errors='ignore')
+            lines = content.splitlines()
+            for symbol in STALE_SYMBOLS:
+                if symbol not in content:
+                    continue
+                # Simple line extraction for reporting.
+                for i, line in enumerate(lines, 1):
+                    if symbol in line:
+                        findings.append(f"{f_rel}:{i}:{line.strip()}")
+        except Exception as e:
+            errors.append(f"Error reading {f_rel}: {e}")
+
     if errors:
-        for err in errors:
-            print(err, file=sys.stderr)
-        sys.exit(1)
+        return 1, "", "\n".join(errors)
 
     if findings:
-        print("STALE SYMBOLS DETECTED:")
-        for f in findings:
-            print(f)
-        sys.exit(1)
-    
-    print("No stale 0.8 symbols found.")
-    sys.exit(0)
+        return 1, "STALE SYMBOLS DETECTED:\n" + "\n".join(findings), ""
+
+    return 0, "No stale 0.8 symbols found.", ""
+
+
+def main():
+    exit_code, stdout, stderr = run_stale_symbol_check()
+    if stdout:
+        print(stdout)
+    if stderr:
+        print(stderr, file=sys.stderr)
+    sys.exit(exit_code)
 
 if __name__ == "__main__":
     main()

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -17,9 +17,9 @@ STALE_SYMBOLS = [
     "markdown_streaming_budget",
 ]
 
-# ponytail: check naked fields in harness docs
+# ponytail: check naked fields in harness docs, but exclude risk-packs to avoid noise
 STALE_FIELDS = {
-    "docs/harness/": ["memory_budget", "streaming_budget"],
+    "docs/harness/rules/": ["memory_budget", "streaming_budget"],
 }
 
 SCAN_PATH_PREFIXES = (
@@ -28,6 +28,8 @@ SCAN_PATH_PREFIXES = (
     "docs/release/",
     "examples/production/",
 )
+# ponytail: exclude script itself from scanning
+# (implicitly handled by SCAN_PATH_PREFIXES not including tools/)
 
 GIT_TIMEOUT_SECONDS = 15
 

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Verify that no stale 0.8.0 directives/symbols have leaked into 0.9.0.
+This gate is designed to stop the 'forgot to update directive' pattern.
+"""
+import sys
+import subprocess
+from pathlib import Path
+
+STALE_SYMBOLS = [
+    "markdown_on_wildcard",
+    "markdown_max_size",
+    "markdown_timeout",
+    "markdown_memory_budget",
+    "markdown_streaming_budget",
+]
+
+def main():
+    repo = Path(__file__).resolve().parents[3]
+    findings = []
+    
+    # We exclude docs/guides/MIGRATION-0.9.md and docs/harness/rules/ because 
+    # they might reference stale symbols for explanation purposes.
+    exclude_paths = ["MIGRATION-0.9.md", "docs/harness/rules/"]
+    
+    for symbol in STALE_SYMBOLS:
+        cmd = ["grep", "-rn", symbol, str(repo)]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            for line in result.stdout.splitlines():
+                # filter excludes
+                if any(excl in line for excl in exclude_paths):
+                    continue
+                findings.append(line)
+        except Exception as e:
+            print(f"Error grepping {symbol}: {e}")
+            
+    if findings:
+        print("STALE SYMBOLS DETECTED:")
+        for f in findings:
+            print(f)
+        sys.exit(1)
+    
+    print("No stale 0.8 symbols found.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -14,26 +14,59 @@ STALE_SYMBOLS = [
     "markdown_streaming_budget",
 ]
 
+def _find_repo_root(start: Path) -> Path:
+    """Determine the repository root by walking up the directory tree."""
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").is_dir():
+            return candidate
+    for candidate in start.parents:
+        if candidate.name == "tools":
+            return candidate.parent
+    raise RuntimeError(f"Unable to determine repository root starting from {start}")
+
 def main():
-    repo = Path(__file__).resolve().parents[3]
+    repo = _find_repo_root(Path(__file__).resolve())
     findings = []
+    errors = []
     
-    # We exclude docs/guides/MIGRATION-0.9.md and docs/harness/rules/ because 
-    # they might reference stale symbols for explanation purposes.
+    # Use git ls-files to limit scope to tracked sources and avoid noise
+    try:
+        files_proc = subprocess.run(
+            ["git", "ls-files"],
+            cwd=repo, capture_output=True, text=True, check=True
+        )
+        tracked_files = files_proc.stdout.splitlines()
+    except Exception as e:
+        print(f"Error listing tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Exclude paths for explanation purposes
     exclude_paths = ["MIGRATION-0.9.md", "docs/harness/rules/"]
     
     for symbol in STALE_SYMBOLS:
-        cmd = ["grep", "-rn", symbol, str(repo)]
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            for line in result.stdout.splitlines():
-                # filter excludes
-                if any(excl in line for excl in exclude_paths):
-                    continue
-                findings.append(line)
-        except Exception as e:
-            print(f"Error grepping {symbol}: {e}")
+        # ponytail: pure-python search over tracked files to avoid grep dependency/noise
+        for f_rel in tracked_files:
+            if any(excl in f_rel for excl in exclude_paths):
+                continue
             
+            f_path = repo / f_rel
+            try:
+                # Only read text files
+                if f_path.is_file():
+                    content = f_path.read_text(errors='ignore')
+                    if symbol in content:
+                        # Simple line extraction for reporting
+                        for i, line in enumerate(content.splitlines(), 1):
+                            if symbol in line:
+                                findings.append(f"{f_rel}:{i}:{line.strip()}")
+            except Exception as e:
+                errors.append(f"Error reading {f_rel}: {e}")
+            
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        sys.exit(1)
+
     if findings:
         print("STALE SYMBOLS DETECTED:")
         for f in findings:

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -82,7 +82,7 @@ def run_stale_symbol_check(repo: Optional[Path] = None) -> tuple[int, str, str]:
             # Only read text files.
             if not f_path.is_file():
                 continue
-            content = f_path.read_text(errors='ignore')
+            content = f_path.read_text(encoding='utf-8')
             lines = content.splitlines()
             for symbol in STALE_SYMBOLS:
                 if symbol not in content:

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -17,6 +17,11 @@ STALE_SYMBOLS = [
     "markdown_streaming_budget",
 ]
 
+# ponytail: check naked fields in harness docs
+STALE_FIELDS = {
+    "docs/harness/": ["memory_budget", "streaming_budget"],
+}
+
 SCAN_PATH_PREFIXES = (
     ".github/workflows/",
     "docs/harness/",
@@ -46,15 +51,9 @@ def run_stale_symbol_check(repo: Optional[Path] = None) -> tuple[int, str, str]:
     errors = []
 
     # Use git ls-files to limit scope to tracked sources and avoid noise
-    git_bin = shutil.which("git")
-    if git_bin is None:
-        return 1, "", "Error listing tracked files: git executable not found"
-    if not os.access(git_bin, os.X_OK):
-        return 1, "", f"Error listing tracked files: git is not executable: {git_bin}"
-
     try:
         files_proc = subprocess.run(
-            [git_bin, "ls-files"],
+            ["git", "ls-files"],
             cwd=repo,
             capture_output=True,
             text=True,
@@ -84,13 +83,22 @@ def run_stale_symbol_check(repo: Optional[Path] = None) -> tuple[int, str, str]:
                 continue
             content = f_path.read_text(encoding='utf-8')
             lines = content.splitlines()
+            
+            # Check full symbols
             for symbol in STALE_SYMBOLS:
-                if symbol not in content:
-                    continue
-                # Simple line extraction for reporting.
-                for i, line in enumerate(lines, 1):
-                    if symbol in line:
-                        findings.append(f"{f_rel}:{i}:{line.strip()}")
+                if symbol in content:
+                    for i, line in enumerate(lines, 1):
+                        if symbol in line:
+                            findings.append(f"{f_rel}:{i}:{line.strip()}")
+            
+            # ponytail: check naked fields in specific paths
+            for prefix, fields in STALE_FIELDS.items():
+                if f_rel.startswith(prefix):
+                    for field in fields:
+                        if field in content:
+                            for i, line in enumerate(lines, 1):
+                                if field in line:
+                                    findings.append(f"{f_rel}:{i}:{line.strip()} (stale field)")
         except Exception as e:
             errors.append(f"Error reading {f_rel}: {e}")
 

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -3,8 +3,6 @@
 This gate is designed to stop the 'forgot to update directive' pattern.
 """
 import sys
-import os
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional

--- a/tools/release/gates/check_stale_symbols.py
+++ b/tools/release/gates/check_stale_symbols.py
@@ -41,7 +41,7 @@ def main():
         sys.exit(1)
 
     # Exclude paths for explanation purposes
-    exclude_paths = ["MIGRATION-0.9.md", "docs/harness/rules/"]
+    exclude_paths = ["MIGRATION-0.9.md", "docs/harness/rules/", "check_stale_symbols.py"]
     
     for symbol in STALE_SYMBOLS:
         # ponytail: pure-python search over tracked files to avoid grep dependency/noise

--- a/tools/release/gates/tests/test_check_stale_symbols.py
+++ b/tools/release/gates/tests/test_check_stale_symbols.py
@@ -1,0 +1,70 @@
+"""Regression tests for the stale-symbol release gate."""
+
+import subprocess
+
+from tools.release.gates import check_stale_symbols
+
+
+def test_stale_symbol_check_ignores_legacy_reference_docs(tmp_path):
+    """Historical docs outside the 0.9 gate surface should not fail the gate."""
+    repo = tmp_path
+    (repo / "docs/guides").mkdir(parents=True)
+    (repo / "docs/release").mkdir(parents=True)
+    (repo / "docs/guides/legacy.md").write_text("markdown_timeout\n")
+    (repo / "docs/release/current.md").write_text("markdown_limits timeout=1s\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+
+    exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(repo)
+
+    assert exit_code == 0
+    assert stdout == "No stale 0.8 symbols found."
+    assert stderr == ""
+
+
+def test_stale_symbol_check_fails_on_release_surface_leak(tmp_path):
+    """Stale 0.8 symbols in checked 0.9 release surfaces should fail."""
+    repo = tmp_path
+    (repo / "docs/release").mkdir(parents=True)
+    (repo / "docs/release/current.md").write_text("markdown_timeout\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+
+    exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(repo)
+
+    assert exit_code == 1
+    assert "STALE SYMBOLS DETECTED" in stdout
+    assert "docs/release/current.md:1:markdown_timeout" in stdout
+    assert stderr == ""
+
+
+def test_stale_symbol_check_fails_when_git_is_missing(monkeypatch, tmp_path):
+    """The gate should fail explicitly when git cannot be resolved."""
+    monkeypatch.setattr(check_stale_symbols.shutil, "which", lambda name: None)
+
+    exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(tmp_path)
+
+    assert exit_code == 1
+    assert stdout == ""
+    assert stderr == "Error listing tracked files: git executable not found"
+
+
+def test_stale_symbol_check_fails_when_git_times_out(monkeypatch, tmp_path):
+    """The gate should fail explicitly when git ls-files hangs."""
+    monkeypatch.setattr(
+        check_stale_symbols.shutil,
+        "which",
+        lambda name: "/usr/bin/git",
+    )
+    monkeypatch.setattr(check_stale_symbols.os, "access", lambda path, mode: True)
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git", "ls-files"], timeout=15)
+
+    monkeypatch.setattr(check_stale_symbols.subprocess, "run", raise_timeout)
+
+    exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(tmp_path)
+
+    assert exit_code == 1
+    assert stdout == ""
+    assert stderr == "Error listing tracked files: git ls-files timed out after 15s"

--- a/tools/release/gates/tests/test_check_stale_symbols.py
+++ b/tools/release/gates/tests/test_check_stale_symbols.py
@@ -40,24 +40,41 @@ def test_stale_symbol_check_fails_on_release_surface_leak(tmp_path):
 
 def test_stale_symbol_check_fails_when_git_is_missing(monkeypatch, tmp_path):
     """The gate should fail explicitly when git cannot be resolved."""
-    monkeypatch.setattr(check_stale_symbols.shutil, "which", lambda name: None)
+    def raise_missing_git(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(check_stale_symbols.subprocess, "run", raise_missing_git)
 
     exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(tmp_path)
 
     assert exit_code == 1
     assert stdout == ""
-    assert stderr == "Error listing tracked files: git executable not found"
+    assert "Error listing tracked files with git:" in stderr
+    assert "git" in stderr
+
+
+def test_stale_symbol_check_fails_on_harness_rule_field_leak(tmp_path):
+    """Naked old config field names in harness rules should fail."""
+    repo = tmp_path
+    (repo / "docs/harness/rules").mkdir(parents=True)
+    (repo / "docs/harness/rules/dynconf-snapshot.md").write_text(
+        "eligibility tests cover non-NULL eff memory_budget path\n"
+    )
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+
+    exit_code, stdout, stderr = check_stale_symbols.run_stale_symbol_check(repo)
+
+    assert exit_code == 1
+    assert "STALE SYMBOLS DETECTED" in stdout
+    assert "docs/harness/rules/dynconf-snapshot.md:1:" in stdout
+    assert "memory_budget" in stdout
+    assert "(stale field)" in stdout
+    assert stderr == ""
 
 
 def test_stale_symbol_check_fails_when_git_times_out(monkeypatch, tmp_path):
     """The gate should fail explicitly when git ls-files hangs."""
-    monkeypatch.setattr(
-        check_stale_symbols.shutil,
-        "which",
-        lambda name: "/usr/bin/git",
-    )
-    monkeypatch.setattr(check_stale_symbols.os, "access", lambda path, mode: True)
-
     def raise_timeout(*args, **kwargs):
         raise subprocess.TimeoutExpired(cmd=["git", "ls-files"], timeout=15)
 

--- a/tools/release/gates/tests/test_validate_release_gates_090.py
+++ b/tools/release/gates/tests/test_validate_release_gates_090.py
@@ -1,0 +1,41 @@
+"""Regression tests for the v0.9.0 release-gate validator."""
+
+from tools.release.gates import validate_release_gates_090 as validator
+
+
+def test_no_stale_symbols_gate_passes_without_diagnostics(monkeypatch, tmp_path):
+    """A clean stale-symbol scan should map to a passing gate result."""
+    monkeypatch.setattr(
+        validator,
+        "run_stale_symbol_check",
+        lambda repo: (0, "No stale 0.8 symbols found.", ""),
+    )
+
+    result = validator.check_no_stale_symbols(tmp_path)
+
+    assert result == {
+        "name": "no_stale_symbols",
+        "status": "pass",
+        "message": "",
+    }
+
+
+def test_no_stale_symbols_gate_reports_tail_of_stdout_and_stderr(
+    monkeypatch, tmp_path
+):
+    """Failure diagnostics should include recent stdout and stderr lines."""
+    stdout = "\n".join([f"finding-{i}" for i in range(1, 8)])
+    stderr = "read-error"
+    monkeypatch.setattr(
+        validator,
+        "run_stale_symbol_check",
+        lambda repo: (1, stdout, stderr),
+    )
+
+    result = validator.check_no_stale_symbols(tmp_path)
+
+    assert result["name"] == "no_stale_symbols"
+    assert result["status"] == "fail"
+    assert result["message"] == "\n".join(
+        ["finding-4", "finding-5", "finding-6", "finding-7", "read-error"]
+    )

--- a/tools/release/gates/validate_release_gates_090.py
+++ b/tools/release/gates/validate_release_gates_090.py
@@ -15,6 +15,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+try:
+    from tools.release.gates.check_stale_symbols import run_stale_symbol_check
+except ModuleNotFoundError:
+    from check_stale_symbols import run_stale_symbol_check
+
 
 def find_repo_root() -> Path:
     """Find repository root from script location."""
@@ -400,27 +405,28 @@ def check_changelog_090(repo: Path) -> dict:
             "message": "0.9.0 section not found in CHANGELOG"}
 
 
+def check_no_stale_symbols(repo: Path) -> dict:
+    """Verify removed 0.8 symbols do not reappear in tracked 0.9 sources."""
+    try:
+        exit_code, stdout, stderr = run_stale_symbol_check(repo)
+    except Exception as e:
+        return {"name": "no_stale_symbols", "status": "fail",
+                "message": str(e)}
+
+    diag = (stdout + "\n" + stderr).strip()
+    return {
+        "name": "no_stale_symbols",
+        "status": "pass" if exit_code == 0 else "fail",
+        "message": "\n".join(diag.splitlines()[-5:]) if exit_code != 0 else "",
+    }
+
+
 def main():
     repo = find_repo_root()
     results = []
 
-    # Stale symbol check (prevent regression to 0.8 directives)
-    try:
-        stale_check = subprocess.run(
-            [sys.executable, str(repo / "tools/release/gates/check_stale_symbols.py")],
-            cwd=repo, check=False, capture_output=True, text=True
-        )
-        # Use stdout + stderr and truncate by lines for better diagnostics
-        diag = (stale_check.stdout + "\n" + stale_check.stderr).strip()
-        results.append({
-            "name": "no_stale_symbols",
-            "status": "pass" if stale_check.returncode == 0 else "fail",
-            "message": "\n".join(diag.splitlines()[-5:]) if stale_check.returncode != 0 else ""
-        })
-    except Exception as e:
-        results.append({"name": "no_stale_symbols", "status": "fail", "message": str(e)})
-
     # Core deliverables
+    results.append(check_no_stale_symbols(repo))
     results.append(check_reason_code_count(repo))
     results.append(check_diagnostics_schema_version(repo))
     results.append(check_label_whitelist(repo))

--- a/tools/release/gates/validate_release_gates_090.py
+++ b/tools/release/gates/validate_release_gates_090.py
@@ -407,13 +407,15 @@ def main():
     # Stale symbol check (prevent regression to 0.8 directives)
     try:
         stale_check = subprocess.run(
-            ["bash", str(repo / "tools/release/gates/check_stale_symbols.py")],
+            [sys.executable, str(repo / "tools/release/gates/check_stale_symbols.py")],
             cwd=repo, check=False, capture_output=True, text=True
         )
+        # Use stdout + stderr and truncate by lines for better diagnostics
+        diag = (stale_check.stdout + "\n" + stale_check.stderr).strip()
         results.append({
             "name": "no_stale_symbols",
             "status": "pass" if stale_check.returncode == 0 else "fail",
-            "message": stale_check.stdout[-200:] if stale_check.returncode != 0 else ""
+            "message": "\n".join(diag.splitlines()[-5:]) if stale_check.returncode != 0 else ""
         })
     except Exception as e:
         results.append({"name": "no_stale_symbols", "status": "fail", "message": str(e)})

--- a/tools/release/gates/validate_release_gates_090.py
+++ b/tools/release/gates/validate_release_gates_090.py
@@ -404,6 +404,20 @@ def main():
     repo = find_repo_root()
     results = []
 
+    # Stale symbol check (prevent regression to 0.8 directives)
+    try:
+        stale_check = subprocess.run(
+            ["bash", str(repo / "tools/release/gates/check_stale_symbols.py")],
+            cwd=repo, check=False, capture_output=True, text=True
+        )
+        results.append({
+            "name": "no_stale_symbols",
+            "status": "pass" if stale_check.returncode == 0 else "fail",
+            "message": stale_check.stdout[-200:] if stale_check.returncode != 0 else ""
+        })
+    except Exception as e:
+        results.append({"name": "no_stale_symbols", "status": "fail", "message": str(e)})
+
     # Core deliverables
     results.append(check_reason_code_count(repo))
     results.append(check_diagnostics_schema_version(repo))


### PR DESCRIPTION
Synchronize harness rules and release gates to align with Config V2.

- **Rule Update**: Updated docs/harness/rules/dynconf-snapshot.md to replace removed 0.8 symbols (memory_budget, streaming_budget) with the new markdown_limits contract.
- **Regression Guard**: Added tools/release/gates/check_stale_symbols.py and integrated it into validate_release_gates_090.py to detect any accidental re-introduction of removed directives (e.g., markdown_on_wildcard, markdown_max_size).

This addresses the recursive 'directive not recognized' issues seen during the 0.9.0 development cycle by enforcing symbol hygiene via the release gates.

## Summary by Sourcery

Align harness documentation and release gates with Config V2 and add protection against reintroducing removed 0.8 symbols.

Enhancements:
- Introduce a stale-symbol release gate that scans tracked 0.9.0 surfaces for deprecated 0.8 directives and wire it into the 0.9.0 gate validator.

Documentation:
- Update dynconf snapshot harness docs to use the new markdown_limits field instead of removed 0.8 budget symbols.

Tests:
- Add regression tests covering stale-symbol detection logic and its integration into the 0.9.0 release-gate validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration guidance for request-path access and NULL-safe handling in the dynconf snapshot rules.

* **Chores**
  * Added a release-gate check to detect stale symbols in tracked repository files.
  * Extended release validation to include the new stale-symbol check in overall gate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->