### PR TITLE
fix(security): resolve CodeQL code-scanning alerts (57 findings)

### DIFF
--- a/packaging/scripts/generate-release-manifest.py
+++ b/packaging/scripts/generate-release-manifest.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
+
 import re
 import subprocess
 import sys

--- a/packaging/scripts/test_release_manifest.py
+++ b/packaging/scripts/test_release_manifest.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
+
 import subprocess
 import sys
 import tempfile
@@ -362,7 +362,7 @@ class TestValidateManifest(unittest.TestCase):
         del manifest["packages"]
         self.manifest_path.write_text(json.dumps(manifest, indent=2))
         errors = self._validate()
-        self.assertTrue(len(errors) > 0)
+        self.assertGreater(len(errors), 0)
 
     def test_version_mismatch(self):
         self._make_valid_manifest()
@@ -374,7 +374,7 @@ class TestValidateManifest(unittest.TestCase):
         fname = "nginx-module-markdown-for-agents_0.8.3_nginx-1.28.0_amd64.deb"
         path = self.artifact_dir / fname
         path.write_bytes(b"real-content")
-        manifest = self._make_valid_manifest([
+        self._make_valid_manifest([
             {
                 "filename": fname,
                 "format": "deb",

--- a/skills/nginx-markdown-harness-maintenance/scripts/test_harness_route.py
+++ b/skills/nginx-markdown-harness-maintenance/scripts/test_harness_route.py
@@ -10,7 +10,6 @@ import sys
 
 import pytest
 
-import harness_route
 from harness_route import (
     _find_repo_root,
     _git_diff_files,
@@ -19,9 +18,11 @@ from harness_route import (
     _match_path,
     _normalize_files,
     _pack_matches,
+    _parse_args,
     _parse_status_output,
     _validate_git_ref,
     _verification_plan,
+    subprocess as _hr_subprocess,
 )
 
 
@@ -256,7 +257,7 @@ def test_git_diff_files_uses_delete_filter(monkeypatch: pytest.MonkeyPatch) -> N
         captured["cmd"] = cmd
         return "docs/harness/README.md\n"
 
-    monkeypatch.setattr(harness_route.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(_hr_subprocess, "check_output", fake_check_output)
     files = _git_diff_files(None)
     assert files == ["docs/harness/README.md"]
     assert "--diff-filter=d" in captured["cmd"]
@@ -269,7 +270,7 @@ def test_parse_args_validates_base_at_cli_boundary(monkeypatch: pytest.MonkeyPat
         "argv",
         ["harness_route.py", "--from-git", "--base", "HEAD~3"],
     )
-    args = harness_route._parse_args()
+    args = _parse_args()
     assert args.base == "HEAD~3"
     assert args.from_git is True
 
@@ -282,7 +283,7 @@ def test_parse_args_rejects_invalid_base_before_main(monkeypatch: pytest.MonkeyP
         ["harness_route.py", "--from-git", "--base", "main; rm -rf /"],
     )
     with pytest.raises(SystemExit):
-        harness_route._parse_args()
+        _parse_args()
 
 
 def test_git_status_files_expands_directory_with_nested_files(
@@ -302,7 +303,7 @@ def test_git_status_files_expands_directory_with_nested_files(
         """Return True only for the test directory path."""
         return path.as_posix().endswith("/some_dir")
 
-    monkeypatch.setattr(harness_route.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(_hr_subprocess, "check_output", fake_check_output)
     monkeypatch.setattr(Path, "is_dir", fake_is_dir)
 
     assert _git_status_files() == [
@@ -327,7 +328,7 @@ def test_git_status_files_directory_without_nested_files_falls_back_to_dir(
         """Return True only for the test directory path."""
         return path.as_posix().endswith("/some_dir")
 
-    monkeypatch.setattr(harness_route.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(_hr_subprocess, "check_output", fake_check_output)
     monkeypatch.setattr(Path, "is_dir", fake_is_dir)
 
     assert _git_status_files() == ["some_dir"]
@@ -342,14 +343,14 @@ def test_git_status_files_directory_ls_files_error_falls_back_to_dir(
         if cmd[:2] == ["git", "status"]:
             return "?? some_dir\n"
         if cmd[:2] == ["git", "ls-files"]:
-            raise harness_route.subprocess.CalledProcessError(1, cmd, output="boom")
+            raise _hr_subprocess.CalledProcessError(1, cmd, output="boom")
         raise AssertionError(f"unexpected command: {cmd}")
 
     def fake_is_dir(path: Path) -> bool:
         """Return True only for the test directory path."""
         return path.as_posix().endswith("/some_dir")
 
-    monkeypatch.setattr(harness_route.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(_hr_subprocess, "check_output", fake_check_output)
     monkeypatch.setattr(Path, "is_dir", fake_is_dir)
 
     assert _git_status_files() == ["some_dir"]
@@ -520,7 +521,7 @@ def test_git_diff_files_accepts_tilde_ref(monkeypatch: pytest.MonkeyPatch) -> No
         captured["cmd"] = cmd
         return "some/file.py\n"
 
-    monkeypatch.setattr(harness_route.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(_hr_subprocess, "check_output", fake_check_output)
     files = _git_diff_files("HEAD~3")
     assert files == ["some/file.py"]
     assert "HEAD~3...HEAD" in captured["cmd"]

--- a/tools/ci/test_check_third_party_notices.py
+++ b/tools/ci/test_check_third_party_notices.py
@@ -12,7 +12,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from tools.ci import check_third_party_notices as checker
+import tools.ci.check_third_party_notices as checker
 
 
 class ThirdPartyNoticesTests(unittest.TestCase):

--- a/tools/complexity/_compare_baseline.py
+++ b/tools/complexity/_compare_baseline.py
@@ -309,7 +309,7 @@ def main() -> int:
     )
 
     if args.output == "-":
-        sys.stdout.write(report)
+        sys.stdout.write(report)  # codeql[py/clear-text-logging-sensitive-data: ignore] — report is a complexity comparison summary, not secrets
         sys.stdout.write("\n")
     else:
         out_path = validate_write_path_within_root(

--- a/tools/complexity/_compare_baseline.py
+++ b/tools/complexity/_compare_baseline.py
@@ -318,6 +318,8 @@ def main() -> int:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fh:
             fh.write(report)
+        sys.stdout.write(report)  # codeql[py/clear-text-logging-sensitive-data: ignore] — report is a complexity comparison summary, not secrets
+        sys.stdout.write("\n")
 
     if new_errors:
         print(f"\nFAIL: {len(new_errors)} new violation(s) not in baseline", file=sys.stderr)

--- a/tools/complexity/_compare_baseline.py
+++ b/tools/complexity/_compare_baseline.py
@@ -308,16 +308,16 @@ def main() -> int:
         new_errors, worsened, ok_msgs,
     )
 
-    if args.output != "-":
+    if args.output == "-":
+        sys.stdout.write(report)
+        sys.stdout.write("\n")
+    else:
         out_path = validate_write_path_within_root(
             args.output, REPO_ROOT, purpose="baseline report",
         )
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fh:
             fh.write(report)
-
-    sys.stdout.write(report)
-    sys.stdout.write("\n")
 
     if new_errors:
         print(f"\nFAIL: {len(new_errors)} new violation(s) not in baseline", file=sys.stderr)

--- a/tools/complexity/_compare_baseline.py
+++ b/tools/complexity/_compare_baseline.py
@@ -308,16 +308,16 @@ def main() -> int:
         new_errors, worsened, ok_msgs,
     )
 
-    if args.output == "-":
-        print(report)
-    else:
+    if args.output != "-":
         out_path = validate_write_path_within_root(
             args.output, REPO_ROOT, purpose="baseline report",
         )
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fh:
             fh.write(report)
-        print(report)
+
+    sys.stdout.write(report)
+    sys.stdout.write("\n")
 
     if new_errors:
         print(f"\nFAIL: {len(new_errors)} new violation(s) not in baseline", file=sys.stderr)

--- a/tools/complexity/tests/test_compare_baseline.py
+++ b/tools/complexity/tests/test_compare_baseline.py
@@ -1,0 +1,31 @@
+"""Regression tests for the complexity baseline CLI."""
+
+import json
+import sys
+
+import tools.complexity._compare_baseline as compare_baseline
+
+
+def test_output_file_mode_also_prints_report_to_stdout(tmp_path, monkeypatch, capsys):
+    """--output writes the report and preserves the historical stdout output."""
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "baseline-report.txt"
+    baseline_path.write_text(json.dumps({"entries": []}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(compare_baseline, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "_compare_baseline.py",
+            "--baseline",
+            str(baseline_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert compare_baseline.main() == 0
+
+    report = output_path.read_text(encoding="utf-8")
+    assert report
+    assert capsys.readouterr().out == report + "\n"

--- a/tools/docs/tests/test_check_packaging_docs.py
+++ b/tools/docs/tests/test_check_packaging_docs.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 # Allow imports from tools/docs/
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -23,8 +22,7 @@ from check_packaging_docs import (
     check_compatibility_matrix,
     check_content_negotiation_sop,
     check_no_hardcoded_release_tags,
-    check_required_sections,
-    check_shortest_success_path,
+
     check_tier_labels,
 )
 

--- a/tools/e2e/fixtures/tls_backend_server.py
+++ b/tools/e2e/fixtures/tls_backend_server.py
@@ -125,7 +125,7 @@ def main() -> None:
     server = ThreadingTLSServer(("127.0.0.1", args.port), tls_ctx)
     try:
         server.serve_forever()
-    except KeyboardInterrupt:
+    except KeyboardInterrupt:  # noqa: BLE001
         pass
     finally:
         server.server_close()

--- a/tools/harness/detect_cwe22_paths.py
+++ b/tools/harness/detect_cwe22_paths.py
@@ -108,10 +108,6 @@ REPO_ROOT_DERIVED_RE = re.compile(
 )
 
 
-_TEMPFILE_VAR_RE = re.compile(
-    r"tempfile\b",
-)
-
 
 # Variables that are file descriptors (int), not paths
 FD_VAR_RE = re.compile(

--- a/tools/harness/detect_forward_decl_order.py
+++ b/tools/harness/detect_forward_decl_order.py
@@ -314,8 +314,9 @@ def main() -> int:
             scan_dir = REPO_ROOT / scan_dir
         try:
             scan_dir = scan_dir.resolve()
-        except OSError:  # noqa: BLE001
-            pass
+        except OSError:
+            print(f"ERROR: cannot resolve {scan_dir}: path canonicalization failed", file=sys.stderr)
+            return 1
 
     if not scan_dir.is_dir():
         print(f"ERROR: {scan_dir} is not a directory", file=sys.stderr)

--- a/tools/harness/detect_forward_decl_order.py
+++ b/tools/harness/detect_forward_decl_order.py
@@ -314,7 +314,7 @@ def main() -> int:
             scan_dir = REPO_ROOT / scan_dir
         try:
             scan_dir = scan_dir.resolve()
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
 
     if not scan_dir.is_dir():

--- a/tools/harness/detect_html_sanitizer_invariants.py
+++ b/tools/harness/detect_html_sanitizer_invariants.py
@@ -32,7 +32,7 @@ Exit codes:
   1 — one or more violations detected
 """
 
-import os
+
 import re
 import sys
 from pathlib import Path

--- a/tools/harness/detect_test_assertion_coverage.py
+++ b/tools/harness/detect_test_assertion_coverage.py
@@ -101,6 +101,7 @@ def _find_test_function_end(content: str, brace_start: int) -> int | None:
     brace_count = 0
     in_string = False
     raw_string_hashes = -1
+    count_brace = True
 
     i = brace_start
     while i < len(content):

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -11,14 +11,12 @@ from pathlib import Path
 
 try:
     from tools.harness.constants import (  # noqa: F401
-        FAIL,
         PASS,
         SKIP_NOT_PRESENT,
         WARN_NEEDS_AUTHOR_REVIEW,
     )
 except ModuleNotFoundError:
     from constants import (  # type: ignore[no-redef]  # noqa: F401
-        FAIL,
         PASS,
         SKIP_NOT_PRESENT,
         WARN_NEEDS_AUTHOR_REVIEW,

--- a/tools/harness/resolve_spec.py
+++ b/tools/harness/resolve_spec.py
@@ -10,7 +10,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 try:
-    from tools.harness.constants import (
+    from tools.harness.constants import (  # noqa: F401
         FAIL,
         PASS,
         SKIP_NOT_PRESENT,

--- a/tools/harness/tests/test_detect_duplicate_code.py
+++ b/tools/harness/tests/test_detect_duplicate_code.py
@@ -100,7 +100,7 @@ def test_signature_duplicate_is_ignored(det, tmp_path):
     ngx_chain_t *in,
     ngx_int_t rc;
     """
-    src = f"""
+    _src = f"""
     static ngx_int_t foo({sig})
     static ngx_int_t bar({sig})
     """

--- a/tools/harness/tests/test_detect_duplicate_code.py
+++ b/tools/harness/tests/test_detect_duplicate_code.py
@@ -100,10 +100,7 @@ def test_signature_duplicate_is_ignored(det, tmp_path):
     ngx_chain_t *in,
     ngx_int_t rc;
     """
-    _src = f"""
-    static ngx_int_t foo({sig})
-    static ngx_int_t bar({sig})
-    """
+
     # The 5-line non-adjacent detector needs 5 matching lines; pad the sig.
     block = """\
     ngx_http_request_t *r,

--- a/tools/harness/tests/test_state_store.py
+++ b/tools/harness/tests/test_state_store.py
@@ -7,7 +7,6 @@ non-dict entries.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from tools.harness import state_store
 

--- a/tools/lib/path_validation.py
+++ b/tools/lib/path_validation.py
@@ -16,6 +16,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -60,7 +61,7 @@ def validate_read_path(
             f"(purpose: {purpose})"
         )
 
-    resolved = Path(raw).resolve()
+    resolved = Path(os.path.normpath(raw)).resolve()
 
     if must_exist and not resolved.exists():
         raise FileNotFoundError(

--- a/tools/lib/path_validation.py
+++ b/tools/lib/path_validation.py
@@ -61,7 +61,7 @@ def validate_read_path(
             f"(purpose: {purpose})"
         )
 
-    resolved = Path(os.path.normpath(raw)).resolve()
+    resolved = Path(os.path.realpath(raw))
 
     if must_exist and not resolved.exists():
         raise FileNotFoundError(

--- a/tools/perf/evidence_pack_generator.py
+++ b/tools/perf/evidence_pack_generator.py
@@ -51,8 +51,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
-import os
+
 import subprocess
 import sys
 from datetime import datetime, timezone

--- a/tools/perf/format_pr_summary.py
+++ b/tools/perf/format_pr_summary.py
@@ -12,7 +12,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
+
 import sys
 from pathlib import Path
 from typing import Any, Optional

--- a/tools/perf/report_utils.py
+++ b/tools/perf/report_utils.py
@@ -8,7 +8,7 @@ import copy
 import json
 import os
 import platform as python_platform
-import re
+
 import statistics
 import sys
 from pathlib import Path

--- a/tools/perf/run_corpus_benchmark.py
+++ b/tools/perf/run_corpus_benchmark.py
@@ -36,13 +36,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
+
 import subprocess
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from statistics import median
+
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from lib.path_validation import validate_read_path, validate_write_path_within_root
@@ -52,11 +52,7 @@ from lib.path_validation import validate_read_path, validate_write_path_within_r
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from report_schema import (  # noqa: E402
-    VALID_CONVERSION_RESULTS,
-    VALID_PAGE_TYPES,
-    validate_report,
-)
+from report_schema import validate_report  # noqa: E402
 from report_utils import detect_platform, write_json  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tools/perf/tests/test_benchmark_harness.py
+++ b/tools/perf/tests/test_benchmark_harness.py
@@ -341,6 +341,112 @@ def test_upstream_mock_splits_chunked_bodies():
     assert b"".join(chunks) == body
 
 
+@pytest.mark.parametrize("component", ["", ".", "..", "a/b", r"a\\b", "nul\x00name"])
+def test_upstream_mock_rejects_unsafe_path_components(component):
+    """Path validation rejects traversal, separators, and NUL bytes."""
+    with pytest.raises(ValueError):
+        MockUpstreamHandler._validate_path_component(component)
+
+
+def test_upstream_mock_preserves_nested_and_double_dot_filenames(tmp_path, monkeypatch):
+    """Valid nested paths and filenames containing ``..`` resolve unchanged."""
+    corpus_dir = tmp_path / "corpus"
+    nested_dir = corpus_dir / "subdir"
+    nested_dir.mkdir(parents=True)
+    double_dot_file = corpus_dir / "a..b.html"
+    nested_file = nested_dir / "file.json"
+    double_dot_file.write_bytes(b"double-dot")
+    nested_file.write_bytes(b"nested")
+    monkeypatch.setenv("CORPUS_DIR", str(corpus_dir))
+    handler = object.__new__(MockUpstreamHandler)
+
+    assert handler._resolve_and_verify_path("a..b.html") == double_dot_file.resolve()
+    assert handler._resolve_and_verify_path("subdir/file.json") == nested_file.resolve()
+
+
+def test_upstream_mock_rejects_symlink_escape(tmp_path, monkeypatch):
+    """A corpus symlink cannot expose a file outside the corpus root."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_bytes(b"outside")
+    escape_link = corpus_dir / "escape.txt"
+    try:
+        escape_link.symlink_to(outside_file)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable on this platform")
+
+    monkeypatch.setenv("CORPUS_DIR", str(corpus_dir))
+    handler = object.__new__(MockUpstreamHandler)
+
+    assert handler._resolve_and_verify_path("escape.txt") is None
+
+
+def _mock_identity_handler(path: str, writer: object) -> MockUpstreamHandler:
+    """Build a response handler with the HTTP transport methods stubbed."""
+    handler = object.__new__(MockUpstreamHandler)
+    handler.path = f"/{path}"
+    handler.wfile = writer
+    handler.send_response = lambda _status: None
+    handler.send_header = lambda *_args: None
+    handler.end_headers = lambda: None
+    handler.send_error = lambda *_args: None
+    return handler
+
+
+def test_upstream_mock_returns_corpus_bytes_without_sanitizing_nul(
+    tmp_path, monkeypatch
+):
+    """Corpus response bodies retain embedded NUL bytes byte-for-byte."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    body = b"before\x00after\x00"
+    (corpus_dir / "raw.bin").write_bytes(body)
+    monkeypatch.setenv("CORPUS_DIR", str(corpus_dir))
+
+    handler = _mock_identity_handler("raw.bin", io.BytesIO())
+    handler.do_GET()
+
+    assert handler.wfile.getvalue() == body
+
+
+class _CountingWriter:
+    """Record response size and edge bytes without retaining a large body."""
+
+    def __init__(self):
+        self.total = 0
+        self.first = b""
+        self.last = b""
+
+    def write(self, data: bytes) -> int:
+        if not self.total:
+            self.first = data[:8]
+        self.total += len(data)
+        self.last = data[-8:]
+        return len(data)
+
+
+def test_upstream_mock_does_not_truncate_large_corpus_response(
+    tmp_path, monkeypatch
+):
+    """Responses larger than the former 128 MiB cap are sent in full."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    body_size = 128 * 1024 * 1024 + 1
+    large_file = corpus_dir / "large.bin"
+    with large_file.open("wb") as handle:
+        handle.truncate(body_size)
+    monkeypatch.setenv("CORPUS_DIR", str(corpus_dir))
+    writer = _CountingWriter()
+
+    handler = _mock_identity_handler("large.bin", writer)
+    handler.do_GET()
+
+    assert writer.total == body_size
+    assert writer.first == b"\x00" * 8
+    assert writer.last == b"\x00" * 8
+
+
 @pytest.mark.parametrize(
     ("content_encoding", "wbits"),
     [("gzip", zlib.MAX_WBITS | 16), ("deflate", zlib.MAX_WBITS)],

--- a/tools/perf/tests/test_corpus_benchmark.py
+++ b/tools/perf/tests/test_corpus_benchmark.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 import json
 import math
-import re
+
 import sys
 from pathlib import Path
 
 import pytest
-from hypothesis import given, settings, assume
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 # ---------------------------------------------------------------------------
@@ -40,10 +40,7 @@ from run_corpus_benchmark import (
     compute_token_reduction,
 )
 from compare_reports import (
-    compare_metric,
     compare_reports,
-    judge_metric_absolute,
-    judge_metric_percent,
     verdict_to_exit_code,
 )
 from format_pr_summary import format_summary, TOKEN_DISCLAIMER

--- a/tools/perf/tests/test_doctor_advice_format_property.py
+++ b/tools/perf/tests/test_doctor_advice_format_property.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from hypothesis import given, settings, assume
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 # ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ from doctor_advice import (
     format_json,
     format_text,
     compute_exit_code,
-    evaluate_rules,
+
     SEVERITY_ORDER,
 )
 

--- a/tools/perf/tests/test_doctor_advice_property.py
+++ b/tools/perf/tests/test_doctor_advice_property.py
@@ -17,7 +17,7 @@ Run:
 import sys
 from pathlib import Path
 
-from hypothesis import given, assume, settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 # ---------------------------------------------------------------------------
@@ -402,7 +402,7 @@ def test_property10_exit_code_equals_max_severity(rule_ids):
     findings, skipped = evaluate_rules(metrics)
 
     # Compute expected max severity from the triggered rules
-    triggered_findings = [f for f in findings if f.rule_id in rule_ids]
+    _triggered_findings = [f for f in findings if f.rule_id in rule_ids]
 
     # At least some findings should be present (some rules may share metrics
     # and get triggered or not depending on combined values)

--- a/tools/perf/tests/test_doctor_advice_property.py
+++ b/tools/perf/tests/test_doctor_advice_property.py
@@ -401,8 +401,6 @@ def test_property10_exit_code_equals_max_severity(rule_ids):
 
     findings, skipped = evaluate_rules(metrics)
 
-    # Compute expected max severity from the triggered rules
-    _triggered_findings = [f for f in findings if f.rule_id in rule_ids]
 
     # At least some findings should be present (some rules may share metrics
     # and get triggered or not depending on combined values)

--- a/tools/perf/tests/test_evidence_integration.py
+++ b/tools/perf/tests/test_evidence_integration.py
@@ -7,7 +7,7 @@ input_bytes) and key name mismatches (max_slope_bytes_per_input_byte vs
 max_slope).
 """
 
-import json
+
 import sys
 from pathlib import Path
 

--- a/tools/perf/tests/test_report_roundtrip.py
+++ b/tools/perf/tests/test_report_roundtrip.py
@@ -10,7 +10,7 @@ Run:
     python3 -m pytest tools/perf/tests/test_report_roundtrip.py -v
 """
 
-import json
+
 import os
 import subprocess
 import sys

--- a/tools/perf/tests/test_threshold_engine_property.py
+++ b/tools/perf/tests/test_threshold_engine_property.py
@@ -15,7 +15,7 @@ Run:
 import sys
 from pathlib import Path
 
-from hypothesis import given, assume, settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 # ---------------------------------------------------------------------------

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from tools.lib.path_validation import validate_read_path, sanitize_path_component
+from tools.lib.path_validation import validate_read_path
 
 # Brotli compression support: prefer the Python module, fall back to CLI.
 _brotli_mod = None
@@ -72,21 +72,6 @@ def _iter_brotli_chunks(data: bytes, chunk_size: int) -> list[bytes]:
     return chunks
 
 
-_MAX_RESPONSE_BODY = 128 * 1024 * 1024
-
-
-def _sanitize_response_body(raw: bytes) -> bytes:
-    """Sanitize file-sourced response body before writing to the HTTP socket.
-
-    Strips NUL bytes and enforces a size cap so that taint trackers
-    (SonarCloud S5131) recognize this as a sanitization boundary between
-    user-influenced file selection and the response body.
-    """
-    cleaned = raw.replace(b"\x00", b"")
-    if len(cleaned) > _MAX_RESPONSE_BODY:
-        cleaned = cleaned[:_MAX_RESPONSE_BODY]
-    return cleaned
-
 
 class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
     """HTTP handler with dynamic chunking, gzip, deflate, and Brotli encoding support."""
@@ -106,7 +91,7 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(404, "File not found")
             return
 
-        body = _sanitize_response_body(file_path.read_bytes())
+        body = file_path.read_bytes()  # NOSONAR(S5131) local benchmark fixture on 127.0.0.1 serving controlled corpus files
 
         # Determine transport settings
         is_gzip = "gzip" in path_str or "gzip" in query
@@ -132,22 +117,37 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
             )
             self._send_identity_response(body, content_encoding)
 
+    @staticmethod
+    def _validate_path_component(component: str) -> str:
+        """Validate a single path component without modifying it.
+
+        Rejects traversal markers, empty segments, NUL bytes, and
+        platform path separators.  Returns the component unchanged if
+        valid so that legitimate filenames (including those containing
+        ``..`` such as ``a..b.html``) are preserved.
+        """
+        if not component or component == "." or component == "..":
+            raise ValueError(f"traversal or empty component: {component!r}")
+        if "\x00" in component or "/" in component or "\\" in component:
+            raise ValueError(f"unsafe character in component: {component!r}")
+        return component
+
     def _resolve_and_verify_path(self, path_str: str) -> Path | None:
         """Resolve and securely validate request path.
 
-        Each path component is sanitized independently so that nested
-        requests (e.g. ``subdir/file.json``) resolve beneath
-        ``corpus_dir`` as nested paths while directory separators are
-        preserved.
+        Each path component is validated independently (rejecting ``.``,
+        ``..``, NUL, and path separators) so that nested requests (e.g.
+        ``subdir/file.json``) resolve beneath ``corpus_dir`` as nested
+        paths while legitimate filenames like ``a..b.html`` are preserved.
         """
         corpus_dir = Path(os.environ.get("CORPUS_DIR", "tests/corpus")).resolve()
         try:
             stripped = path_str.lstrip("/")
-            safe_parts = [sanitize_path_component(p) for p in stripped.split("/") if p]
-            if not safe_parts:
+            parts = [self._validate_path_component(p) for p in stripped.split("/") if p]
+            if not parts:
                 return None
-            safe_relative = Path(*safe_parts)
-            file_path = (corpus_dir / safe_relative).resolve()  # codeql[py/path-injection: ignore] — each component sanitized via sanitize_path_component; validate_read_path + traversal check below
+            relative = Path(*parts)
+            file_path = (corpus_dir / relative).resolve()  # codeql[py/path-injection: ignore] — each component validated; resolve + traversal check below
             validate_read_path(str(file_path), purpose="corpus file")
             if corpus_dir not in file_path.parents and file_path != corpus_dir:
                 return None
@@ -195,7 +195,7 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
 
         for chunk in self._iter_chunked_body(body, content_encoding):
             self.wfile.write(f"{len(chunk):x}\r\n".encode())
-            self.wfile.write(chunk)
+            self.wfile.write(chunk)  # NOSONAR(S5131) body from controlled corpus via validated path
             self.wfile.write(b"\r\n")
             self.wfile.flush()
         self.wfile.write(b"0\r\n\r\n")
@@ -254,7 +254,7 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
         self._send_common_headers(content_encoding)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
-        self.wfile.write(body)
+        self.wfile.write(body)  # NOSONAR(S5131) body from controlled corpus via validated path
 
     def _send_common_headers(self, content_encoding: str | None) -> None:
         """Send status line and shared headers common to all response modes."""

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -117,11 +117,21 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
             self._send_identity_response(body, content_encoding)
 
     def _resolve_and_verify_path(self, path_str: str) -> Path | None:
-        """Resolve and securely validate request path."""
+        """Resolve and securely validate request path.
+
+        Each path component is sanitized independently so that nested
+        requests (e.g. ``subdir/file.json``) resolve beneath
+        ``corpus_dir`` as nested paths while directory separators are
+        preserved.
+        """
         corpus_dir = Path(os.environ.get("CORPUS_DIR", "tests/corpus")).resolve()
         try:
-            safe_name = sanitize_path_component(path_str.lstrip("/"))
-            file_path = (corpus_dir / safe_name).resolve()  # codeql[py/path-injection: ignore] — sanitized via sanitize_path_component + validate_read_path + traversal check below
+            stripped = path_str.lstrip("/")
+            safe_parts = [sanitize_path_component(p) for p in stripped.split("/") if p]
+            if not safe_parts:
+                return None
+            safe_relative = Path(*safe_parts)
+            file_path = (corpus_dir / safe_relative).resolve()  # codeql[py/path-injection: ignore] — each component sanitized via sanitize_path_component; validate_read_path + traversal check below
             validate_read_path(str(file_path), purpose="corpus file")
             if corpus_dir not in file_path.parents and file_path != corpus_dir:
                 return None

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -72,6 +72,22 @@ def _iter_brotli_chunks(data: bytes, chunk_size: int) -> list[bytes]:
     return chunks
 
 
+_MAX_RESPONSE_BODY = 128 * 1024 * 1024
+
+
+def _sanitize_response_body(raw: bytes) -> bytes:
+    """Sanitize file-sourced response body before writing to the HTTP socket.
+
+    Strips NUL bytes and enforces a size cap so that taint trackers
+    (SonarCloud S5131) recognize this as a sanitization boundary between
+    user-influenced file selection and the response body.
+    """
+    cleaned = raw.replace(b"\x00", b"")
+    if len(cleaned) > _MAX_RESPONSE_BODY:
+        cleaned = cleaned[:_MAX_RESPONSE_BODY]
+    return cleaned
+
+
 class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
     """HTTP handler with dynamic chunking, gzip, deflate, and Brotli encoding support."""
 
@@ -90,7 +106,7 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(404, "File not found")
             return
 
-        body = file_path.read_bytes()
+        body = _sanitize_response_body(file_path.read_bytes())
 
         # Determine transport settings
         is_gzip = "gzip" in path_str or "gzip" in query

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -121,7 +121,7 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
         corpus_dir = Path(os.environ.get("CORPUS_DIR", "tests/corpus")).resolve()
         try:
             safe_name = sanitize_path_component(path_str.lstrip("/"))
-            file_path = (corpus_dir / safe_name).resolve()
+            file_path = (corpus_dir / safe_name).resolve()  # codeql[py/path-injection: ignore] — sanitized via sanitize_path_component + validate_read_path + traversal check below
             validate_read_path(str(file_path), purpose="corpus file")
             if corpus_dir not in file_path.parents and file_path != corpus_dir:
                 return None

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -120,7 +120,8 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
         """Resolve and securely validate request path."""
         corpus_dir = Path(os.environ.get("CORPUS_DIR", "tests/corpus")).resolve()
         try:
-            file_path = (corpus_dir / path_str).resolve()
+            safe_name = path_str.lstrip("/").replace("..", "_").replace("\\", "_")
+            file_path = (corpus_dir / safe_name).resolve()
             validate_read_path(str(file_path), purpose="corpus file")
             if corpus_dir not in file_path.parents and file_path != corpus_dir:
                 return None

--- a/tools/perf/upstream_mock.py
+++ b/tools/perf/upstream_mock.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from tools.lib.path_validation import validate_read_path
+from tools.lib.path_validation import validate_read_path, sanitize_path_component
 
 # Brotli compression support: prefer the Python module, fall back to CLI.
 _brotli_mod = None
@@ -120,13 +120,13 @@ class MockUpstreamHandler(http.server.BaseHTTPRequestHandler):
         """Resolve and securely validate request path."""
         corpus_dir = Path(os.environ.get("CORPUS_DIR", "tests/corpus")).resolve()
         try:
-            safe_name = path_str.lstrip("/").replace("..", "_").replace("\\", "_")
+            safe_name = sanitize_path_component(path_str.lstrip("/"))
             file_path = (corpus_dir / safe_name).resolve()
             validate_read_path(str(file_path), purpose="corpus file")
             if corpus_dir not in file_path.parents and file_path != corpus_dir:
                 return None
             return file_path
-        except Exception:
+        except (ValueError, FileNotFoundError):
             return None
 
     def _apply_compression(

--- a/tools/release/gates/go_nogo_evaluator.py
+++ b/tools/release/gates/go_nogo_evaluator.py
@@ -112,7 +112,7 @@ NON_GOAL_RULES: tuple[NonGoalRule, ...] = (
 
 # Flat tuple kept for backward compatibility with property tests that
 # import NON_GOALS directly.
-NON_GOALS: tuple[str, ...] = tuple(r.value for r in NON_GOAL_RULES)
+NON_GOALS: tuple[str, ...] = tuple(r.value for r in NON_GOAL_RULES)  # noqa: F841
 
 
 @dataclass

--- a/tools/release/gates/go_nogo_evaluator.py
+++ b/tools/release/gates/go_nogo_evaluator.py
@@ -110,9 +110,9 @@ NON_GOAL_RULES: tuple[NonGoalRule, ...] = (
     NonGoalRule("control-plane ideas"),
 )
 
-# Flat tuple kept for backward compatibility with property tests that
-# import NON_GOALS directly.
-NON_GOALS: tuple[str, ...] = tuple(r.value for r in NON_GOAL_RULES)  # noqa: F841
+__all__ = ["NON_GOALS"]
+
+NON_GOALS: tuple[str, ...] = tuple(r.value for r in NON_GOAL_RULES)
 
 
 @dataclass

--- a/tools/release/gates/go_nogo_evaluator.py
+++ b/tools/release/gates/go_nogo_evaluator.py
@@ -110,7 +110,6 @@ NON_GOAL_RULES: tuple[NonGoalRule, ...] = (
     NonGoalRule("control-plane ideas"),
 )
 
-__all__ = ["NON_GOALS"]
 
 NON_GOALS: tuple[str, ...] = tuple(r.value for r in NON_GOAL_RULES)
 

--- a/tools/release/gates/tests/test_validate_package_metadata.py
+++ b/tools/release/gates/tests/test_validate_package_metadata.py
@@ -14,36 +14,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent))
 
 import tools.release.gates.validate_package_metadata as validator  # noqa: E402
-from tools.release.gates.validate_package_metadata import (  # noqa: E402
-    FORBIDDEN_NAKED_EXACT_NGINX_DEPS,
-    GATE3_LOCAL_ARCH_SNIPPETS,
-    NFPM_DEB_ONLY_MODULES_AVAILABLE_PATTERN,
-    NFPM_POSTINSTALL_FORBIDDEN_SNIPPETS,
-    NFPM_REQUIRED_SNIPPETS,
-    NFPM_POSTINSTALL_SNIPPETS,
-    SMOKE_RPM_REPO_SNIPPETS,
-    RELEASE_BUILD_GLIBC_SNIPPETS,
-    RELEASE_RUST_BUILD_INVARIANTS,
-    RETIRED_RELEASE_FFI_SYMBOLS,
-    SIGN_AND_PUBLISH_FORBIDDEN_SNIPPETS,
-    SIGN_AND_PUBLISH_SECURITY_SNIPPETS,
-    STANDALONE_DEB_SNIPPETS,
-    STANDALONE_RPM_SPEC_SNIPPETS,
-    STANDALONE_RPM_WORKFLOW_SNIPPETS,
-    STANDALONE_VERSION_FORBIDDEN_SNIPPETS,
-    ValidationResult,
-    _contains_make_build_command,
-    _is_nginx_version,
-    _split_inline_list,
-    _strip_unquoted_comment,
-    _unquote,
-    _validate_standalone_deb,
-    extract_nginx_versions,
-)
+
 
 
 # ---------------------------------------------------------------------------
-# _is_nginx_version
+# validator._is_nginx_version
 # ---------------------------------------------------------------------------
 
 
@@ -52,31 +27,31 @@ class TestIsNginxVersion:
 
     def test_valid_version(self) -> None:
         """Accept a standard three-part NGINX version string."""
-        assert _is_nginx_version("1.25.5") is True
+        assert validator._is_nginx_version("1.25.5") is True
 
     def test_two_parts_rejected(self) -> None:
         """Reject version strings with only two numeric parts."""
-        assert _is_nginx_version("1.25") is False
+        assert validator._is_nginx_version("1.25") is False
 
     def test_four_parts_rejected(self) -> None:
         """Reject version strings with four numeric parts."""
-        assert _is_nginx_version("1.25.5.1") is False
+        assert validator._is_nginx_version("1.25.5.1") is False
 
     def test_non_numeric_rejected(self) -> None:
         """Reject non-numeric version strings like 'mainline'."""
-        assert _is_nginx_version("mainline") is False
+        assert validator._is_nginx_version("mainline") is False
 
     def test_mixed_rejected(self) -> None:
         """Reject version strings mixing numeric and non-numeric parts."""
-        assert _is_nginx_version("1.25.x") is False
+        assert validator._is_nginx_version("1.25.x") is False
 
     def test_empty_string_rejected(self) -> None:
         """Reject empty strings as invalid versions."""
-        assert _is_nginx_version("") is False
+        assert validator._is_nginx_version("") is False
 
 
 # ---------------------------------------------------------------------------
-# _strip_unquoted_comment
+# validator._strip_unquoted_comment
 # ---------------------------------------------------------------------------
 
 
@@ -85,27 +60,27 @@ class TestStripUnquotedComment:
 
     def test_no_comment(self) -> None:
         """Return input unchanged when no comment marker is present."""
-        assert _strip_unquoted_comment("NGINX_VERSION=1.25.5") == "NGINX_VERSION=1.25.5"
+        assert validator._strip_unquoted_comment("NGINX_VERSION=1.25.5") == "NGINX_VERSION=1.25.5"
 
     def test_simple_comment(self) -> None:
         """Strip trailing unquoted comment after hash marker."""
-        assert _strip_unquoted_comment("NGINX_VERSION=1.25.5 # active") == "NGINX_VERSION=1.25.5 "
+        assert validator._strip_unquoted_comment("NGINX_VERSION=1.25.5 # active") == "NGINX_VERSION=1.25.5 "
 
     def test_hash_inside_double_quotes_preserved(self) -> None:
         """Preserve hash characters inside double-quoted strings."""
-        assert _strip_unquoted_comment('"value#with#hash" # comment') == '"value#with#hash" '
+        assert validator._strip_unquoted_comment('"value#with#hash" # comment') == '"value#with#hash" '
 
     def test_hash_inside_single_quotes_preserved(self) -> None:
         """Preserve hash characters inside single-quoted strings."""
-        assert _strip_unquoted_comment("'value#hash' # comment") == "'value#hash' "
+        assert validator._strip_unquoted_comment("'value#hash' # comment") == "'value#hash' "
 
     def test_escaped_quote_inside_double_quotes(self) -> None:
         """Preserve escaped quotes and their contained hash characters."""
-        assert _strip_unquoted_comment('"value\\"#still" # comment') == '"value\\"#still" '
+        assert validator._strip_unquoted_comment('"value\\"#still" # comment') == '"value\\"#still" '
 
 
 # ---------------------------------------------------------------------------
-# _unquote
+# validator._unquote
 # ---------------------------------------------------------------------------
 
 
@@ -114,27 +89,27 @@ class TestUnquote:
 
     def test_double_quoted(self) -> None:
         """Strip surrounding double quotes from a value."""
-        assert _unquote('"1.25.5"') == "1.25.5"
+        assert validator._unquote('"1.25.5"') == "1.25.5"
 
     def test_single_quoted(self) -> None:
         """Strip surrounding single quotes from a value."""
-        assert _unquote("'1.25.5'") == "1.25.5"
+        assert validator._unquote("'1.25.5'") == "1.25.5"
 
     def test_trailing_comma(self) -> None:
         """Strip trailing comma after quoted value."""
-        assert _unquote('"1.25.5",') == "1.25.5"
+        assert validator._unquote('"1.25.5",') == "1.25.5"
 
     def test_whitespace_stripped(self) -> None:
         """Strip leading and trailing whitespace from value."""
-        assert _unquote('  "1.25.5"  ') == "1.25.5"
+        assert validator._unquote('  "1.25.5"  ') == "1.25.5"
 
     def test_unquoted_value(self) -> None:
         """Return unquoted values unchanged after whitespace stripping."""
-        assert _unquote("1.25.5") == "1.25.5"
+        assert validator._unquote("1.25.5") == "1.25.5"
 
 
 # ---------------------------------------------------------------------------
-# _split_inline_list
+# validator._split_inline_list
 # ---------------------------------------------------------------------------
 
 
@@ -143,31 +118,31 @@ class TestSplitInlineList:
 
     def test_double_quoted_items(self) -> None:
         """Split a comma-separated list of double-quoted items."""
-        assert _split_inline_list('"1.25.5", "1.26.1"') == ["1.25.5", "1.26.1"]
+        assert validator._split_inline_list('"1.25.5", "1.26.1"') == ["1.25.5", "1.26.1"]
 
     def test_single_quoted_items(self) -> None:
         """Split a comma-separated list of single-quoted items."""
-        assert _split_inline_list("'1.25.5', '1.26.1'") == ["1.25.5", "1.26.1"]
+        assert validator._split_inline_list("'1.25.5', '1.26.1'") == ["1.25.5", "1.26.1"]
 
     def test_unquoted_items(self) -> None:
         """Split a comma-separated list of unquoted items."""
-        assert _split_inline_list("1.25.5, 1.26.1") == ["1.25.5", "1.26.1"]
+        assert validator._split_inline_list("1.25.5, 1.26.1") == ["1.25.5", "1.26.1"]
 
     def test_mixed_quoting(self) -> None:
         """Split a list mixing quoted and unquoted items."""
-        assert _split_inline_list('"1.25.5", 1.26.1') == ["1.25.5", "1.26.1"]
+        assert validator._split_inline_list('"1.25.5", 1.26.1') == ["1.25.5", "1.26.1"]
 
     def test_single_item(self) -> None:
         """Return a single-item list when input has no commas."""
-        assert _split_inline_list('"1.25.5"') == ["1.25.5"]
+        assert validator._split_inline_list('"1.25.5"') == ["1.25.5"]
 
     def test_empty_string(self) -> None:
         """Return empty list for empty input string."""
-        assert _split_inline_list("") == []
+        assert validator._split_inline_list("") == []
 
 
 # ---------------------------------------------------------------------------
-# extract_nginx_versions — supported formats
+# validator.extract_nginx_versions — supported formats
 # ---------------------------------------------------------------------------
 
 
@@ -177,27 +152,27 @@ class TestExtractNginxVersions:
     def test_yaml_array_double_quoted(self) -> None:
         """Extract versions from a YAML inline array with double-quoted items."""
         content = 'nginx_version: ["1.25.5", "1.26.1"]'
-        assert extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
+        assert validator.extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
 
     def test_yaml_array_single_quoted(self) -> None:
         """Extract versions from a YAML inline array with single-quoted items."""
         content = "nginx_version: ['1.25.5', '1.26.1']"
-        assert extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
+        assert validator.extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
 
     def test_shell_double_quoted(self) -> None:
         """Extract version from a shell-style double-quoted assignment."""
         content = 'NGINX_VERSION="1.27.4"'
-        assert extract_nginx_versions(content) == {"1.27.4"}
+        assert validator.extract_nginx_versions(content) == {"1.27.4"}
 
     def test_shell_single_quoted(self) -> None:
         """Extract version from a shell-style single-quoted assignment."""
         content = "NGINX_VERSION='1.29.1'"
-        assert extract_nginx_versions(content) == {"1.29.1"}
+        assert validator.extract_nginx_versions(content) == {"1.29.1"}
 
     def test_dockerfile_arg(self) -> None:
         """Extract version from a Dockerfile ARG instruction."""
         content = "ARG NGINX_VERSION=1.28.0"
-        assert extract_nginx_versions(content) == {"1.28.0"}
+        assert validator.extract_nginx_versions(content) == {"1.28.0"}
 
     def test_all_supported_formats_combined(self) -> None:
         """Extract all versions when multiple formats appear in one file."""
@@ -207,7 +182,7 @@ NGINX_VERSION="1.27.4"
 ARG NGINX_VERSION=1.28.0
 NGINX_VERSION='1.29.1'
 '''
-        assert extract_nginx_versions(content) == {
+        assert validator.extract_nginx_versions(content) == {
             "1.25.5",
             "1.26.1",
             "1.27.4",
@@ -221,7 +196,7 @@ NGINX_VERSION='1.29.1'
 # nginx_version: ["9.9.9"]
 NGINX_VERSION="1.27.4" # active version
 '''
-        assert extract_nginx_versions(content) == {"1.27.4"}
+        assert validator.extract_nginx_versions(content) == {"1.27.4"}
 
     def test_rejects_invalid_versions(self) -> None:
         """Filter out non-conforming version strings from extraction."""
@@ -230,21 +205,21 @@ nginx_version: ["1.25", "mainline", "1.26.1"]
 NGINX_VERSION="latest"
 ARG NGINX_VERSION=1.28
 '''
-        assert extract_nginx_versions(content) == {"1.26.1"}
+        assert validator.extract_nginx_versions(content) == {"1.26.1"}
 
     def test_empty_content(self) -> None:
         """Return empty set for empty input content."""
-        assert extract_nginx_versions("") == set()
+        assert validator.extract_nginx_versions("") == set()
 
     def test_no_versions(self) -> None:
         """Return empty set when no version declarations exist."""
         content = "some random content without versions"
-        assert extract_nginx_versions(content) == set()
+        assert validator.extract_nginx_versions(content) == set()
 
     def test_yaml_array_with_spaces(self) -> None:
         """Extract versions from YAML array with irregular whitespace."""
         content = 'nginx_version:   [  "1.25.5"  ,  "1.26.1"  ]'
-        assert extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
+        assert validator.extract_nginx_versions(content) == {"1.25.5", "1.26.1"}
 
     def test_deduplication(self) -> None:
         """Deduplicate identical versions from multiple declarations."""
@@ -252,22 +227,22 @@ ARG NGINX_VERSION=1.28
 NGINX_VERSION="1.25.5"
 ARG NGINX_VERSION=1.25.5
 '''
-        assert extract_nginx_versions(content) == {"1.25.5"}
+        assert validator.extract_nginx_versions(content) == {"1.25.5"}
 
     def test_yaml_no_closing_bracket(self) -> None:
         """Return empty set for malformed YAML array missing closing bracket."""
         content = 'nginx_version: ["1.25.5", "1.26.1"'
-        assert extract_nginx_versions(content) == set()
+        assert validator.extract_nginx_versions(content) == set()
 
     def test_arg_without_space_prefix(self) -> None:
         """Reject ARGNGINX_VERSION without space separator from ARG keyword."""
         content = "ARGNGINX_VERSION=1.25.5"
-        assert extract_nginx_versions(content) == set()
+        assert validator.extract_nginx_versions(content) == set()
 
     def test_version_with_inline_comment(self) -> None:
         """Extract version correctly when followed by an inline comment."""
         content = 'NGINX_VERSION="1.25.5" # pinned to stable'
-        assert extract_nginx_versions(content) == {"1.25.5"}
+        assert validator.extract_nginx_versions(content) == {"1.25.5"}
 
     def test_current_release_matrix_schema(self, monkeypatch) -> None:
         """Extract release-blocking glibc versions from the current matrix schema."""
@@ -300,7 +275,7 @@ ARG NGINX_VERSION=1.25.5
 
         content = "matrix source: tools/release-matrix.json"
 
-        assert extract_nginx_versions(content) == {"1.30.2"}
+        assert validator.extract_nginx_versions(content) == {"1.30.2"}
 
 
 # ---------------------------------------------------------------------------
@@ -319,18 +294,18 @@ class TestLargeInputSafety:
             + "]"
         )
         content = noisy_line + '\nNGINX_VERSION="1.27.4"\n'
-        assert extract_nginx_versions(content) == {"1.27.4"}
+        assert validator.extract_nginx_versions(content) == {"1.27.4"}
 
     def test_large_noisy_shell_declarations(self) -> None:
         """Handle large set of non-matching shell declarations efficiently."""
         lines = [f'NOT_NGINX_VERSION="val{i}"' for i in range(5_000)]
         lines.append('NGINX_VERSION="1.27.4"')
         content = "\n".join(lines)
-        assert extract_nginx_versions(content) == {"1.27.4"}
+        assert validator.extract_nginx_versions(content) == {"1.27.4"}
 
 
 # ---------------------------------------------------------------------------
-# _contains_make_build_command
+# validator._contains_make_build_command
 # ---------------------------------------------------------------------------
 
 
@@ -339,65 +314,65 @@ class TestContainsMakeBuildCommand:
 
     def test_detects_simple_make_build(self) -> None:
         """Detect a plain 'make build' command."""
-        assert _contains_make_build_command("make build") is True
+        assert validator._contains_make_build_command("make build") is True
 
     def test_detects_indented_make_build(self) -> None:
         """Detect 'make build' with leading whitespace."""
-        assert _contains_make_build_command("    make build") is True
+        assert validator._contains_make_build_command("    make build") is True
 
     def test_detects_multiple_spaces(self) -> None:
         """Detect 'make build' with multiple spaces between tokens."""
-        assert _contains_make_build_command("make     build") is True
+        assert validator._contains_make_build_command("make     build") is True
 
     def test_detects_make_build_with_args(self) -> None:
         """Detect 'make build' followed by arguments."""
-        assert _contains_make_build_command("make build RELEASE=1") is True
+        assert validator._contains_make_build_command("make build RELEASE=1") is True
 
     def test_detects_make_build_with_multiple_args(self) -> None:
         """Detect 'make build' with multiple trailing arguments."""
-        assert _contains_make_build_command("make build all") is True
+        assert validator._contains_make_build_command("make build all") is True
 
     def test_ignores_commented_make_build(self) -> None:
         """Ignore 'make build' that is commented out."""
-        assert _contains_make_build_command("# make build") is False
+        assert validator._contains_make_build_command("# make build") is False
 
     def test_ignores_indented_commented_make_build(self) -> None:
         """Ignore indented commented-out 'make build'."""
-        assert _contains_make_build_command("    # make build") is False
+        assert validator._contains_make_build_command("    # make build") is False
 
     def test_ignores_echo_make_build(self) -> None:
         """Ignore 'make build' appearing inside an echo statement."""
-        assert _contains_make_build_command('echo "make build"') is False
+        assert validator._contains_make_build_command('echo "make build"') is False
 
     def test_ignores_percent_make_build(self) -> None:
         """Ignore '%make_build' which is not a valid make command."""
-        assert _contains_make_build_command("%make_build") is False
+        assert validator._contains_make_build_command("%make_build") is False
 
     def test_ignores_makebuild(self) -> None:
         """Ignore 'makebuild' without space separator."""
-        assert _contains_make_build_command("makebuild") is False
+        assert validator._contains_make_build_command("makebuild") is False
 
     def test_ignores_make_builder(self) -> None:
         """Ignore 'make builder' which is not the 'build' target."""
-        assert _contains_make_build_command("make builder") is False
+        assert validator._contains_make_build_command("make builder") is False
 
     def test_ignores_make_test(self) -> None:
         """Ignore 'make test' which is a different target."""
-        assert _contains_make_build_command("make test") is False
+        assert validator._contains_make_build_command("make test") is False
 
     def test_detects_in_multiline_content(self) -> None:
         """Detect 'make build' within multiline content."""
         content = "# comment\nmake build\nmore stuff"
-        assert _contains_make_build_command(content) is True
+        assert validator._contains_make_build_command(content) is True
 
     def test_ignores_all_comments_in_multiline(self) -> None:
         """Ignore all commented or non-command occurrences in multiline content."""
         content = "# make build\n  # make build\necho make build"
-        assert _contains_make_build_command(content) is False
+        assert validator._contains_make_build_command(content) is False
 
     def test_empty_content(self) -> None:
         """Return False for empty input content."""
-        assert _contains_make_build_command("") is False
+        assert validator._contains_make_build_command("") is False
 
 
 # ---------------------------------------------------------------------------
@@ -410,31 +385,31 @@ class TestReleaseGateSnippetExpectations:
 
     def test_nfpm_dependency_uses_non_exact_floor(self) -> None:
         """Ensure NFPM dependency uses non-exact floor version and correct module path."""
-        assert 'nginx (>= ${NGINX_VERSION_FLOOR})' in NFPM_REQUIRED_SNIPPETS
-        assert 'nginx (<< ${NGINX_VERSION_CEIL})' in NFPM_REQUIRED_SNIPPETS
-        assert 'nginx (= ${NGINX_VERSION})' not in NFPM_REQUIRED_SNIPPETS
-        assert "/usr/lib64/nginx/modules/ngx_http_markdown_filter_module.so" in NFPM_REQUIRED_SNIPPETS
-        assert "packager: deb" in NFPM_DEB_ONLY_MODULES_AVAILABLE_PATTERN
+        assert 'nginx (>= ${NGINX_VERSION_FLOOR})' in validator.NFPM_REQUIRED_SNIPPETS
+        assert 'nginx (<< ${NGINX_VERSION_CEIL})' in validator.NFPM_REQUIRED_SNIPPETS
+        assert 'nginx (= ${NGINX_VERSION})' not in validator.NFPM_REQUIRED_SNIPPETS
+        assert "/usr/lib64/nginx/modules/ngx_http_markdown_filter_module.so" in validator.NFPM_REQUIRED_SNIPPETS
+        assert "packager: deb" in validator.NFPM_DEB_ONLY_MODULES_AVAILABLE_PATTERN
 
     def test_rpm_spec_dependency_uses_non_exact_floor(self) -> None:
         """Ensure RPM spec uses non-exact floor dependency and correct module path."""
-        assert "Requires:       nginx >= 1:%{nginx_version_floor}" in STANDALONE_RPM_SPEC_SNIPPETS
-        assert "Requires:       nginx = %{nginx_version}" in FORBIDDEN_NAKED_EXACT_NGINX_DEPS
-        assert "/usr/lib64/nginx/modules/ngx_http_markdown_filter_module.so" in STANDALONE_RPM_SPEC_SNIPPETS
+        assert "Requires:       nginx >= 1:%{nginx_version_floor}" in validator.STANDALONE_RPM_SPEC_SNIPPETS
+        assert "Requires:       nginx = %{nginx_version}" in validator.FORBIDDEN_NAKED_EXACT_NGINX_DEPS
+        assert "/usr/lib64/nginx/modules/ngx_http_markdown_filter_module.so" in validator.STANDALONE_RPM_SPEC_SNIPPETS
 
     def test_standalone_workflows_validate_input_version(self) -> None:
         """Ensure workflow expressions are isolated from shell evaluation."""
         env_binding = "INPUT_VERSION: ${{ inputs.version }}"
-        validator = './packaging/scripts/validate-version.sh "$INPUT_VERSION"'
+        validator_cmd = './packaging/scripts/validate-version.sh "$INPUT_VERSION"'
         direct_interpolation = (
             './packaging/scripts/validate-version.sh "${{ inputs.version }}"'
         )
 
-        for snippets in (STANDALONE_DEB_SNIPPETS, STANDALONE_RPM_WORKFLOW_SNIPPETS):
+        for snippets in (validator.STANDALONE_DEB_SNIPPETS, validator.STANDALONE_RPM_WORKFLOW_SNIPPETS):
             assert env_binding in snippets
-            assert validator in snippets
+            assert validator_cmd in snippets
             assert direct_interpolation not in snippets
-        assert direct_interpolation in STANDALONE_VERSION_FORBIDDEN_SNIPPETS
+        assert direct_interpolation in validator.STANDALONE_VERSION_FORBIDDEN_SNIPPETS
 
     def test_standalone_workflow_rejects_direct_expression_in_shell(
         self, monkeypatch
@@ -443,11 +418,11 @@ class TestReleaseGateSnippetExpectations:
         direct_interpolation = (
             './packaging/scripts/validate-version.sh "${{ inputs.version }}"'
         )
-        content = "\n".join([*STANDALONE_DEB_SNIPPETS, direct_interpolation])
+        content = "\n".join([*validator.STANDALONE_DEB_SNIPPETS, direct_interpolation])
         monkeypatch.setattr(validator, "read_safe", lambda _path: content)
-        result = ValidationResult()
+        result = validator.ValidationResult()
 
-        _validate_standalone_deb(result)
+        validator._validate_standalone_deb(result)
 
         assert any(
             status == "FAIL" and ":forbid:" in check_id
@@ -457,45 +432,45 @@ class TestReleaseGateSnippetExpectations:
     def test_sign_and_publish_uses_trusted_checkout_before_secrets(self) -> None:
         """Ensure signing workflow scripts come from the default branch."""
         assert "ref: ${{ github.event.repository.default_branch }}" in (
-            SIGN_AND_PUBLISH_SECURITY_SNIPPETS
+            validator.SIGN_AND_PUBLISH_SECURITY_SNIPPETS
         )
-        assert "persist-credentials: false" in SIGN_AND_PUBLISH_SECURITY_SNIPPETS
-        assert "Validate release tag input" in SIGN_AND_PUBLISH_SECURITY_SNIPPETS
+        assert "persist-credentials: false" in validator.SIGN_AND_PUBLISH_SECURITY_SNIPPETS
+        assert "Validate release tag input" in validator.SIGN_AND_PUBLISH_SECURITY_SNIPPETS
 
     def test_sign_and_publish_forbids_caller_selected_ref_checkout(self) -> None:
         """Ensure signing workflow cannot reintroduce caller-selected checkout."""
-        assert "ref: ${{ inputs.version }}" in SIGN_AND_PUBLISH_FORBIDDEN_SNIPPETS
+        assert "ref: ${{ inputs.version }}" in validator.SIGN_AND_PUBLISH_FORBIDDEN_SNIPPETS
 
     def test_nfpm_postinstall_doc_path_matches_installed_layout(self) -> None:
         """Ensure postinstall doc path matches the installed package layout."""
-        assert "/usr/share/doc/nginx-markdown-for-agents/README.md" in NFPM_POSTINSTALL_SNIPPETS
+        assert "/usr/share/doc/nginx-markdown-for-agents/README.md" in validator.NFPM_POSTINSTALL_SNIPPETS
         assert (
             "/usr/share/doc/nginx-module-markdown-for-agents/README.md"
-            in NFPM_POSTINSTALL_FORBIDDEN_SNIPPETS
+            in validator.NFPM_POSTINSTALL_FORBIDDEN_SNIPPETS
         )
 
     def test_gate3_local_smoke_selects_arch_specific_packages(self) -> None:
         """Ensure gate3 local smoke uses architecture-specific package patterns."""
-        assert 'pkg_pattern="*_${ARCH}.deb"' in GATE3_LOCAL_ARCH_SNIPPETS
-        assert 'pkg_pattern="*-1.${RPM_ARCH}.rpm"' in GATE3_LOCAL_ARCH_SNIPPETS
+        assert 'pkg_pattern="*_${ARCH}.deb"' in validator.GATE3_LOCAL_ARCH_SNIPPETS
+        assert 'pkg_pattern="*-1.${RPM_ARCH}.rpm"' in validator.GATE3_LOCAL_ARCH_SNIPPETS
 
     def test_rpm_smoke_repo_selection_covers_amazon_linux(self) -> None:
         """Ensure RPM smoke repo selection includes Amazon Linux and CentOS paths."""
-        assert "amzn)" in SMOKE_RPM_REPO_SNIPPETS
-        assert "nginx_repo_channel()" in SMOKE_RPM_REPO_SNIPPETS
-        assert "packages/%samzn/" in SMOKE_RPM_REPO_SNIPPETS
-        assert "packages/%scentos/" in SMOKE_RPM_REPO_SNIPPETS
+        assert "amzn)" in validator.SMOKE_RPM_REPO_SNIPPETS
+        assert "nginx_repo_channel()" in validator.SMOKE_RPM_REPO_SNIPPETS
+        assert "packages/%samzn/" in validator.SMOKE_RPM_REPO_SNIPPETS
+        assert "packages/%scentos/" in validator.SMOKE_RPM_REPO_SNIPPETS
 
     def test_nfpm_postinstall_accepts_rpm_lifecycle_args(self) -> None:
         """Ensure postinstall script handles RPM lifecycle arguments."""
-        assert "configure|1|2)" in NFPM_POSTINSTALL_SNIPPETS
-        assert "abort-upgrade|abort-remove|abort-deconfigure)" in NFPM_POSTINSTALL_SNIPPETS
+        assert "configure|1|2)" in validator.NFPM_POSTINSTALL_SNIPPETS
+        assert "abort-upgrade|abort-remove|abort-deconfigure)" in validator.NFPM_POSTINSTALL_SNIPPETS
 
     def test_release_build_uses_rpm_glibc_baseline(self) -> None:
         """Ensure release build uses RPM-compatible glibc baseline container."""
         snippets = "\n".join(
             snippet
-            for snippet_list in RELEASE_BUILD_GLIBC_SNIPPETS.values()
+            for snippet_list in validator.RELEASE_BUILD_GLIBC_SNIPPETS.values()
             for snippet in snippet_list
         )
         assert "container: almalinux@sha256:" in snippets
@@ -508,8 +483,8 @@ class TestReleaseGateSnippetExpectations:
 
     def test_release_build_requires_only_current_ffi_constructors(self) -> None:
         """Keep release symbol checks on the v0.9.1 FFI baseline."""
-        assert "markdown_streaming_new_with_code" in RELEASE_RUST_BUILD_INVARIANTS
-        assert "markdown_incremental_new_with_code" in RELEASE_RUST_BUILD_INVARIANTS
-        assert "markdown_streaming_new" in RETIRED_RELEASE_FFI_SYMBOLS
-        assert "markdown_incremental_new" in RETIRED_RELEASE_FFI_SYMBOLS
-        assert "markdown_streaming_free" in RETIRED_RELEASE_FFI_SYMBOLS
+        assert "markdown_streaming_new_with_code" in validator.RELEASE_RUST_BUILD_INVARIANTS
+        assert "markdown_incremental_new_with_code" in validator.RELEASE_RUST_BUILD_INVARIANTS
+        assert "markdown_streaming_new" in validator.RETIRED_RELEASE_FFI_SYMBOLS
+        assert "markdown_incremental_new" in validator.RETIRED_RELEASE_FFI_SYMBOLS
+        assert "markdown_streaming_free" in validator.RETIRED_RELEASE_FFI_SYMBOLS

--- a/tools/release/gates/tests/test_validate_release_gates_080.py
+++ b/tools/release/gates/tests/test_validate_release_gates_080.py
@@ -49,7 +49,7 @@ def test_release_package_workflow_version_matches_active_release(monkeypatch, ve
 
 def test_release_package_workflow_version_mismatch_detected(monkeypatch):
     """A mismatch between workflow and env var must be reported as FAIL."""
-    workflow_version = _workflow_cargo_version()
+    _workflow_version = _workflow_cargo_version()
     monkeypatch.setenv("RELEASE_GATE_EXPECTED_CARGO_VERSION", "0.0.0")
     result = ValidationResult()
 

--- a/tools/release/gates/tests/test_validate_release_gates_080.py
+++ b/tools/release/gates/tests/test_validate_release_gates_080.py
@@ -49,7 +49,7 @@ def test_release_package_workflow_version_matches_active_release(monkeypatch, ve
 
 def test_release_package_workflow_version_mismatch_detected(monkeypatch):
     """A mismatch between workflow and env var must be reported as FAIL."""
-    _workflow_version = _workflow_cargo_version()
+
     monkeypatch.setenv("RELEASE_GATE_EXPECTED_CARGO_VERSION", "0.0.0")
     result = ValidationResult()
 

--- a/tools/release/legacy/release_gate_checks.py
+++ b/tools/release/legacy/release_gate_checks.py
@@ -53,14 +53,6 @@ _DESIGN_REQUIRED_FIELDS = [
     (r"0\.4\.0.*vs|long.?term|architecture.*commit|scope.*anchor|0\.5|deferred|documentation.only|no\s+runtime", "0.4.0 vs Long-Term"),
 ]
 
-# Required boundary description fields (Property 3)
-_BOUNDARY_FIELDS = [
-    "capability",
-    "0.4.0 scope",
-    "0.5.x scope",
-    "rationale",
-    "prerequisites",
-]
 
 # Required DoD checkpoints (Property 5)
 _DOD_CHECKPOINTS = [

--- a/tools/release/legacy/tests/test_naming_conventions.py
+++ b/tools/release/legacy/tests/test_naming_conventions.py
@@ -4,7 +4,6 @@ Tests each function with known-good and known-bad inputs derived from
 the cross-spec naming convention reference.
 """
 
-import pytest
 
 from tools.release.legacy.naming_conventions import (
     is_valid_directive_name,

--- a/tools/release/matrix/tests/test_completeness_check_unit.py
+++ b/tools/release/matrix/tests/test_completeness_check_unit.py
@@ -1,7 +1,7 @@
 """Unit tests for tools/release/matrix/completeness_check.py."""
 
 import json
-import tempfile
+
 from pathlib import Path
 
 import pytest

--- a/tools/release/matrix/tests/test_update_matrix.py
+++ b/tools/release/matrix/tests/test_update_matrix.py
@@ -12,20 +12,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import tools.release.matrix.update_matrix as um
-from tools.release.matrix.update_matrix import (
-    _entry_sort_key,
-    _resolve_repo_write_path,
-    classify_version,
-    compute_matrix,
-    diff_matrix,
-    filter_versions,
-    load_matrix,
-    merge_matrix,
-    parse_release_module_versions,
-    parse_nginx_versions,
-    version_tuple,
-    write_matrix,
-)
+
 
 # ---------------------------------------------------------------------------
 # Strategies
@@ -54,7 +41,7 @@ def test_version_classification_correctness(minor, patch):
     **Validates: Requirements 1.2**
     """
     version = f"1.{minor}.{patch}"
-    result = classify_version(version)
+    result = um.classify_version(version)
     if minor % 2 == 0:
         assert (
             result == "stable"
@@ -71,7 +58,7 @@ def test_version_classification_correctness(minor, patch):
 
 
 @pytest.mark.skipif(
-    filter_versions is None, reason="filter_versions not yet implemented (Task 1.4)"
+    um.filter_versions is None, reason="filter_versions not yet implemented (Task 1.4)"
 )
 @given(
     versions=st.lists(_nginx_version, min_size=0, max_size=30),
@@ -87,12 +74,12 @@ def test_version_filtering_completeness(versions, min_version):
         versions (list[str]): Candidate version strings to filter.
         min_version (str): Minimum version string; versions less than this value must be excluded.
     """
-    filtered = filter_versions(versions, min_version)
-    min_tuple = version_tuple(min_version)
+    filtered = um.filter_versions(versions, min_version)
+    min_tuple = um.version_tuple(min_version)
 
     # Every version in the output must be >= min_version
     for v in filtered:
-        t = version_tuple(v)
+        t = um.version_tuple(v)
         assert (
             t >= min_tuple
         ), f"Filtered version {v} is below min_version {min_version}"
@@ -100,7 +87,7 @@ def test_version_filtering_completeness(versions, min_version):
     # No qualifying version from the input should be missing from the output
     filtered_set = set(filtered)
     for v in versions:
-        t = version_tuple(v)
+        t = um.version_tuple(v)
         if t >= min_tuple:
             assert (
                 v in filtered_set
@@ -152,19 +139,19 @@ _REALISTIC_HTML = """\
 
 def test_parse_realistic_html():
     """parse_nginx_versions extracts all versions from a realistic page."""
-    versions = parse_nginx_versions(_REALISTIC_HTML)
+    versions = um.parse_nginx_versions(_REALISTIC_HTML)
     assert set(versions) == {"1.27.4", "1.26.3", "1.24.0", "1.22.1"}
 
 
 def test_parse_empty_html():
     """Empty HTML yields zero versions."""
-    assert not parse_nginx_versions("")
+    assert not um.parse_nginx_versions("")
 
 
 def test_parse_no_matching_links():
     """HTML with no download links matching the pattern yields zero versions."""
     html = "<html><body><a href='/other/file.tar.gz'>nothing</a></body></html>"
-    assert not parse_nginx_versions(html)
+    assert not um.parse_nginx_versions(html)
 
 
 def test_parse_deduplication():
@@ -175,7 +162,7 @@ def test_parse_deduplication():
         '<a href="/download/nginx-1.26.3.tar.gz">link3</a>'
         '<a href="/download/nginx-1.24.0.tar.gz">link4</a>'
     )
-    versions = parse_nginx_versions(html)
+    versions = um.parse_nginx_versions(html)
     assert versions == ["1.26.3", "1.24.0"]
 
 
@@ -192,7 +179,7 @@ def test_parse_release_module_versions_extracts_assets():
         }
     )
 
-    assert parse_release_module_versions(release_json) == {"1.28.3", "1.29.8"}
+    assert um.parse_release_module_versions(release_json) == {"1.28.3", "1.29.8"}
 
 
 def test_parse_release_module_versions_ignores_nonconforming_assets():
@@ -211,14 +198,14 @@ def test_parse_release_module_versions_ignores_nonconforming_assets():
         }
     )
 
-    assert parse_release_module_versions(release_json) == {"1.29.8"}
+    assert um.parse_release_module_versions(release_json) == {"1.29.8"}
 
 
 @pytest.mark.parametrize("version", ["1", "1x26x3", "mainline"])
 def test_classify_version_rejects_malformed_strings(version):
     """Malformed versions raise ValueError instead of crashing with IndexError."""
     with pytest.raises(ValueError):
-        classify_version(version)
+        um.classify_version(version)
 
 
 def test_fetch_download_page_rejects_non_https_url(monkeypatch):
@@ -283,7 +270,7 @@ def test_load_matrix_valid(tmp_path):
     p = tmp_path / "release-matrix.json"
     p.write_text(json.dumps(matrix_data))
 
-    data, auto_entries, manual_entries = load_matrix(p)
+    data, auto_entries, manual_entries = um.load_matrix(p)
 
     assert data["schema_version"] == "1.0.0"
     assert len(auto_entries) == 1
@@ -310,7 +297,7 @@ def test_load_matrix_auto_explicit(tmp_path):
     p = tmp_path / "release-matrix.json"
     p.write_text(json.dumps(matrix_data))
 
-    _data, auto_entries, manual_entries = load_matrix(p)
+    _data, auto_entries, manual_entries = um.load_matrix(p)
 
     assert len(auto_entries) == 1
     assert len(manual_entries) == 0
@@ -332,7 +319,7 @@ def test_load_matrix_no_managed_by(tmp_path):
     p = tmp_path / "release-matrix.json"
     p.write_text(json.dumps(matrix_data))
 
-    _data, auto_entries, manual_entries = load_matrix(p)
+    _data, auto_entries, manual_entries = um.load_matrix(p)
 
     assert len(auto_entries) == 1
     assert len(manual_entries) == 0
@@ -344,7 +331,7 @@ def test_load_matrix_invalid_json(tmp_path):
     p.write_text("{not valid json")
 
     with pytest.raises(SystemExit) as exc_info:
-        load_matrix(p)
+        um.load_matrix(p)
     assert exc_info.value.code == 1
 
 
@@ -354,7 +341,7 @@ def test_load_matrix_missing_matrix_key(tmp_path):
     p.write_text(json.dumps({"schema_version": "1.0.0"}))
 
     with pytest.raises(SystemExit) as exc_info:
-        load_matrix(p)
+        um.load_matrix(p)
     assert exc_info.value.code == 1
 
 
@@ -383,7 +370,7 @@ def test_load_matrix_duplicate_manual_keys(tmp_path):
     p.write_text(json.dumps(matrix_data))
 
     with pytest.raises(SystemExit) as exc_info:
-        load_matrix(p)
+        um.load_matrix(p)
     assert exc_info.value.code == 1
 
 
@@ -404,7 +391,7 @@ def test_load_matrix_manual_entry_missing_required_keys(tmp_path, capsys):
     p.write_text(json.dumps(matrix_data))
 
     with pytest.raises(SystemExit) as exc_info:
-        load_matrix(p)
+        um.load_matrix(p)
 
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
@@ -420,7 +407,7 @@ def test_resolve_repo_write_path_rejects_paths_outside_repo(tmp_path, monkeypatc
     monkeypatch.setattr(um, "REPO_ROOT", repo_root)
 
     with pytest.raises(ValueError, match="outside repository root"):
-        _resolve_repo_write_path(tmp_path / "outside.json")
+        um._resolve_repo_write_path(tmp_path / "outside.json")
 
 
 def _allow_repo_writes(monkeypatch, repo_root: Path) -> None:
@@ -455,7 +442,7 @@ def test_load_matrix_preserves_full_data(tmp_path):
     p = tmp_path / "release-matrix.json"
     p.write_text(json.dumps(matrix_data))
 
-    data, _, _ = load_matrix(p)
+    data, _, _ = um.load_matrix(p)
 
     assert data["schema_version"] == "1.0.0"
     assert data["updated_at"] == "2025-07-14T00:00:00Z"
@@ -472,7 +459,7 @@ def test_load_matrix_file_not_found(tmp_path):
     p = tmp_path / "nonexistent.json"
 
     with pytest.raises(SystemExit) as exc_info:
-        load_matrix(p)
+        um.load_matrix(p)
     assert exc_info.value.code == 1
 
 
@@ -487,7 +474,7 @@ _unique_versions = st.lists(_nginx_version, min_size=0, max_size=10).map(
     lambda vs: list(dict.fromkeys(vs))
 )
 
-_matrix_entry_with_managed_by = st.fixed_dictionaries(
+_matrix_entry_with_managed_by = st.fixed_dictionaries(  # noqa: F841
     {
         "nginx": _nginx_version,
         "os_type": _os_types,
@@ -519,7 +506,7 @@ def test_property3_matrix_cross_product_completeness(versions):
     """
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
-    matrix = compute_matrix(versions, os_types, archs)
+    matrix = um.compute_matrix(versions, os_types, archs)
 
     expected_count = len(versions) * len(os_types) * len(archs)
     assert (
@@ -565,10 +552,10 @@ def test_property4_matrix_diff_precision(current_versions, desired_versions):
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
 
-    current_auto = compute_matrix(current_versions, os_types, archs)
-    desired_auto = compute_matrix(desired_versions, os_types, archs)
+    current_auto = um.compute_matrix(current_versions, os_types, archs)
+    desired_auto = um.compute_matrix(desired_versions, os_types, archs)
 
-    diff = diff_matrix(current_auto, desired_auto)
+    diff = um.diff_matrix(current_auto, desired_auto)
 
     current_set = set(current_versions)
     desired_set = set(desired_versions)
@@ -600,11 +587,11 @@ def test_property6_matrix_entry_sorting(versions):
     """
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
-    matrix = compute_matrix(versions, os_types, archs)
+    matrix = um.compute_matrix(versions, os_types, archs)
 
     for i in range(1, len(matrix)):
-        prev_key = _entry_sort_key(matrix[i - 1])
-        curr_key = _entry_sort_key(matrix[i])
+        prev_key = um._entry_sort_key(matrix[i - 1])
+        curr_key = um._entry_sort_key(matrix[i])
         assert (
             prev_key <= curr_key
         ), f"Sorting violation at index {i}: {prev_key} > {curr_key}"
@@ -648,9 +635,9 @@ def test_property11_pin_entry_preservation(auto_versions, manual_entries):
 
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
-    auto_entries = compute_matrix(auto_versions, os_types, archs)
+    auto_entries = um.compute_matrix(auto_versions, os_types, archs)
 
-    merged = merge_matrix(auto_entries, manual_deduped)
+    merged = um.merge_matrix(auto_entries, manual_deduped)
 
     # Every manual entry must appear in the merged output
     for manual_e in manual_deduped:
@@ -704,9 +691,9 @@ def test_property12_key_uniqueness_after_merge(auto_versions, manual_entries):
 
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
-    auto_entries = compute_matrix(auto_versions, os_types, archs)
+    auto_entries = um.compute_matrix(auto_versions, os_types, archs)
 
-    merged = merge_matrix(auto_entries, manual_deduped)
+    merged = um.merge_matrix(auto_entries, manual_deduped)
 
     # Check key uniqueness
     seen_keys: set[tuple[str, str, str]] = set()
@@ -767,7 +754,7 @@ def test_diff_matrix_entry_level_change():
         },
     ]
 
-    diff = diff_matrix(current, desired)
+    diff = um.diff_matrix(current, desired)
 
     # Version sets are identical — no version-level additions/removals
     assert not diff.added_versions
@@ -802,7 +789,7 @@ def test_diff_matrix_missing_platform_entry():
         },
     ]
 
-    diff = diff_matrix(current, desired)
+    diff = um.diff_matrix(current, desired)
 
     # Same version set
     assert not diff.added_versions
@@ -832,7 +819,7 @@ def test_write_matrix_basic(tmp_path, monkeypatch):
             },
         ],
     }
-    write_matrix(target, data)
+    um.write_matrix(target, data)
 
     content = target.read_text()
     assert content.endswith("\n")
@@ -855,7 +842,7 @@ def test_write_matrix_preserves_all_fields(tmp_path, monkeypatch):
         },
         "matrix": [],
     }
-    write_matrix(target, data)
+    um.write_matrix(target, data)
 
     parsed = json.loads(target.read_text())
     assert parsed["schema_version"] == "2.0.0"
@@ -871,7 +858,7 @@ def test_write_matrix_overwrites_existing(tmp_path, monkeypatch):
     target.write_text('{"old": true}\n')
 
     data = {"schema_version": "1.0.0", "matrix": []}
-    write_matrix(target, data)
+    um.write_matrix(target, data)
 
     parsed = json.loads(target.read_text())
     assert "old" not in parsed
@@ -883,7 +870,7 @@ def test_write_matrix_no_temp_file_on_success(tmp_path, monkeypatch):
     _allow_repo_writes(monkeypatch, tmp_path)
     target = tmp_path / "release-matrix.json"
     data = {"schema_version": "1.0.0", "matrix": []}
-    write_matrix(target, data)
+    um.write_matrix(target, data)
 
     tmp_file = tmp_path / "release-matrix.json.tmp"
     assert not tmp_file.exists()
@@ -915,7 +902,7 @@ def test_write_matrix_cleans_up_temp_on_failure(tmp_path, monkeypatch):
 
     raised = False
     try:
-        write_matrix(target, {"schema_version": "1.0.0", "matrix": []})
+        um.write_matrix(target, {"schema_version": "1.0.0", "matrix": []})
     except OSError:
         raised = True
 

--- a/tools/release/matrix/tests/test_update_matrix.py
+++ b/tools/release/matrix/tests/test_update_matrix.py
@@ -474,15 +474,6 @@ _unique_versions = st.lists(_nginx_version, min_size=0, max_size=10).map(
     lambda vs: list(dict.fromkeys(vs))
 )
 
-_matrix_entry_with_managed_by = st.fixed_dictionaries(  # noqa: F841
-    {
-        "nginx": _nginx_version,
-        "os_type": _os_types,
-        "arch": _archs,
-        "support_tier": st.just("full"),
-    },
-    optional={"managed_by": st.just("manual")},
-)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/release/matrix/tests/test_update_matrix.py
+++ b/tools/release/matrix/tests/test_update_matrix.py
@@ -816,6 +816,7 @@ def test_write_matrix_basic(tmp_path, monkeypatch):
     assert content.endswith("\n")
     parsed = json.loads(content)
     assert parsed == data
+    assert target.stat().st_mode & 0o777 == 0o644
     # Verify 2-space indentation
     assert '  "schema_version"' in content
 
@@ -854,6 +855,7 @@ def test_write_matrix_overwrites_existing(tmp_path, monkeypatch):
     parsed = json.loads(target.read_text())
     assert "old" not in parsed
     assert parsed["schema_version"] == "1.0.0"
+    assert target.stat().st_mode & 0o777 == 0o644
 
 
 def test_write_matrix_no_temp_file_on_success(tmp_path, monkeypatch):

--- a/tools/release/matrix/tests/test_update_matrix_cli.py
+++ b/tools/release/matrix/tests/test_update_matrix_cli.py
@@ -10,14 +10,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 import tools.release.matrix.update_matrix as um
-from tools.release.matrix.update_matrix import (
-    DOC_MARKER_BEGIN,
-    DOC_MARKER_END,
-    compute_matrix,
-    main,
-    parse_args,
-    update_doc_table,
-)
+
 
 from tools.release.matrix.tests.test_update_matrix import (
     _archs,
@@ -26,7 +19,7 @@ from tools.release.matrix.tests.test_update_matrix import (
     _os_types,
     _unique_versions,
     _allow_repo_writes,
-    write_matrix,
+
 )
 
 # ---------------------------------------------------------------------------
@@ -44,13 +37,13 @@ def _make_doc_with_markers(before: str, after: str) -> str:
     Returns:
         str: The composed document with placeholder content between markers.
     """
-    return f"{before}\n{DOC_MARKER_BEGIN}\nold table content\n{DOC_MARKER_END}\n{after}"
+    return f"{before}\n{um.DOC_MARKER_BEGIN}\nold table content\n{um.DOC_MARKER_END}\n{after}"
 
 
 def _parse_doc_table_tuples(new_content: str) -> set[tuple[str, str, str, str]]:
     """Extract data tuples from the generated doc table between markers."""
-    begin_idx = new_content.index(DOC_MARKER_BEGIN) + len(DOC_MARKER_BEGIN)
-    end_idx = new_content.index(DOC_MARKER_END)
+    begin_idx = new_content.index(um.DOC_MARKER_BEGIN) + len(um.DOC_MARKER_BEGIN)
+    end_idx = new_content.index(um.DOC_MARKER_END)
     table_rows = new_content[begin_idx:end_idx].strip().split("\n")
     data_rows = [row for row in table_rows if row.startswith("|") and "---" not in row]
     if data_rows:
@@ -80,7 +73,7 @@ def _expected_doc_table_tuples(entries: list[dict]) -> set[tuple[str, str, str, 
 _schema_version = st.from_regex(r"[0-9]+\.[0-9]+\.[0-9]+", fullmatch=True)
 
 _surrounding_text = st.text(min_size=0, max_size=200).filter(
-    lambda t: DOC_MARKER_BEGIN not in t and DOC_MARKER_END not in t and "\r" not in t
+    lambda t: um.DOC_MARKER_BEGIN not in t and um.DOC_MARKER_END not in t and "\r" not in t
 )
 
 
@@ -109,7 +102,7 @@ def test_property5_schema_version_preservation(
     }
     _allow_repo_writes(monkeypatch, tmp_path)
     target = tmp_path / "release-matrix.json"
-    write_matrix(target, data)
+    um.write_matrix(target, data)
 
     parsed = json.loads(target.read_text())
     assert (
@@ -148,7 +141,7 @@ def test_property7_doc_table_reflects_matrix(tmp_path, entries):
     doc_path = tmp_path / "INSTALLATION.md"
     doc_path.write_text(doc_content)
 
-    new_content = update_doc_table(doc_path, entries)
+    new_content = um.update_doc_table(doc_path, entries)
 
     parsed_tuples = _parse_doc_table_tuples(new_content)
     expected_tuples = _expected_doc_table_tuples(entries)
@@ -195,10 +188,10 @@ def test_property8_doc_surrounding_content_preservation(
     doc_path = tmp_path / "INSTALLATION.md"
     doc_path.write_text(doc_content)
 
-    new_content = update_doc_table(doc_path, entries)
+    new_content = um.update_doc_table(doc_path, entries)
 
     # Content before the BEGIN marker must be preserved
-    begin_idx = new_content.index(DOC_MARKER_BEGIN)
+    begin_idx = new_content.index(um.DOC_MARKER_BEGIN)
     actual_before = new_content[:begin_idx]
     expected_before = before + "\n"
     assert actual_before == expected_before, (
@@ -208,7 +201,7 @@ def test_property8_doc_surrounding_content_preservation(
     )
 
     # Content after the END marker must be preserved
-    end_marker_end = new_content.index(DOC_MARKER_END) + len(DOC_MARKER_END)
+    end_marker_end = new_content.index(um.DOC_MARKER_END) + len(um.DOC_MARKER_END)
     actual_after = new_content[end_marker_end:]
     expected_after = "\n" + after
     assert actual_after == expected_after, (
@@ -228,31 +221,31 @@ class TestParseArgs:
 
     def test_no_flags_defaults(self):
         """Normal mode: both flags are False when no arguments given."""
-        args = parse_args([])
+        args = um.parse_args([])
         assert args.dry_run is False
         assert args.check_only is False
 
     def test_dry_run_flag(self):
         """``--dry-run`` sets dry_run=True, check_only=False."""
-        args = parse_args(["--dry-run"])
+        args = um.parse_args(["--dry-run"])
         assert args.dry_run is True
         assert args.check_only is False
 
     def test_check_only_flag(self):
         """``--check-only`` sets check_only=True, dry_run=False."""
-        args = parse_args(["--check-only"])
+        args = um.parse_args(["--check-only"])
         assert args.check_only is True
         assert args.dry_run is False
 
     def test_mutual_exclusion(self):
         """``--dry-run`` and ``--check-only`` cannot be used together."""
         with pytest.raises(SystemExit):
-            parse_args(["--dry-run", "--check-only"])
+            um.parse_args(["--dry-run", "--check-only"])
 
     def test_argv_none_uses_sys_argv(self, monkeypatch):
         """When argv is None, argparse reads from sys.argv."""
         monkeypatch.setattr(sys, "argv", ["update_matrix.py", "--dry-run"])
-        args = parse_args(None)
+        args = um.parse_args(None)
         assert args.dry_run is True
         assert args.check_only is False
 
@@ -328,7 +321,7 @@ def test_property9_read_only_modes_do_not_modify_files(tmp_path, versions, monke
     matrix_data = {
         "schema_version": "1.0.0",
         "updated_at": "2025-07-14T00:00:00Z",
-        "matrix": compute_matrix(["1.24.0"], ["glibc", "musl"], ["x86_64", "aarch64"]),
+        "matrix": um.compute_matrix(["1.24.0"], ["glibc", "musl"], ["x86_64", "aarch64"]),
     }
     matrix_path.write_text(json.dumps(matrix_data, indent=2) + "\n")
 
@@ -336,11 +329,11 @@ def test_property9_read_only_modes_do_not_modify_files(tmp_path, versions, monke
     doc_content = (
         "# Installation Guide\n"
         "Some intro text.\n"
-        f"{DOC_MARKER_BEGIN}\n"
+        f"{um.DOC_MARKER_BEGIN}\n"
         "| NGINX Version | OS Type | Architecture | Support Tier |\n"
         "|---------------|---------|--------------|--------------|\n"
         "| 1.24.0 | glibc | x86_64 | Full |\n"
-        f"{DOC_MARKER_END}\n"
+        f"{um.DOC_MARKER_END}\n"
         "Footer content.\n"
     )
     doc_path.write_text(doc_content)
@@ -365,7 +358,7 @@ def test_property9_read_only_modes_do_not_modify_files(tmp_path, versions, monke
     mock_html = _build_mock_html(versions)
     monkeypatch.setattr(um, "fetch_download_page", lambda _url: mock_html)
     # --- Run --dry-run ----------------------------------------------------
-    main(["--dry-run"])
+    um.main(["--dry-run"])
 
     assert (
         matrix_path.read_bytes() == matrix_before
@@ -374,7 +367,7 @@ def test_property9_read_only_modes_do_not_modify_files(tmp_path, versions, monke
     assert diff_path.read_bytes() == diff_before, "--dry-run modified matrix-diff.json"
 
     # --- Run --check-only -------------------------------------------------
-    main(["--check-only"])
+    um.main(["--check-only"])
 
     assert (
         matrix_path.read_bytes() == matrix_before
@@ -402,8 +395,8 @@ def test_property10_idempotent_matrix_computation(versions):
     os_types = ["glibc", "musl"]
     archs = ["x86_64", "aarch64"]
 
-    first = compute_matrix(versions, os_types, archs)
-    second = compute_matrix(versions, os_types, archs)
+    first = um.compute_matrix(versions, os_types, archs)
+    second = um.compute_matrix(versions, os_types, archs)
 
     # Byte-identical: serialise both to JSON and compare
     first_json = json.dumps(first, indent=2, sort_keys=True)
@@ -451,12 +444,12 @@ def _build_installation_doc(entries: list[dict]) -> str:
     return (
         "# Installation Guide\n"
         "Some intro text.\n"
-        f"{DOC_MARKER_BEGIN}\n"
+        f"{um.DOC_MARKER_BEGIN}\n"
         "| NGINX Version | OS Type | Architecture | Support Tier |\n"
         "|---------------|---------|--------------|--------------|\n"
         + "\n".join(table_rows)
         + "\n"
-        f"{DOC_MARKER_END}\n"
+        f"{um.DOC_MARKER_END}\n"
         "Footer content.\n"
     )
 
@@ -469,7 +462,7 @@ def _setup_cli_env(
     html_versions=None,
 ):
     """Create a complete temporary CLI test environment and monkeypatch module-level
-    paths and download behavior for main()/CLI tests.
+    paths and download behavior for um.main()/CLI tests.
 
     Creates these files under tmp_path:
     - release-matrix.json with auto-managed matrix entries for each version in
@@ -544,7 +537,7 @@ def test_cli_dry_run_no_file_writes(tmp_path, monkeypatch, capsys):
     matrix_before = matrix_path.read_bytes()
     doc_before = doc_path.read_bytes()
 
-    exit_code = main(["--dry-run"])
+    exit_code = um.main(["--dry-run"])
 
     assert exit_code == 0
     # Files must be untouched
@@ -573,7 +566,7 @@ def test_cli_check_only_fresh_exit_0(tmp_path, monkeypatch):
         html_versions=versions,
     )
 
-    exit_code = main(["--check-only"])
+    exit_code = um.main(["--check-only"])
     assert exit_code == 0
 
 
@@ -587,7 +580,7 @@ def test_cli_check_only_fresh_with_latest_official_versions(tmp_path, monkeypatc
         html_versions=versions,
     )
 
-    exit_code = main(["--check-only"])
+    exit_code = um.main(["--check-only"])
     assert exit_code == 0
 
 
@@ -604,7 +597,7 @@ def test_cli_check_only_ignores_release_asset_versions_not_on_download_page(
         html_versions=existing,
     )
 
-    exit_code = main(["--check-only"])
+    exit_code = um.main(["--check-only"])
     assert exit_code == 0
 
 
@@ -621,7 +614,7 @@ def test_cli_check_only_stale_exit_2(tmp_path, monkeypatch):
         html_versions=from_nginx,
     )
 
-    exit_code = main(["--check-only"])
+    exit_code = um.main(["--check-only"])
     assert exit_code == 2
 
 
@@ -645,7 +638,7 @@ def test_cli_check_only_error_exit_1(tmp_path, monkeypatch):
 
     monkeypatch.setattr(um, "fetch_download_page", raise_url_error)
 
-    exit_code = main(["--check-only"])
+    exit_code = um.main(["--check-only"])
     assert exit_code == 1
 
 
@@ -666,7 +659,7 @@ def test_cli_diff_json_structure(tmp_path, monkeypatch):
         html_versions=from_nginx,
     )
 
-    exit_code = main([])
+    exit_code = um.main([])
     assert exit_code == 0
     assert diff_path.exists()
 
@@ -691,7 +684,7 @@ def test_cli_diff_json_removed_versions(tmp_path, monkeypatch):
 
     # The default min is 1.24.0, so 1.26.3 passes. 1.24.0 disappears from
     # the latest nginx.org download page, so it gets removed from the desired matrix.
-    exit_code = main([])
+    exit_code = um.main([])
     assert exit_code == 0
     assert diff_path.exists()
 
@@ -754,7 +747,7 @@ def test_cli_rollback_on_doc_write_failure(tmp_path, monkeypatch):
 
     monkeypatch.setattr("os.replace", selective_replace)
 
-    exit_code = main([])
+    exit_code = um.main([])
     assert exit_code == 1
 
     # Matrix should be restored to its original content
@@ -782,7 +775,7 @@ def test_cli_no_change_exit_0(tmp_path, monkeypatch, capsys):
     matrix_before = matrix_path.read_bytes()
     doc_before = doc_path.read_bytes()
 
-    exit_code = main([])
+    exit_code = um.main([])
     assert exit_code == 0
 
     # No files modified
@@ -812,7 +805,7 @@ def test_cli_version_logging(tmp_path, monkeypatch, capsys):
         html_versions=from_nginx,
     )
 
-    exit_code = main([])
+    exit_code = um.main([])
     assert exit_code == 0
 
     captured = capsys.readouterr()

--- a/tools/release/matrix/tests/test_update_matrix_cli.py
+++ b/tools/release/matrix/tests/test_update_matrix_cli.py
@@ -14,12 +14,20 @@ import tools.release.matrix.update_matrix as um
 
 from tools.release.matrix.tests.test_update_matrix import (
     _archs,
-    _matrix_entry_with_managed_by,
     _nginx_version,
     _os_types,
     _unique_versions,
     _allow_repo_writes,
+)
 
+_matrix_entry_with_managed_by = st.fixed_dictionaries(
+    {
+        "nginx": _nginx_version,
+        "os_type": _os_types,
+        "arch": _archs,
+        "support_tier": st.just("full"),
+    },
+    optional={"managed_by": st.just("manual")},
 )
 
 # ---------------------------------------------------------------------------

--- a/tools/release/matrix/update_matrix.py
+++ b/tools/release/matrix/update_matrix.py
@@ -190,6 +190,7 @@ def _write_repo_text(path: Path, content: str) -> None:
             0o600,
             dir_fd=parent_fd,
         )
+        os.fchmod(file_fd, 0o600)
         with os.fdopen(file_fd, "w", encoding="utf-8") as handle:
             handle.write(content)
     finally:

--- a/tools/release/matrix/update_matrix.py
+++ b/tools/release/matrix/update_matrix.py
@@ -168,7 +168,8 @@ def _write_repo_text(path: Path, content: str) -> None:
     """Write `content` to `path` within the repository using UTF-8 encoding.
 
     The path is validated to stay under the repository root, missing parent
-    directories are created, and file mode 0o644 is used.
+    directories are created, and file mode 0o644 is used for repository
+    metadata files that are not secrets.
 
     Parameters:
         path (Path): Destination path inside the repository.
@@ -187,10 +188,10 @@ def _write_repo_text(path: Path, content: str) -> None:
         file_fd = os.open(
             safe_path.name,
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
+            0o644,
             dir_fd=parent_fd,
         )
-        os.fchmod(file_fd, 0o600)
+        os.fchmod(file_fd, 0o644)  # NOSONAR(S2612) repository metadata, not secrets
         with os.fdopen(file_fd, "w", encoding="utf-8") as handle:
             handle.write(content)
     finally:

--- a/tools/release/matrix/update_matrix.py
+++ b/tools/release/matrix/update_matrix.py
@@ -30,6 +30,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NoReturn
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from urllib.error import URLError
@@ -125,7 +126,7 @@ def classify_version(version: str) -> str:
     return "stable" if minor % 2 == 0 else "mainline"
 
 
-def _matrix_error(message: str) -> None:
+def _matrix_error(message: str) -> NoReturn:
     """Print a matrix validation error and exit with code 1."""
     print(message, file=sys.stderr)
     sys.exit(1)
@@ -186,7 +187,7 @@ def _write_repo_text(path: Path, content: str) -> None:
         file_fd = os.open(
             safe_path.name,
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o644,
+            0o600,
             dir_fd=parent_fd,
         )
         with os.fdopen(file_fd, "w", encoding="utf-8") as handle:

--- a/tools/render_release_matrix_docs.py
+++ b/tools/render_release_matrix_docs.py
@@ -547,9 +547,9 @@ def _generate_compatibility_matrix(
         "## Platform Compatibility Matrix",
         "",
         "| NGINX Version | Channel | OS | libc | Arch | Artifact "
-        "| Test Level | Tier | Blocking | Workflow |",
+        + "| Test Level | Tier | Blocking | Workflow |",
         "|---------------|---------|-----|------|------|----------"
-        "|------------|------|----------|----------|",
+        + "|------------|------|----------|----------|",
     ]
 
     sorted_entries = sorted(


### PR DESCRIPTION
## Description

Address the 57 CodeQL code-scanning findings identified by the initial scan across the Python tooling scripts. The final implementation preserves the tools' documented behavior while adding path, file-output, and response-integrity regression coverage.

## Review follow-up

- CodeQL alert [#143](https://github.com/cnkang/nginx-markdown-for-agents/security/code-scanning/143) is formally dismissed as **false positive** with an audit note. Complexity reports contain file paths, function names, and scores, not secrets or user data.
- The complexity CLI intentionally retains its historical behavior: `--output FILE` writes the report to the file and also prints the report to stdout.
- The upstream mock returns controlled corpus bytes unchanged, including embedded NUL bytes and responses larger than the former 128 MiB threshold.

## Changes Made

### Error-level fixes (13 alerts)

- **py/path-injection** (6): Validate each upstream mock URL path component without renaming legitimate filenames, resolve nested paths, reject traversal/separators/NULs, and enforce the resolved corpus-root boundary. Add the validated path handling boundary in `validate_read_path`.
- **py/clear-text-logging-sensitive-data** (2): Keep complexity report output on stdout and document the controlled, non-secret report semantics; alert #143 is tracked as a reviewed false positive.
- **py/uninitialized-local-variable** (5): Mark `_matrix_error` as `NoReturn` and initialize `count_brace` before use.

### Warning-level fixes (3 alerts)

- **py/implicit-string-concatenation-in-list** (2): Use explicit concatenation in `render_release_matrix_docs.py`.
- **py/overly-permissive-file** (1): Keep repository metadata writes at the documented final mode `0644`; these files are not secrets.

### Note-level cleanup (41 alerts)

- Remove unused imports and locals, consolidate import styles, replace the imprecise assertion, and retain only documented compatibility symbols/annotations.
- Remove the incomplete `__all__ = ["NON_GOALS"]` declaration so `import *` continues to expose the module's public symbols.

## Regression coverage

- Upstream mock: safe component validation, `a..b.html` preservation, nested paths, symlink escape rejection, NUL-preserving responses, and no truncation beyond 128 MiB.
- Complexity CLI: `--output FILE` writes the same report that is printed to stdout.
- Matrix writer: both new and existing files finish with mode `0644`.

## Testing

- [x] `python3 -m pytest -q tools/perf/tests/test_benchmark_harness.py tools/complexity/tests/test_compare_baseline.py tools/release/matrix/tests/test_update_matrix.py tools/release/matrix/tests/test_update_matrix_cli.py` — 130 passed, 1 skipped
- [x] `make complexity-check` — no new complexity violations
- [x] Orphan-comment and NOSONAR discipline checks pass
- [x] Existing CI, CodeQL, SonarCloud, fuzz, smoke, supply-chain, and cluster checks pass

## Type of Change

- [x] Bug fix / security hardening
- [x] Regression tests

## Documentation

All changed docs and comments remain in English.
