### PR TITLE
fix(security): resolve remaining CodeQL Python alerts

### DIFF
--- a/tools/ci/test_check_third_party_notices.py
+++ b/tools/ci/test_check_third_party_notices.py
@@ -9,8 +9,8 @@ import subprocess
 import tempfile
 import textwrap
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-from unittest import mock
 
 import tools.ci.check_third_party_notices as checker
 

--- a/tools/harness/tests/test_detect_duplicate_code.py
+++ b/tools/harness/tests/test_detect_duplicate_code.py
@@ -95,13 +95,7 @@ def test_memory_duplicate_classified_direct_fix(det, tmp_path):
 
 def test_signature_duplicate_is_ignored(det, tmp_path):
     # Two function signatures with same params → signature/ignore
-    sig = """\
-    ngx_http_request_t *r,
-    ngx_chain_t *in,
-    ngx_int_t rc;
-    """
-
-    # The 5-line non-adjacent detector needs 5 matching lines; pad the sig.
+    # The 5-line non-adjacent detector needs 5 matching lines; pad the signature.
     block = """\
     ngx_http_request_t *r,
     ngx_chain_t *in,

--- a/tools/harness/tests/test_detect_duplicate_code.py
+++ b/tools/harness/tests/test_detect_duplicate_code.py
@@ -114,6 +114,7 @@ def test_signature_duplicate_is_ignored(det, tmp_path):
     # NOT appear as direct-fix warnings.
     assert "[signature]" in joined
     assert "ignore-by-rule" in joined
+    assert not any("[signature]" in warning for warning in warnings)
 
 
 def test_structural_duplicate_is_review(det, tmp_path):


### PR DESCRIPTION
## Description

Resolve the remaining CodeQL Python security alerts in the affected test tooling while preserving the existing test behavior.

## Related Issues

No related issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update
- [x] CI/Build change

## Changes Made

- Updated the `unittest.mock` import to use `import unittest.mock as mock`, satisfying the CodeQL Python security check.
- Removed the unused signature fixture variable and clarified the duplicate-detection test comment.
- Kept the duplicate-detection coverage for signature duplicates and review-only verdicts.
- Ensured the modified test file ends with a newline.

## Testing

- [ ] Unit tests pass (`make test-all`)
- [ ] Integration tests pass
- [x] Existing focused tests pass
- [ ] Manual testing completed (if applicable)

Focused validation completed:

- `python3 -m pytest tools/harness/tests/test_detect_duplicate_code.py -q --tb=short` — 9 passed
- `python3 -m unittest tools/ci/test_check_third_party_notices.py` — 4 passed

## Documentation

- [x] Documentation and code comments updated
- [x] All docs/comments in English
- [ ] C code follows NGINX coding style (not applicable; no C changes)

## Checklist

- [x] Code follows project style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All focused tests pass
- [ ] `cargo fmt` and `cargo clippy` pass (not applicable; no Rust changes)

## Document Updates

| Version | Date | Author | Changes |
|---------|------|--------|---------|
| 0.5.0 | 2026-07-27 | cnkang | Updated PR description to follow the project template and document CodeQL test-alert fixes |
