### PR TITLE
fix(packaging): resolve RPM smoke-test dependencies

### DIFF
--- a/packaging/scripts/smoke-test-basic.sh
+++ b/packaging/scripts/smoke-test-basic.sh
@@ -296,8 +296,17 @@ REPO
 
         # --- RPM: Install module package ---
         info "Installing module package: ${PACKAGE_FILE}"
-        rpm -Uvh "${PACKAGE_FILE}" >>"${INSTALL_LOG}" 2>&1 \
-            || die "rpm -Uvh failed for ${PACKAGE_FILE}"
+        # Use the distro package manager so dependencies such as libbrotli
+        # are resolved from the configured repositories before installation.
+        if command -v dnf >/dev/null 2>&1; then
+            dnf install -y "${PACKAGE_FILE}" >>"${INSTALL_LOG}" 2>&1 \
+                || die "dnf install failed for ${PACKAGE_FILE}"
+        elif command -v yum >/dev/null 2>&1; then
+            yum install -y "${PACKAGE_FILE}" >>"${INSTALL_LOG}" 2>&1 \
+                || die "yum install failed for ${PACKAGE_FILE}"
+        else
+            die "Neither dnf nor yum found for RPM module installation"
+        fi
 
         # --- RPM: Verify nginx -V ---
         info "Running nginx -V..."

--- a/tools/release/gates/tests/test_validate_package_metadata.py
+++ b/tools/release/gates/tests/test_validate_package_metadata.py
@@ -461,6 +461,21 @@ class TestReleaseGateSnippetExpectations:
         assert "packages/%samzn/" in validator.SMOKE_RPM_REPO_SNIPPETS
         assert "packages/%scentos/" in validator.SMOKE_RPM_REPO_SNIPPETS
 
+    def test_rpm_smoke_install_resolves_package_dependencies(self) -> None:
+        """Ensure RPM smoke tests use dnf/yum instead of raw rpm installation."""
+        assert (
+            'dnf install -y "${PACKAGE_FILE}"'
+            in validator.SMOKE_RPM_INSTALL_SNIPPETS
+        )
+        assert (
+            'yum install -y "${PACKAGE_FILE}"'
+            in validator.SMOKE_RPM_INSTALL_SNIPPETS
+        )
+
+        result = validator.ValidationResult()
+        validator.validate_smoke_test_rpm_install(result)
+        assert not result.has_failures
+
     def test_nfpm_postinstall_accepts_rpm_lifecycle_args(self) -> None:
         """Ensure postinstall script handles RPM lifecycle arguments."""
         assert "configure|1|2)" in validator.NFPM_POSTINSTALL_SNIPPETS

--- a/tools/release/gates/validate_package_metadata.py
+++ b/tools/release/gates/validate_package_metadata.py
@@ -197,6 +197,10 @@ SMOKE_RPM_REPO_SNIPPETS = [
     "almalinux|centos|rocky|rhel)",
     "packages/%scentos/",
 ]
+SMOKE_RPM_INSTALL_SNIPPETS = [
+    'dnf install -y "${PACKAGE_FILE}"',
+    'yum install -y "${PACKAGE_FILE}"',
+]
 GATE3_LOCAL_ARCH_SNIPPETS = [
     'pkg_pattern="*_${ARCH}.deb"',
     'pkg_pattern="*-1.${RPM_ARCH}.rpm"',
@@ -953,6 +957,21 @@ def validate_smoke_test_repo_selection(result: ValidationResult) -> None:
     )
 
 
+def validate_smoke_test_rpm_install(result: ValidationResult) -> None:
+    """Require RPM smoke tests to resolve local-package dependencies."""
+    content = read_safe(SMOKE_TEST_BASIC)
+    if not content:
+        result.fail(
+            "smoke-rpm-install:exists",
+            f"{SMOKE_TEST_BASIC_NAME} not found",
+        )
+        return
+    _check_snippets(
+        content, SMOKE_RPM_INSTALL_SNIPPETS, "smoke-rpm-install",
+        SMOKE_TEST_BASIC_NAME, result,
+    )
+
+
 def validate_gate3_local_arch_selection(result: ValidationResult) -> None:
     """Validate local Gate 3 smoke selects architecture-matched packages."""
     content = read_safe(GATE3_LOCAL_PACKAGE_SMOKE)
@@ -1082,6 +1101,7 @@ def main() -> int:
     validate_release_artifact_flow(result)
     validate_standalone_workflow_packaging(result)
     validate_smoke_test_repo_selection(result)
+    validate_smoke_test_rpm_install(result)
     validate_gate3_local_arch_selection(result)
     validate_nfpm_postinstall_lifecycle(result)
     validate_release_build_glibc_baseline(result)


### PR DESCRIPTION
## Summary

Fix the RPM package smoke-test failure observed in Release Packages run 30471193815.

## Root cause

The smoke test installed the local module RPM with `rpm -Uvh`, which does not resolve repository dependencies. AlmaLinux therefore rejected the package because `libbrotli` was not installed, even though the dependency is available from the configured repositories.

## Changes

- Install the local RPM through `dnf` or `yum` so dependencies are resolved.
- Add a release metadata validator check and regression test for both package-manager paths.

## Validation

- `bash -n packaging/scripts/smoke-test-basic.sh`
- `shellcheck packaging/scripts/smoke-test-basic.sh`
- `python3 -m pytest tools/release/gates/tests/test_validate_package_metadata.py -q` — 68 passed
- `python3 tools/release/gates/validate_package_metadata.py` — 189 passed, 0 failed
- `python3 tools/release/gates/validate_release_metadata.py --version 0.9.1`
- `make docs-check`
- `make complexity-check`

The full local release gate reached the module performance evidence step and correctly stopped because no local `NGINX_BIN` was configured; tag CI builds the module and supplies that evidence.

## Summary by Sourcery

Ensure RPM smoke tests install packages via distro package managers so dependencies are resolved and enforce this via release metadata validation.

Bug Fixes:
- Resolve RPM smoke-test failures caused by installing local RPMs without resolving repository dependencies.

Enhancements:
- Add a release gate validator that checks RPM smoke tests use dnf/yum for local package installation.

Tests:
- Extend package metadata validator tests to cover the new RPM smoke installation requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPM module installation during smoke tests by using the system package manager, ensuring package dependencies are resolved automatically.
  * Added clear failure handling when installation tools are unavailable or installation fails.

* **Tests**
  * Added release-gate validation to confirm RPM installation commands are present and functioning as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->