### PR TITLE
fix(release): use canonical amd64 benchmark artifact

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -828,7 +828,7 @@ jobs:
           # Select the oldest (first) release-blocking NGINX version as
           # the canonical benchmark runtime.  Using a single, explicit
           # version avoids the filename collision that occurs when
-          # multiple module-so-*-x86_64 artifacts are merged into the
+          # multiple module-so-*-amd64 artifacts are merged into the
           # same directory (they all contain build/nginx and
           # build/ngx_http_markdown_filter_module.so).
           BENCH_VERSION="$(python3 -c "
@@ -851,7 +851,7 @@ jobs:
           # artifact.  This avoids the filename collision from
           # merge-multiple when multiple NGINX versions produce the same
           # build/nginx and build/ngx_http_markdown_filter_module.so names.
-          name: module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-x86_64
+          name: module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-amd64
           path: module-runtime
 
       - name: Run tag release gates

--- a/tools/perf/tests/test_evidence_gate.py
+++ b/tools/perf/tests/test_evidence_gate.py
@@ -239,7 +239,7 @@ def test_tag_release_job_supplies_module_enabled_nginx():
         "Release gate must explicitly select a canonical benchmark NGINX "
         "version to avoid artifact filename collisions"
     )
-    assert "module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-x86_64" in workflow, (
+    assert "module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-amd64" in workflow, (
         "Release gate must download the canonical benchmark NGINX artifact "
         "by exact name, not a wildcard pattern with merge-multiple"
     )

--- a/tools/release/gates/tests/test_validate_release_gates_080.py
+++ b/tools/release/gates/tests/test_validate_release_gates_080.py
@@ -60,3 +60,18 @@ def test_release_package_workflow_version_mismatch_detected(monkeypatch):
     assert len(workflow_checks) == 1
     assert workflow_checks[0][0] == "FAIL"
     assert "0.0.0" in workflow_checks[0][1]
+
+
+def test_release_gate_downloads_canonical_amd64_module_artifact():
+    """The benchmark gate must consume the build job's amd64 artifact name."""
+
+    workflow = Path(RELEASE_PACKAGES_WORKFLOW).read_text(encoding="utf-8")
+
+    assert (
+        "name: module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-amd64"
+        in workflow
+    )
+    assert (
+        "name: module-so-${{ steps.bench-nginx.outputs.bench_nginx_version }}-x86_64"
+        not in workflow
+    )


### PR DESCRIPTION
## Summary

- fix the tag-only release gate to download the benchmark artifact using the canonical amd64 name emitted by the build matrix
- add a regression test preventing the x86_64 artifact-name drift

## Evidence

- actionlint -no-color -shellcheck= .github/workflows/release-packages.yml
- python3 -m pytest tools/release/gates/tests/test_validate_release_gates_080.py -q (3 passed)
- python3 tools/release/matrix/validate_workflow_matrix_consumers.py
- python3 tools/release/gates/validate_package_metadata.py (189 passed)
- git diff --check

The preceding v0.9.1 tag run passed all package builds and RPM smoke tests; it failed only because this release-gate artifact lookup used x86_64 while the producer used amd64.

## Summary by Sourcery

Align release benchmark artifact consumption with the canonical amd64 artifact name and guard against future naming drift with tests.

Bug Fixes:
- Update the tag-release benchmark gate to download the amd64 module artifact instead of the x86_64 variant to match the build matrix output.

Tests:
- Add a regression test ensuring the release benchmark gate references the canonical amd64 artifact name and not the x86_64 variant.