### PR TITLE
fix(release): validate canonical reason-code source

### DIFF
--- a/docs/architecture/FFI_MIGRATION_CONTRACT.md
+++ b/docs/architecture/FFI_MIGRATION_CONTRACT.md
@@ -41,6 +41,13 @@ The following families have current NGINX production consumers:
 The generated header contains only the bundled production boundary. Test-only
 Rust helpers are not emitted as C declarations.
 
+The canonical reason-code source is
+`components/rust-converter/src/decision/reason_code.rs`. The
+`markdown_reason_code_str`, `markdown_reason_code_metric_key`, and
+`markdown_reason_code_count` exports expose that source to the C consumer;
+reason-code variants and discriminants must remain synchronized across this
+boundary.
+
 ## Removed v0.9.1 entries
 
 | Removed entry | Evidence | Replacement |

--- a/tools/release/gates/tests/test_validate_release_gates_070.py
+++ b/tools/release/gates/tests/test_validate_release_gates_070.py
@@ -1,0 +1,27 @@
+"""Regression tests for the v0.7.x release-gate validator."""
+
+from tools.release.gates.validate_release_gates_070 import _gate_2_items
+
+
+def _reason_code_check(contract: str) -> bool:
+    checks = _gate_2_items("", contract, "", "", "", "", "", "")
+    return dict(checks)["reason code source"]
+
+
+def test_reason_code_gate_accepts_canonical_ffi_contract():
+    """The gate checks the documented source and its production exports."""
+
+    contract = """
+    components/rust-converter/src/decision/reason_code.rs
+    markdown_reason_code_str
+    markdown_reason_code_metric_key
+    markdown_reason_code_count
+    """
+
+    assert _reason_code_check(contract)
+
+
+def test_reason_code_gate_rejects_unrelated_reason_text():
+    """A generic reason phrase must not satisfy the source contract gate."""
+
+    assert not _reason_code_check("Error/reason is documented here")

--- a/tools/release/gates/validate_release_gates_070.py
+++ b/tools/release/gates/validate_release_gates_070.py
@@ -39,6 +39,12 @@ DECISION_LOG_IMPL_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ng
 HEADERS_IMPL_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_http_markdown_headers_impl.h"
 DECOMPRESSION_C = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_http_markdown_decompression.c"
 FILTER_MODULE_H = PROJECT_ROOT / "components" / "nginx-module" / "src" / "ngx_http_markdown_filter_module.h"
+REASON_CODE_SOURCE = "components/rust-converter/src/decision/reason_code.rs"
+REASON_CODE_FFI_EXPORTS = (
+    "markdown_reason_code_str",
+    "markdown_reason_code_metric_key",
+    "markdown_reason_code_count",
+)
 
 GATE_1 = "Gate 1"
 GATE_2 = "Gate 2"
@@ -361,7 +367,11 @@ def _gate_2_items(
     return [
         ("ffi boundary tests", "make test-nginx-unit" in docs and "make test-rust" in docs),
         ("layout tests", "test_ffi_header_plan_layout" in abi and "test_ffi_accept_result_layout" in abi),
-        ("reason code source", "reason code" in ffi_contract.lower()),
+        (
+            "reason code source",
+            REASON_CODE_SOURCE in ffi_contract
+            and all(export in ffi_contract for export in REASON_CODE_FFI_EXPORTS),
+        ),
         ("delivery semantics tests", "delivery_counter_test.c" in unit_test_files),
         ("delivery_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in conversion or "NGX_HTTP_MARKDOWN_METRIC_INC(results.delivery_count)" in payload),
         ("decision_count metric write", "NGX_HTTP_MARKDOWN_METRIC_INC(results.decision_count)" in decision_log),


### PR DESCRIPTION
## Summary
- fix the 0.7.x release gate false negative for the reason-code FFI contract
- validate the canonical Rust source path and all production reason-code exports
- document the source-of-truth contract and add regression tests

## Evidence
- python3 -m pytest tools/release/gates/tests/test_validate_release_gates_070.py -q (2 passed)
- RELEASE_GATE_EXPECTED_CARGO_VERSION=0.9.1 python3 tools/release/gates/validate_release_gates_070.py --mode strict (52 passed, 0 failed)
- git diff --check

## Summary by Sourcery

Tighten the v0.7.x release-gate validation for the reason-code FFI contract and document its canonical source, adding regression tests to prevent future false negatives.

Bug Fixes:
- Ensure the v0.7.x release gate validates the canonical Rust reason-code source path and required FFI exports instead of matching generic reason text.

Enhancements:
- Define explicit constants for the canonical reason-code Rust source file and its FFI export symbols in the release-gate validator.
- Document the reason-code FFI source-of-truth and synchronization requirements in the FFI migration contract docs.

Tests:
- Add regression tests verifying the reason-code gate accepts a canonical FFI contract and rejects unrelated reason text.