### PR TITLE
docs(release): finalize v0.9.1 metadata

### DIFF
--- a/docs/guides/PACKAGE_DISTRIBUTION.md
+++ b/docs/guides/PACKAGE_DISTRIBUTION.md
@@ -10,7 +10,7 @@ integrity verification via SHA256SUMS, and GPG signature verification.
 
 | Channel | Format | Status | Signing |
 |---------|--------|--------|---------|
-| GitHub Releases | .deb + .rpm | Tag-specific; verify assets before downloading | SHA256SUMS / GPG when published |
+| GitHub Releases | .deb + .rpm | Active for v0.7.0+ release artifacts; tag-specific; verify assets before downloading | SHA256SUMS / GPG when published |
 | Self-hosted APT | .deb | Planned; no public repository URL yet | GPG |
 | Self-hosted YUM | .rpm | Planned; no public repository URL yet | GPG |
 

--- a/docs/guides/PACKAGE_INSTALLATION.md
+++ b/docs/guides/PACKAGE_INSTALLATION.md
@@ -6,7 +6,7 @@ official NGINX repository packages.
 
 ## Repository Publishing Status
 
-GitHub Releases are the intended distribution channel for DEB and RPM package
+GitHub Releases are the current distribution channel for DEB and RPM package
 artifacts, but asset availability is tag-specific.
 Public APT/YUM repositories are planned but not available yet.
 They are not part of the current GA channel.

--- a/docs/project/PROJECT_STATUS.md
+++ b/docs/project/PROJECT_STATUS.md
@@ -28,7 +28,7 @@ operations, architecture, and contributor-facing harness maintenance.
 
 ### Current Release Line 0.9.1
 
-**Status:** Released 2026-07-29. 0.9.1 introduces zero-copy output for
+**Status:** Stable release, published 2026-07-29. 0.9.1 introduces zero-copy output for
 streaming, gzip plus zlib/raw-deflate plus Brotli streaming decompression,
 and full-buffer copy reduction, all guarded by strict performance evidence
 gates.

--- a/docs/release/0.9.1-release-notes.md
+++ b/docs/release/0.9.1-release-notes.md
@@ -1,7 +1,7 @@
 # Release Notes: 0.9.1
 
 **Date**: 2026-07-29
-**Status**: General Availability
+**Status**: Stable release
 **Type**: Final pre-v1.0 compatibility reset
 
 ---


### PR DESCRIPTION
## Summary

Finalize the v0.9.1 release metadata and package-channel wording required by the tag-only release validators.

## Changes

- Mark the project status and release notes as a stable release.
- Align package distribution wording with the current GitHub Release channel.
- Preserve tag-specific asset verification guidance.

## Validation

- `python3 tools/release/gates/validate_release_metadata.py --version 0.9.1`
- `python3 tools/release/gates/validate_package_metadata.py` — 187 passed, 0 failed
- `make docs-check`
- `git diff --check`

## Summary by Sourcery

Finalize v0.9.1 release metadata language and distribution channel descriptions across project documentation.

Documentation:
- Clarify GitHub Releases as the current DEB/RPM distribution channel with tag-specific asset availability.
- Update package distribution table to describe GitHub Releases status as active for v0.7.0+ artifacts while keeping tag-specific verification guidance.
- Mark the 0.9.1 release line and release notes as a stable release rather than generic GA wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that GitHub Releases provide DEB and RPM packages for v0.7.0 and later.
  * Added guidance to verify published release assets before downloading.
  * Updated project status and release notes to identify version 0.9.1 as a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->